### PR TITLE
EVG-1331 Properly add variables to Evergreen expansions

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -64,11 +64,11 @@ functions:
            export UPLOAD_BUCKET="${project}"
            export PROJECT_DIRECTORY="$PWD"
 
-           echo 'DRIVERS_TOOLS: "$DRIVERS_TOOLS"' >> expansion.yml
-           echo 'MONGO_ORCHESTRATION_HOME: "$MONGO_ORCHESTRATION_HOME"' >> expansion.yml
-           echo 'MONGODB_BINARIES: "$MONGODB_BINARIES"' >> expansion.yml
-           echo 'UPLOAD_BUCKET: "$UPLOAD_BUCKET"' >> expansion.yml
-           echo 'PROJECT_DIRECTORY: "$PROJECT_DIRECTORY"' >> expansion.yml
+           echo DRIVERS_TOOLS: "$DRIVERS_TOOLS" >> expansion.yml
+           echo MONGO_ORCHESTRATION_HOME: "$MONGO_ORCHESTRATION_HOME" >> expansion.yml
+           echo MONGODB_BINARIES: "$MONGODB_BINARIES" >> expansion.yml
+           echo UPLOAD_BUCKET: "$UPLOAD_BUCKET" >> expansion.yml
+           echo PROJECT_DIRECTORY: "$PROJECT_DIRECTORY" >> expansion.yml
 
            # Make it easier to get a good shell
            cat <<EOT >> expansion.yml
@@ -269,7 +269,6 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        # FIXME: See EVG-1331
         local_file: ${DRIVERS_TOOLS}/.evergreen/orchestration/server.log
         remote_file: ${UPLOAD_BUCKET}/${build_variant}/${revision}/${version_id}/${build_id}/logs/${task_id}-${execution}-orchestration.log
         bucket: mciuploads

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -64,11 +64,11 @@ functions:
            export UPLOAD_BUCKET="${project}"
            export PROJECT_DIRECTORY="$PWD"
 
-           echo DRIVERS_TOOLS: "$DRIVERS_TOOLS" >> expansion.yml
-           echo MONGO_ORCHESTRATION_HOME: "$MONGO_ORCHESTRATION_HOME" >> expansion.yml
-           echo MONGODB_BINARIES: "$MONGODB_BINARIES" >> expansion.yml
-           echo UPLOAD_BUCKET: "$UPLOAD_BUCKET" >> expansion.yml
-           echo PROJECT_DIRECTORY: "$PROJECT_DIRECTORY" >> expansion.yml
+           echo "DRIVERS_TOOLS: \"$DRIVERS_TOOLS\"" >> expansion.yml
+           echo "MONGO_ORCHESTRATION_HOME: \"$MONGO_ORCHESTRATION_HOME\"" >> expansion.yml
+           echo "MONGODB_BINARIES: \"$MONGODB_BINARIES\"" >> expansion.yml
+           echo "UPLOAD_BUCKET: \"$UPLOAD_BUCKET\"" >> expansion.yml
+           echo "PROJECT_DIRECTORY: \"$PROJECT_DIRECTORY\"" >> expansion.yml
 
            # Make it easier to get a good shell
            cat <<EOT >> expansion.yml
@@ -85,6 +85,8 @@ functions:
               export PATH="$MONGODB_BINARIES:$PATH"
               export PROJECT="${project}"
            EOT
+           # See what we've done
+           cat expansion.yml
 
     # Load the expansion file to make an evergreen variable with the current unique version
     - command: expansions.update

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -56,13 +56,13 @@ functions:
                  export DRIVERS_TOOLS="c:/drivers-tools"
                  ;;
               *)
-                 export DRIVERS_TOOLS="$PWD/../drivers-tools"
+                 export DRIVERS_TOOLS="$(pwd)/../drivers-tools"
                  ;;
            esac
            export MONGO_ORCHESTRATION_HOME="$DRIVERS_TOOLS/.evergreen/orchestration"
            export MONGODB_BINARIES="$DRIVERS_TOOLS/mongodb/bin"
            export UPLOAD_BUCKET="${project}"
-           export PROJECT_DIRECTORY="$PWD"
+           export PROJECT_DIRECTORY="$(pwd)"
 
            echo "DRIVERS_TOOLS: \"$DRIVERS_TOOLS\"" >> expansion.yml
            echo "MONGO_ORCHESTRATION_HOME: \"$MONGO_ORCHESTRATION_HOME\"" >> expansion.yml


### PR DESCRIPTION
With single quotes around the echo string, the expansion.yml file becomes:
```yml
DRIVERS_TOOLS: "$DRIVERS_TOOLS"
MONGO_ORCHESTRATION_HOME: "$MONGO_ORCHESTRATION_HOME"
MONGODB_BINARIES: "$MONGODB_BINARIES"
UPLOAD_BUCKET: "$UPLOAD_BUCKET"
PROJECT_DIRECTORY: "$PROJECT_DIRECTORY"
```
Without the quotes, the variables are expanded properly into:
```yml
DRIVERS_TOOLS: /Users/shane/git/drivers-evergreen-tools/../drivers-tools
MONGO_ORCHESTRATION_HOME: /Users/shane/git/drivers-evergreen-tools/../drivers-tools/.evergreen/orchestration
MONGODB_BINARIES: /Users/shane/git/drivers-evergreen-tools/../drivers-tools/mongodb/bin
UPLOAD_BUCKET: driver-tools
PROJECT_DIRECTORY: /Users/shane/git/drivers-evergreen-tools
```