### PR TITLE
Add links for downloading MongoDB on more distros

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -84,13 +84,6 @@ functions:
     - command: expansions.update
       params:
         file: src/expansion.yml
-    - command: shell.exec
-      params:
-        continue_on_err: true
-        # Must be http as RHEL55 has https issues
-        script: |
-          ${PREPARE_SHELL}
-          pip install --upgrade git+git://github.com/mongodb/mongo-orchestration@master
 
   "prepare resources":
     - command: shell.exec
@@ -337,7 +330,13 @@ functions:
       params:
         script: |
           ${PREPARE_SHELL}
-          cd $MONGO_ORCHESTRATION_HOME
+          cd "$MONGO_ORCHESTRATION_HOME"
+          # source the mongo-orchestration virtualenv if it exists
+          if [ -f venv/bin/activate ]; then
+            . venv/bin/activate
+          elif [ -f venv/Scripts/activate ]; then
+            . venv/Scripts/activate
+          fi
           mongo-orchestration stop
           cd -
           rm -rf $DRIVERS_TOOLS || true

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -687,6 +687,17 @@ axes:
         display_name: "RHEL 7.0"
         run_on: rhel70-small
 
+      - id: suse11-x86-64-test
+        display_name: "SUSE 11 (x86_64)"
+        run_on: suse11-test
+
+      - id: linux-64-amzn-test
+        display_name: "Amazon Linux (Enterprise)"
+        run_on: linux-64-amzn-test
+
+      - id: debian71-test
+        display_name: "Debian 7.1"
+        run_on: debian71-test
 
   - id: os-nossl
     display_name: OS
@@ -757,6 +768,13 @@ axes:
       - id: ubuntu1604-zseries-small
         display_name: "Ubuntu 16.04 (zSeries)"
         run_on: ubuntu1604-zseries-small
+
+  - id: os-requires-32
+    display_name: OS
+    values:
+      - id: suse12-x86-64-test
+        display_name: "SUSE 12 (x86_64)"
+        run_on: suse12-test
 
 
   - id: topology
@@ -867,6 +885,19 @@ buildvariants:
      - name: "test-3.4-sharded"
      - name: "test-3.4-standalone"
 
+- matrix_name: "tests-os-requires-32"
+  matrix_spec: {"os-requires-32": "*", auth: "*", ssl: "*" }
+  display_name: "${os-requires-32} ${auth} ${ssl}"
+  tasks:
+     - name: "test-latest-replicaset"
+     - name: "test-latest-sharded"
+     - name: "test-latest-standalone"
+     - name: "test-3.4-replicaset"
+     - name: "test-3.4-sharded"
+     - name: "test-3.4-standalone"
+     - name: "test-3.2-replicaset"
+     - name: "test-3.2-sharded"
+     - name: "test-3.2-standalone"
 
 
       # Platform notes
@@ -885,5 +916,7 @@ buildvariants:
       # Solaris MongoDB SSL builds are not available
       # Darwin MongoDB SSL builds are not available for 2.4 and 2.6
       # Windows does not support MongoDB 2.4
+      # Debian 7.1 does not support MongoDB 2.4
+      # SUSE12 x86_64 is only supported by MongoDB 3.2+
       # vim: set et sw=2 ts=2 :
 

--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -31,9 +31,9 @@ get_distro ()
       DISTRO="amzn64"
    fi
 
-   OS=$(uname -s)
+   OS_NAME=$(uname -s)
    MARCH=$(uname -m)
-   DISTRO=$(echo "$OS-$DISTRO-$MARCH" | tr '[:upper:]' '[:lower:]')
+   DISTRO=$(echo "$OS_NAME-$DISTRO-$MARCH" | tr '[:upper:]' '[:lower:]')
 
    echo $DISTRO
 }

--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -7,7 +7,7 @@ get_distro ()
    if [ -f /etc/os-release ]; then
       . /etc/os-release
       DISTRO="${ID}-${VERSION_ID}"
-   elif command -v lsb_release 2>/dev/null; then
+   elif command -v lsb_release >/dev/null 2>&1; then
       name=$(lsb_release -s -i)
       if [ "$name" = "RedHatEnterpriseServer" ]; then # RHEL 6.2 at least
          name="rhel"
@@ -27,6 +27,8 @@ get_distro ()
    elif [ -f /etc/lsb-release ]; then
       . /etc/lsb-release
       DISTRO="${DISTRIB_ID}-${DISTRIB_RELEASE}"
+   elif grep -R "Amazon Linux" "/etc/system-release" >/dev/null 2>&1; then
+      DISTRO="amzn64"
    fi
 
    OS=$(uname -s)
@@ -110,12 +112,44 @@ get_mongodb_download_url_for ()
              MONGODB_26=""
              MONGODB_24=""
       ;;
+      linux-sles-11*-x86_64)
+         MONGODB_LATEST="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-suse11-latest.tgz"
+             MONGODB_34="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-suse11-${VERSION_34}.tgz"
+             MONGODB_32="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-suse11-${VERSION_32}.tgz"
+             MONGODB_30="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-suse11-${VERSION_30}.tgz"
+             MONGODB_26="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-suse11-${VERSION_26}.tgz"
+             MONGODB_24="http://downloads.10gen.com/linux/mongodb-linux-x86_64-subscription-suse11-${VERSION_24}.tgz"
+      ;;
       linux-sles-12.1-s390x)
          MONGODB_LATEST="http://downloads.10gen.com/linux/mongodb-linux-s390x-enterprise-suse12-latest.tgz"
              MONGODB_34="http://downloads.10gen.com/linux/mongodb-linux-s390x-enterprise-suse12-${VERSION_34}.tgz"
              MONGODB_32=""
              MONGODB_30=""
              MONGODB_26=""
+             MONGODB_24=""
+      ;;
+      linux-sles-12*-x86_64)
+         MONGODB_LATEST="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-suse12-latest.tgz"
+             MONGODB_34="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-suse12-${VERSION_34}.tgz"
+             MONGODB_32="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-suse12-${VERSION_32}.tgz"
+             MONGODB_30=""
+             MONGODB_26=""
+             MONGODB_24=""
+      ;;
+      linux-amzn64*)
+         MONGODB_LATEST="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-amzn64-latest.tgz"
+             MONGODB_34="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-amzn64-${VERSION_34}.tgz"
+             MONGODB_32="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-amzn64-${VERSION_32}.tgz"
+             MONGODB_30="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-amzn64-${VERSION_30}.tgz"
+             MONGODB_26="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-amzn64-${VERSION_26}.tgz"
+             MONGODB_24="http://downloads.10gen.com/linux/mongodb-linux-x86_64-subscription-amzn64-${VERSION_24}.tgz"
+      ;;
+      linux-debian-7*)
+         MONGODB_LATEST="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-debian71-latest.tgz"
+             MONGODB_34="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-debian71-${VERSION_34}.tgz"
+             MONGODB_32="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-debian71-${VERSION_32}.tgz"
+             MONGODB_30="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-debian71-${VERSION_30}.tgz"
+             MONGODB_26="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-debian71-${VERSION_26}.tgz"
              MONGODB_24=""
       ;;
       linux-debian-8*)

--- a/.evergreen/run-orchestration.sh
+++ b/.evergreen/run-orchestration.sh
@@ -57,7 +57,7 @@ elif virtualenv venv || python -m virtualenv venv; then
 fi
 cd -
 
-case "$DISTRO" in
+case "$OS" in
   cygwin*)
     ORCHESTRATION_ARGUMENTS="$ORCHESTRATION_ARGUMENTS -s wsgiref"
     ;;


### PR DESCRIPTION
Add links for Debian 7.1, Amazon x86_64 Linux, SLES 11, and SLES 12.

Also, changes MO setup to always install into a virtualenv where possible because mongo-orchestration doesn't run on Amazon x86_64 Linux otherwise.