### PR TITLE
Add link for Ubuntu 16.04 (x86_64) MongoDB 3.2

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -741,10 +741,6 @@ axes:
         display_name: "Debian 8.1"
         run_on: debian81-test
 
-      - id: ubuntu-16.04
-        display_name: "Ubuntu 16.04"
-        run_on: ubuntu1604-test
-
       - id: rhel71-power8-test
         display_name: "RHEL 7.1 (POWER8)"
         run_on: rhel71-power8-test
@@ -775,6 +771,10 @@ axes:
       - id: suse12-x86-64-test
         display_name: "SUSE 12 (x86_64)"
         run_on: suse12-test
+
+      - id: ubuntu-16.04
+        display_name: "Ubuntu 16.04"
+        run_on: ubuntu1604-test
 
 
   - id: topology

--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -187,7 +187,7 @@ get_mongodb_download_url_for ()
       linux-ubuntu-16.04*)
          MONGODB_LATEST="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-ubuntu1604-latest.tgz"
              MONGODB_34="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-ubuntu1604-${VERSION_34}.tgz"
-             MONGODB_32=""
+             MONGODB_32="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-ubuntu1604-${VERSION_32}.tgz"
              MONGODB_30=""
              MONGODB_26=""
              MONGODB_24=""


### PR DESCRIPTION
MongoDB 3.2 is available on Ubuntu 16.04 (x86_64).