### PR TITLE
Fix "install dependencies" function definition

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -379,13 +379,13 @@ functions:
           echo '{"results": [{ "status": "FAIL", "test_file": "Build", "log_raw": "No test-results.json found was created"  } ]}' > ${PROJECT_DIRECTORY}/test-results.json
 
   "install dependencies":
-    type: test
-    params:
-      working_dir: "src"
-      script: |
-        ${PREPARE_SHELL}
-        file="${PROJECT_DIRECTORY}/.evergreen/install-dependencies.sh"
-        [ -f ${file} ] && sh ${file} || echo "${file} not available, skipping"
+    - command: shell.exec
+      params:
+        working_dir: "src"
+        script: |
+          ${PREPARE_SHELL}
+          file="${PROJECT_DIRECTORY}/.evergreen/install-dependencies.sh"
+          [ -f ${file} ] && sh ${file} || echo "${file} not available, skipping"
 
 pre:
   - func: "fetch source"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -385,7 +385,8 @@ functions:
         script: |
           ${PREPARE_SHELL}
           file="${PROJECT_DIRECTORY}/.evergreen/install-dependencies.sh"
-          [ -f ${file} ] && sh ${file} || echo "${file} not available, skipping"
+          # Don't use ${file} syntax here because evergreen treats it as an empty expansion.
+          [ -f "$file" ] && sh $file || echo "$file not available, skipping"
 
 pre:
   - func: "fetch source"


### PR DESCRIPTION
Before this change the "install dependencies" pre hook was silently skipped, see https://jira.mongodb.org/browse/EVG-763.