### PR TITLE
Add storage engine testing for standalones

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -965,7 +965,7 @@ buildvariants:
      - name: "test-3.4-sharded_cluster"
      - name: "test-3.4-standalone"
 
-# Storage Engine Tests
+# Storage Engine Tests on Amazon Linux (Enterprise)
 - matrix_name: "tests-storage-engines"
   matrix_spec: {"os-fully-featured": "linux-64-amzn-test", storage-engine: "*" }
   display_name: "${os-fully-featured} ${storage-engine}"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -314,7 +314,7 @@ functions:
       params:
         script: |
           ${PREPARE_SHELL}
-          MONGODB_VERSION=${VERSION} TOPOLOGY=${TOPOLOGY} AUTH=${AUTH} SSL=${SSL} sh ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
+          MONGODB_VERSION=${VERSION} TOPOLOGY=${TOPOLOGY} AUTH=${AUTH} SSL=${SSL} STORAGE_ENGINE=${STORAGE_ENGINE} sh ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
     # run-orchestration generates expansion file with the MONGODB_URI for the cluster
     - command: expansions.update
       params:
@@ -832,6 +832,21 @@ axes:
         display_name: NoSSL
         variables:
            SSL: "nossl"
+  - id: storage-engine
+    display_name: Storage
+    values:
+      - id: mmapv1
+        display_name: MMAPv1
+        variables:
+           STORAGE_ENGINE: "mmapv1"
+      - id: wiredtiger
+        display_name: WiredTiger
+        variables:
+           STORAGE_ENGINE: "wiredtiger"
+      - id: inmemory
+        display_name: InMemory
+        variables:
+           STORAGE_ENGINE: "inmemory"
 
 
 buildvariants:
@@ -949,6 +964,26 @@ buildvariants:
      - name: "test-3.4-replica_set"
      - name: "test-3.4-sharded_cluster"
      - name: "test-3.4-standalone"
+
+# Storage Engine Tests
+- matrix_name: "tests-storage-engines"
+  matrix_spec: {"os-fully-featured": "linux-64-amzn-test", storage-engine: "*" }
+  display_name: "${os-fully-featured} ${storage-engine}"
+  rules:
+    - if:
+        os-fully-featured: "*"
+        storage-engine: ["mmapv1", "inmemory"]
+      then:
+        add_tasks:
+          - "test-latest-standalone"
+          - "test-3.4-standalone"
+          - "test-3.2-standalone"
+    - if:
+        os-fully-featured: "*"
+        storage-engine: "wiredtiger"
+      then:
+        add_tasks:
+          - "test-3.0-standalone"
 
       # Platform notes
       # i386 builds of OpenSSL or Cyrus SASL are not available

--- a/.evergreen/orchestration/configs/servers/inmemory.json
+++ b/.evergreen/orchestration/configs/servers/inmemory.json
@@ -5,7 +5,7 @@
         "bind_ip": "localhost,::1",
         "logappend": true,
         "journal": true,
-        "storageEngine": "wiredTiger",
+        "storageEngine": "inMemory",
         "port": 27017
     }
 }

--- a/.evergreen/orchestration/configs/servers/mmapv1.json
+++ b/.evergreen/orchestration/configs/servers/mmapv1.json
@@ -2,7 +2,7 @@
     "name": "mongod",
     "procParams": {
         "ipv6": true,
-	"bind_ip": "localhost,::1",
+        "bind_ip": "localhost,::1",
         "logappend": true,
         "journal": true,
         "storageEngine": "mmapv1",

--- a/.evergreen/run-orchestration.sh
+++ b/.evergreen/run-orchestration.sh
@@ -31,14 +31,9 @@ if [ "$SSL" != "nossl" ]; then
    ORCHESTRATION_FILE="${ORCHESTRATION_FILE}-ssl"
 fi
 
+# Storage engine config files do not exist for different topology, auth, or ssl modes.
 if [ ! -z "$STORAGE_ENGINE" ]; then
   ORCHESTRATION_FILE="$STORAGE_ENGINE"
-fi
-
-# Only wiredTiger supports enableMajorityReadConcern. This can be removed once
-# mongo-orchestration properly checks the storageEngine is compatible.
-if [ -z "$STORAGE_ENGINE" || "$STORAGE_ENGINE" = "wiredtiger" ]; then
-  ENABLE_MAJORITY_READ_CONCERN="--enable-majority-read-concern"
 fi
 
 export ORCHESTRATION_FILE="$MONGO_ORCHESTRATION_HOME/configs/${TOPOLOGY}s/${ORCHESTRATION_FILE}.json"
@@ -47,7 +42,7 @@ export ORCHESTRATION_URL="http://localhost:8889/v1/${TOPOLOGY}s"
 echo From shell `date` > $MONGO_ORCHESTRATION_HOME/server.log
 
 
-ORCHESTRATION_ARGUMENTS="-e default -f $MONGO_ORCHESTRATION_HOME/orchestration.config --socket-timeout-ms=60000 --bind=127.0.0.1 $ENABLE_MAJORITY_READ_CONCERN"
+ORCHESTRATION_ARGUMENTS="-e default -f $MONGO_ORCHESTRATION_HOME/orchestration.config --socket-timeout-ms=60000 --bind=127.0.0.1 --enable-majority-read-concern"
 
 cd "$MONGO_ORCHESTRATION_HOME"
 # Setup or use the existing virtualenv for mongo-orchestration


### PR DESCRIPTION
The change lets drivers test against standalone mongods with the mmapv1, wiredTiger, or inMemory storage engine.

Evergreen: https://evergreen.mongodb.com/version/58ae355b3ff1225d73022c73

Resolves https://github.com/mongodb-labs/drivers-evergreen-tools/issues/15.