### PR TITLE
Add support for Windows SSL tests

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -361,6 +361,8 @@ functions:
             cat $i | tr -d '\r' > $i.new
             mv $i.new $i
           done
+          # Copy client certificate because symlinks do not work on Windows.
+          cp ${DRIVERS_TOOLS}/.evergreen/x509gen/client.pem ${MONGO_ORCHESTRATION_HOME}/lib/client.pem
 
   "make files executable":
     - command: shell.exec
@@ -712,9 +714,9 @@ axes:
         display_name: "Solaris"
         run_on: solaris
 
-      # TODO: move Windows to a matrix that runs SSL tests with MongoDB >= 2.6.
-      # SSL is available on Windows since MongoDB 2.6 but mongo-orchestration
-      # fails setting up the cluster.
+  - id: os-windows
+    display_name: OS
+    values:
       - id: windows-64-vs2010-test
         display_name: "Windows (VS2010)"
         run_on: windows-64-vs2010-test
@@ -984,6 +986,37 @@ buildvariants:
       then:
         add_tasks:
           - "test-3.0-standalone"
+
+- matrix_name: "tests-windows"
+  matrix_spec: {os-windows: "*", auth: "*", ssl: "*" }
+  display_name: "${os-windows} ${auth} ${ssl}"
+  tasks:
+     - name: "test-latest-replica_set"
+     - name: "test-latest-sharded_cluster"
+     - name: "test-latest-standalone"
+     - name: "test-3.4-replica_set"
+     - name: "test-3.4-sharded_cluster"
+     - name: "test-3.4-standalone"
+     - name: "test-3.2-replica_set"
+     - name: "test-3.2-sharded_cluster"
+     - name: "test-3.2-standalone"
+     - name: "test-3.0-replica_set"
+     - name: "test-3.0-sharded_cluster"
+     - name: "test-3.0-standalone"
+     - name: "test-2.6-replica_set"
+     - name: "test-2.6-sharded_cluster"
+     - name: "test-2.6-standalone"
+  rules:
+     # Windows MongoDB 2.4 does not support SSL.
+     - if:
+         os-windows: "*"
+         auth: "*"
+         ssl: "nossl"
+       then:
+         add_tasks:
+           - name: "test-2.4-replica_set"
+           - name: "test-2.4-sharded_cluster"
+           - name: "test-2.4-standalone"
 
       # Platform notes
       # i386 builds of OpenSSL or Cyrus SASL are not available


### PR DESCRIPTION
Fixes https://github.com/mongodb-labs/drivers-evergreen-tools/issues/11.

The client certificate cannot be a symlink on Windows, git/Windows does not
support symlinks.

```
$ git clone git@github.com:mongodb-labs/drivers-evergreen-tools.git
Cloning into 'drivers-evergreen-tools'...
$ ls -l drivers-evergreen-tools/.evergreen/orchestration/lib
total 1
-rwxr-xr-x 1 Administrator None 24 Feb 24 22:14 client.pem
$ cat drivers-evergreen-tools/.evergreen/orchestration/lib/client.pem
../../x509gen/client.pem
$ git clone -c core.symlinks=true git@github.com:mongodb-labs/drivers-evergreen-tools.git withsymlinks
Cloning into 'withsymlinks'...
error: unable to create symlink .evergreen/orchestration/lib/client.pem (Function not implemented)
error: unable to create symlink .evergreen/x509gen/7750279a.0 (Function not implemented)
fatal: unable to checkout working tree
warning: Clone succeeded, but checkout failed.
You can inspect what was checked out with 'git status'
and retry the checkout with 'git checkout -f HEAD'
```

 This causes mongo-orc to fail since the certificate is invalid:
```
2017-02-24 19:58:57,196 [ERROR] mongo_orchestration.servers:341 - isMaster failed!
Traceback (most recent call last):
  File "c:\cygwin\home\administrator\mongo-orchestration\mongo_orchestration\servers.py", line 338, in start
    self.run_command('isMaster')
  File "c:\cygwin\home\administrator\mongo-orchestration\mongo_orchestration\servers.py", line 260, in run_command
    result = getattr(self.connection.admin, mode)(command, name, **d)
  File "c:\cygwin\home\administrator\mongo-orchestration\mongo_orchestration\servers.py", line 190, in connection
    connected(c)
  File "c:\cygwin\home\administrator\mongo-orchestration\mongo_orchestration\common.py", line 141, in connected
    client.admin.command('ismaster')
  File "c:\cygwin\home\administrator\venv\lib\site-packages\pymongo\database.py", line 491, in command
    with client._socket_for_reads(read_preference) as (sock_info, slave_ok):
  File "c:\python27\Lib\contextlib.py", line 17, in __enter__
    return self.gen.next()
  File "c:\cygwin\home\administrator\venv\lib\site-packages\pymongo\mongo_client.py", line 859, in _socket_for_reads
    with self._get_socket(read_preference) as sock_info:
  File "c:\python27\Lib\contextlib.py", line 17, in __enter__
    return self.gen.next()
  File "c:\cygwin\home\administrator\venv\lib\site-packages\pymongo\mongo_client.py", line 823, in _get_socket
    server = self._get_topology().select_server(selector)
  File "c:\cygwin\home\administrator\venv\lib\site-packages\pymongo\topology.py", line 214, in select_server
    address))
  File "c:\cygwin\home\administrator\venv\lib\site-packages\pymongo\topology.py", line 189, in select_servers
    self._error_message(selector))
ServerSelectionTimeoutError: SSL handshake failed: [Errno 336265225] _ssl.c:351: error:140B0009:SSL routines:SSL_CTX_use_PrivateKey_file:PEM lib
```