### PR TITLE
Don't start MongoDB with --nohttpinterface

### DIFF
--- a/.evergreen/orchestration/configs/replica_sets/auth-ssl.json
+++ b/.evergreen/orchestration/configs/replica_sets/auth-ssl.json
@@ -7,8 +7,7 @@
     {
       "procParams": {
         "ipv6": true,
-	"bind_ip": "localhost,::1",
-        "nohttpinterface": true,
+        "bind_ip": "localhost,::1",
         "journal": true,
         "noprealloc": true,
         "nssize": 1,
@@ -25,8 +24,7 @@
     {
       "procParams": {
         "ipv6": true,
-	"bind_ip": "localhost,::1",
-        "nohttpinterface": true,
+        "bind_ip": "localhost,::1",
         "journal": true,
         "noprealloc": true,
         "nssize": 1,
@@ -43,8 +41,7 @@
     {
       "procParams": {
         "ipv6": true,
-	"bind_ip": "localhost,::1",
-        "nohttpinterface": true,
+        "bind_ip": "localhost,::1",
         "journal": true,
         "noprealloc": true,
         "nssize": 1,

--- a/.evergreen/orchestration/configs/replica_sets/auth.json
+++ b/.evergreen/orchestration/configs/replica_sets/auth.json
@@ -6,8 +6,7 @@
     {
       "procParams": {
         "ipv6": true,
-	"bind_ip": "localhost,::1",
-        "nohttpinterface": true,
+        "bind_ip": "localhost,::1",
         "journal": true,
         "noprealloc": true,
         "nssize": 1,
@@ -24,8 +23,7 @@
     {
       "procParams": {
         "ipv6": true,
-	"bind_ip": "localhost,::1",
-        "nohttpinterface": true,
+        "bind_ip": "localhost,::1",
         "journal": true,
         "noprealloc": true,
         "nssize": 1,
@@ -42,8 +40,7 @@
     {
       "procParams": {
         "ipv6": true,
-	"bind_ip": "localhost,::1",
-        "nohttpinterface": true,
+        "bind_ip": "localhost,::1",
         "journal": true,
         "noprealloc": true,
         "nssize": 1,

--- a/.evergreen/orchestration/configs/replica_sets/basic-ssl.json
+++ b/.evergreen/orchestration/configs/replica_sets/basic-ssl.json
@@ -4,8 +4,7 @@
     {
       "procParams": {
         "ipv6": true,
-	"bind_ip": "localhost,::1",
-        "nohttpinterface": true,
+        "bind_ip": "localhost,::1",
         "journal": true,
         "noprealloc": true,
         "nssize": 1,
@@ -22,8 +21,7 @@
     {
       "procParams": {
         "ipv6": true,
-	"bind_ip": "localhost,::1",
-        "nohttpinterface": true,
+        "bind_ip": "localhost,::1",
         "journal": true,
         "noprealloc": true,
         "nssize": 1,
@@ -40,8 +38,7 @@
     {
       "procParams": {
         "ipv6": true,
-	"bind_ip": "localhost,::1",
-        "nohttpinterface": true,
+        "bind_ip": "localhost,::1",
         "journal": true,
         "noprealloc": true,
         "nssize": 1,

--- a/.evergreen/orchestration/configs/replica_sets/basic.json
+++ b/.evergreen/orchestration/configs/replica_sets/basic.json
@@ -4,8 +4,7 @@
     {
       "procParams": {
         "ipv6": true,
-	"bind_ip": "localhost,::1",
-        "nohttpinterface": true,
+        "bind_ip": "localhost,::1",
         "journal": true,
         "noprealloc": true,
         "nssize": 1,
@@ -22,8 +21,7 @@
     {
       "procParams": {
         "ipv6": true,
-	"bind_ip": "localhost,::1",
-        "nohttpinterface": true,
+        "bind_ip": "localhost,::1",
         "journal": true,
         "noprealloc": true,
         "nssize": 1,
@@ -40,8 +38,7 @@
     {
       "procParams": {
         "ipv6": true,
-	"bind_ip": "localhost,::1",
-        "nohttpinterface": true,
+        "bind_ip": "localhost,::1",
         "journal": true,
         "noprealloc": true,
         "nssize": 1,


### PR DESCRIPTION
Removed in MongoDB 3.5.7+, SERVER-29000.