### PR TITLE
Start shards as single member replica sets.

### DIFF
--- a/.evergreen/orchestration/configs/sharded_clusters/auth-ssl.json
+++ b/.evergreen/orchestration/configs/sharded_clusters/auth-ssl.json
@@ -7,25 +7,29 @@
     {
       "id": "sh01",
       "shardParams": {
-        "procParams": {
-          "ipv6": true,
-          "bind_ip": "127.0.0.1,::1",
-          "shardsvr": true,
-          "setParameter" : { "enableTestCommands": 1 },
-          "port": 27217
-        }
+        "members": [{
+          "procParams": {
+            "ipv6": true,
+            "bind_ip": "127.0.0.1,::1",
+            "shardsvr": true,
+            "setParameter" : { "enableTestCommands": 1 },
+            "port": 27217
+          }
+        }]
       }
     },
     {
       "id": "sh02",
       "shardParams": {
-        "procParams": {
-          "ipv6": true,
-          "bind_ip": "127.0.0.1,::1",
-          "shardsvr": true,
-          "setParameter" : { "enableTestCommands": 1 },
-          "port": 27218
-        }
+        "members": [{
+          "procParams": {
+            "ipv6": true,
+            "bind_ip": "127.0.0.1,::1",
+            "shardsvr": true,
+            "setParameter" : { "enableTestCommands": 1 },
+            "port": 27218
+          }
+        }]
       }
     }
   ],

--- a/.evergreen/orchestration/configs/sharded_clusters/auth.json
+++ b/.evergreen/orchestration/configs/sharded_clusters/auth.json
@@ -7,23 +7,29 @@
     {
       "id": "sh01",
       "shardParams": {
-        "procParams": {
-          "ipv6": true,
-          "bind_ip": "127.0.0.1,::1",
-          "shardsvr": true,
-          "port": 27217
-        }
+        "members": [{
+          "procParams": {
+            "ipv6": true,
+            "bind_ip": "127.0.0.1,::1",
+            "shardsvr": true,
+            "setParameter" : { "enableTestCommands": 1 },
+            "port": 27217
+          }
+        }]
       }
     },
     {
       "id": "sh02",
       "shardParams": {
-        "procParams": {
-          "ipv6": true,
-          "bind_ip": "127.0.0.1,::1",
-          "shardsvr": true,
-          "port": 27218
-        }
+        "members": [{
+          "procParams": {
+            "ipv6": true,
+            "bind_ip": "127.0.0.1,::1",
+            "shardsvr": true,
+            "setParameter" : { "enableTestCommands": 1 },
+            "port": 27218
+          }
+        }]
       }
     }
   ],

--- a/.evergreen/orchestration/configs/sharded_clusters/basic-ssl.json
+++ b/.evergreen/orchestration/configs/sharded_clusters/basic-ssl.json
@@ -4,23 +4,29 @@
     {
       "id": "sh01",
       "shardParams": {
-        "procParams": {
-          "ipv6": true,
-          "bind_ip": "127.0.0.1,::1",
-          "shardsvr": true,
-          "port": 27217
-        }
+        "members": [{
+          "procParams": {
+            "ipv6": true,
+            "bind_ip": "127.0.0.1,::1",
+            "shardsvr": true,
+            "setParameter" : { "enableTestCommands": 1 },
+            "port": 27217
+          }
+        }]
       }
     },
     {
       "id": "sh02",
       "shardParams": {
-        "procParams": {
-          "ipv6": true,
-          "bind_ip": "127.0.0.1,::1",
-          "shardsvr": true,
-          "port": 27218
-        }
+        "members": [{
+          "procParams": {
+            "ipv6": true,
+            "bind_ip": "127.0.0.1,::1",
+            "shardsvr": true,
+            "setParameter" : { "enableTestCommands": 1 },
+            "port": 27218
+          }
+        }]
       }
     }
   ],

--- a/.evergreen/orchestration/configs/sharded_clusters/basic.json
+++ b/.evergreen/orchestration/configs/sharded_clusters/basic.json
@@ -4,23 +4,29 @@
     {
       "id": "sh01",
       "shardParams": {
-        "procParams": {
-          "ipv6": true,
-          "bind_ip": "127.0.0.1,::1",
-          "shardsvr": true,
-          "port": 27217
-        }
+        "members": [{
+          "procParams": {
+            "ipv6": true,
+            "bind_ip": "127.0.0.1,::1",
+            "shardsvr": true,
+            "setParameter" : { "enableTestCommands": 1 },
+            "port": 27217
+          }
+        }]
       }
     },
     {
       "id": "sh02",
       "shardParams": {
-        "procParams": {
-          "ipv6": true,
-          "bind_ip": "127.0.0.1,::1",
-          "shardsvr": true,
-          "port": 27218
-        }
+        "members": [{
+          "procParams": {
+            "ipv6": true,
+            "bind_ip": "127.0.0.1,::1",
+            "shardsvr": true,
+            "setParameter" : { "enableTestCommands": 1 },
+            "port": 27218
+          }
+        }]
       }
     }
   ],


### PR DESCRIPTION
ChangeStreams and retryable writes require replica sets.