### PR TITLE
Remove solaris distro.

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -710,10 +710,6 @@ axes:
         display_name: "macOS 10.12"
         run_on: macos-1012
 
-      - id: solaris
-        display_name: "Solaris"
-        run_on: solaris
-
   - id: os-windows
     display_name: OS
     values:


### PR DESCRIPTION
The solaris distro no longer exists: https://engineering.mongodb.com/post/farewell-solaris