### PR TITLE
Fix distro comparison on SUSE 12 Z Series

### DIFF
--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -132,7 +132,7 @@ get_mongodb_download_url_for ()
              MONGODB_26="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-suse11-${VERSION_26}.tgz"
              MONGODB_24="http://downloads.10gen.com/linux/mongodb-linux-x86_64-subscription-suse11-${VERSION_24}.tgz"
       ;;
-      linux-sles-12.1-s390x)
+      linux-sles-12*-s390x)
          MONGODB_LATEST="http://downloads.10gen.com/linux/mongodb-linux-s390x-enterprise-suse12-latest.tgz"
              MONGODB_36="http://downloads.10gen.com/linux/mongodb-linux-s390x-enterprise-suse12-${VERSION_36}.tgz"
              MONGODB_34="http://downloads.10gen.com/linux/mongodb-linux-s390x-enterprise-suse12-${VERSION_34}.tgz"


### PR DESCRIPTION
Fixes the following bug:
```
 [2018/02/27 15:26:54.096] + download_and_extract 'Unknown version: 3.4 for linux-sles-12.3-s390x' 'tar zxf'
 [2018/02/27 15:26:54.096] linux-sles-12.3-s390x
 [2018/02/27 15:26:54.096] + MONGODB_DOWNLOAD_URL='Unknown version: 3.4 for linux-sles-12.3-s390x'
 [2018/02/27 15:26:54.096] + EXTRACT='tar zxf'
 [2018/02/27 15:26:54.096] Unknown version: 3.4 for linux-sles-12.3-s390x
 [2018/02/27 15:26:54.096] Unknown version: 3.4 for linux-sles-12.3-s390x
 [2018/02/27 15:26:54.096] + cd /data/mci/2b5053f22b5ce16489af0ed34a35dc72/src/../drivers-tools
 [2018/02/27 15:26:54.096] + curl Unknown version: 3.4 for linux-sles-12.3-s390x --silent --max-time 120 --fail --output mongodb-binaries.tgz
 [2018/02/27 15:28:54.641] Command failed: command [pid=20947] encountered problem: exit status 6
 [2018/02/27 15:28:54.641] Task completed - FAILURE.
```