### PR TITLE
Don't use arbiters in auth configs

### DIFF
--- a/.evergreen/orchestration/configs/replica_sets/auth-ssl.json
+++ b/.evergreen/orchestration/configs/replica_sets/auth-ssl.json
@@ -51,7 +51,6 @@
         "smallfiles": true
       },
       "rsParams": {
-        "arbiterOnly": true
       }
     }
   ],

--- a/.evergreen/orchestration/configs/replica_sets/auth.json
+++ b/.evergreen/orchestration/configs/replica_sets/auth.json
@@ -50,7 +50,6 @@
         "smallfiles": true
       },
       "rsParams": {
-        "arbiterOnly": true
       }
     }
   ],


### PR DESCRIPTION
This is to work around https://jira.mongodb.org/browse/SERVER-34421
and should be reverted once that is fixed and shipped.
