### PR TITLE
Remove nssize and smallfiles startup options

### DIFF
--- a/.evergreen/orchestration/configs/replica_sets/auth-ssl.json
+++ b/.evergreen/orchestration/configs/replica_sets/auth-ssl.json
@@ -9,11 +9,8 @@
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
         "journal": true,
-        "noprealloc": true,
-	"oplogSize": 500,
-        "nssize": 1,
-        "port": 27017,
-        "smallfiles": true
+       "oplogSize": 500,
+        "port": 27017
       },
       "rsParams": {
         "tags": {
@@ -27,11 +24,8 @@
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
         "journal": true,
-        "noprealloc": true,
- 	"oplogSize": 500,
-        "nssize": 1,
-        "port": 27018,
-        "smallfiles": true
+        "oplogSize": 500,
+        "port": 27018
       },
       "rsParams": {
         "tags": {
@@ -45,10 +39,7 @@
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
         "journal": true,
-        "noprealloc": true,
-        "nssize": 1,
-        "port": 27019,
-        "smallfiles": true
+        "port": 27019
       },
       "rsParams": {
       }

--- a/.evergreen/orchestration/configs/replica_sets/auth.json
+++ b/.evergreen/orchestration/configs/replica_sets/auth.json
@@ -8,11 +8,8 @@
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
         "journal": true,
-        "noprealloc": true,
- 	"oplogSize": 500,
-        "nssize": 1,
-        "port": 27017,
-        "smallfiles": true
+        "oplogSize": 500,
+        "port": 27017
       },
       "rsParams": {
         "tags": {
@@ -26,11 +23,8 @@
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
         "journal": true,
-        "noprealloc": true,
- 	"oplogSize": 500,
-        "nssize": 1,
-        "port": 27018,
-        "smallfiles": true
+        "oplogSize": 500,
+        "port": 27018
       },
       "rsParams": {
         "tags": {
@@ -44,10 +38,7 @@
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
         "journal": true,
-        "noprealloc": true,
-        "nssize": 1,
-        "port": 27019,
-        "smallfiles": true
+        "port": 27019
       },
       "rsParams": {
       }

--- a/.evergreen/orchestration/configs/replica_sets/basic-ssl.json
+++ b/.evergreen/orchestration/configs/replica_sets/basic-ssl.json
@@ -6,11 +6,8 @@
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
         "journal": true,
-        "noprealloc": true,
-	"oplogSize": 500,
-        "nssize": 1,
-        "port": 27017,
-        "smallfiles": true
+        "oplogSize": 500,
+        "port": 27017
       },
       "rsParams": {
         "tags": {
@@ -24,11 +21,8 @@
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
         "journal": true,
-        "noprealloc": true,
-	"oplogSize": 500,
-        "nssize": 1,
-        "port": 27018,
-        "smallfiles": true
+        "oplogSize": 500,
+        "port": 27018
       },
       "rsParams": {
         "tags": {
@@ -42,10 +36,7 @@
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
         "journal": true,
-        "noprealloc": true,
-        "nssize": 1,
-        "port": 27019,
-        "smallfiles": true
+        "port": 27019
       },
       "rsParams": {
         "arbiterOnly": true

--- a/.evergreen/orchestration/configs/replica_sets/basic.json
+++ b/.evergreen/orchestration/configs/replica_sets/basic.json
@@ -6,11 +6,8 @@
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
         "journal": true,
-        "noprealloc": true,
-	"oplogSize": 500,
-        "nssize": 1,
-        "port": 27017,
-        "smallfiles": true
+        "oplogSize": 500,
+        "port": 27017
       },
       "rsParams": {
         "tags": {
@@ -24,11 +21,8 @@
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
         "journal": true,
-        "noprealloc": true,
-	"oplogSize": 500,
-        "nssize": 1,
-        "port": 27018,
-        "smallfiles": true
+        "oplogSize": 500,
+        "port": 27018
       },
       "rsParams": {
         "tags": {
@@ -42,10 +36,7 @@
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
         "journal": true,
-        "noprealloc": true,
-        "nssize": 1,
-        "port": 27019,
-        "smallfiles": true
+        "port": 27019
       },
       "rsParams": {
         "arbiterOnly": true

--- a/.evergreen/orchestration/configs/servers/auth-ssl.json
+++ b/.evergreen/orchestration/configs/servers/auth-ssl.json
@@ -5,7 +5,7 @@
     "password": "pwd123",
     "procParams": {
         "ipv6": true,
-	"bind_ip": "127.0.0.1,::1",
+        "bind_ip": "127.0.0.1,::1",
         "logappend": true,
         "journal": true,
         "port": 27017


### PR DESCRIPTION
Removed in 4.2, see SERVER-35715 and SERVER-35984.