### PR TITLE
Make curl retry more times

### DIFF
--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -344,7 +344,7 @@ download_and_extract ()
    EXTRACT=$2
 
    cd $DRIVERS_TOOLS
-   curl --retry 5 -sS $MONGODB_DOWNLOAD_URL --max-time 300 --output mongodb-binaries.tgz
+   curl --retry 8 -sS $MONGODB_DOWNLOAD_URL --max-time 300 --output mongodb-binaries.tgz
    $EXTRACT mongodb-binaries.tgz
 
    rm mongodb-binaries.tgz


### PR DESCRIPTION
I've seen task system failures because curl failed.  More retries (with exponential backoff) might help.  I'd rather have a longer delay with a chance of success than false positive test failures.