### PR TITLE
PYTHON-1644 Ensure primary starts on port 27017

### DIFF
--- a/.evergreen/orchestration/configs/replica_sets/auth-ssl.json
+++ b/.evergreen/orchestration/configs/replica_sets/auth-ssl.json
@@ -13,6 +13,7 @@
         "port": 27017
       },
       "rsParams": {
+        "priority": 1,
         "tags": {
           "ordinal": "one",
           "dc": "ny"

--- a/.evergreen/orchestration/configs/replica_sets/auth-ssl.json
+++ b/.evergreen/orchestration/configs/replica_sets/auth-ssl.json
@@ -13,7 +13,7 @@
         "port": 27017
       },
       "rsParams": {
-        "priority": 1,
+        "priority": 10,
         "tags": {
           "ordinal": "one",
           "dc": "ny"

--- a/.evergreen/orchestration/configs/replica_sets/auth.json
+++ b/.evergreen/orchestration/configs/replica_sets/auth.json
@@ -12,6 +12,7 @@
         "port": 27017
       },
       "rsParams": {
+        "priority": 1,
         "tags": {
           "ordinal": "one",
           "dc": "ny"

--- a/.evergreen/orchestration/configs/replica_sets/auth.json
+++ b/.evergreen/orchestration/configs/replica_sets/auth.json
@@ -12,7 +12,7 @@
         "port": 27017
       },
       "rsParams": {
-        "priority": 1,
+        "priority": 10,
         "tags": {
           "ordinal": "one",
           "dc": "ny"

--- a/.evergreen/orchestration/configs/replica_sets/basic-ssl.json
+++ b/.evergreen/orchestration/configs/replica_sets/basic-ssl.json
@@ -10,7 +10,7 @@
         "port": 27017
       },
       "rsParams": {
-        "priority": 1,
+        "priority": 10,
         "tags": {
           "ordinal": "one",
           "dc": "ny"

--- a/.evergreen/orchestration/configs/replica_sets/basic-ssl.json
+++ b/.evergreen/orchestration/configs/replica_sets/basic-ssl.json
@@ -10,6 +10,7 @@
         "port": 27017
       },
       "rsParams": {
+        "priority": 1,
         "tags": {
           "ordinal": "one",
           "dc": "ny"

--- a/.evergreen/orchestration/configs/replica_sets/basic.json
+++ b/.evergreen/orchestration/configs/replica_sets/basic.json
@@ -10,7 +10,7 @@
         "port": 27017
       },
       "rsParams": {
-        "priority": 1,
+        "priority": 10,
         "tags": {
           "ordinal": "one",
           "dc": "ny"

--- a/.evergreen/orchestration/configs/replica_sets/basic.json
+++ b/.evergreen/orchestration/configs/replica_sets/basic.json
@@ -10,6 +10,7 @@
         "port": 27017
       },
       "rsParams": {
+        "priority": 1,
         "tags": {
           "ordinal": "one",
           "dc": "ny"


### PR DESCRIPTION
Fixes [PYTHON-1644](https://jira.mongodb.org/browse/PYTHON-1644): https://evergreen.mongodb.com/version/5c7ee3e532f4176c5c1f23c1

The remaining test failures are from a server change which added the `keyPattern` and `keyValue` fields to writeErrors.