### PR TITLE
PYTHON-1830 Update to Amazon Linux 2018

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -717,9 +717,9 @@ axes:
     display_name: OS
     values:
 
-      - id: linux-64-amzn-test
-        display_name: "Amazon Linux (Enterprise)"
-        run_on: linux-64-amzn-test
+      - id: amazon1-2018-test
+        display_name: "Amazon Linux 2018 (Enterprise)"
+        run_on: amazon1-2018-test
 
   # OSes that support versions of MongoDB without SSL.
   - id: os-nossl
@@ -1022,12 +1022,20 @@ buildvariants:
 
 # Storage Engine Tests on Amazon Linux (Enterprise)
 - matrix_name: "tests-storage-engines"
-  matrix_spec: {"os-fully-featured": "linux-64-amzn-test", storage-engine: "*" }
+  matrix_spec: {"os-fully-featured": "amazon1-2018-test", storage-engine: "*" }
   display_name: "${os-fully-featured} ${storage-engine}"
   rules:
     - if:
         os-fully-featured: "*"
-        storage-engine: ["mmapv1", "inmemory"]
+        storage-engine: ["mmapv1"]
+      then:
+        add_tasks:
+          - "test-3.6-standalone"
+          - "test-3.4-standalone"
+          - "test-3.2-standalone"
+    - if:
+        os-fully-featured: "*"
+        storage-engine: ["inmemory"]
       then:
         add_tasks:
           - "test-latest-standalone"

--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -171,7 +171,7 @@ get_mongodb_download_url_for ()
              MONGODB_26=""
              MONGODB_24=""
       ;;
-      linux-amzn64*)
+      linux-amzn*-x86_64)
          MONGODB_LATEST="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-amzn64-latest.tgz"
              MONGODB_40="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-amzn64-${VERSION_40}.tgz"
              MONGODB_36="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-amzn64-${VERSION_36}.tgz"


### PR DESCRIPTION
MongoDB 4.2 requires Amazon Linux 2018.
Amazon Linux 2018 also supports MongoDB>=2.4.
On amazon1-2018 _DISTRO is generated as linux-amzn-2018.03-x86_64
On linux-64-amzn _DISTRO is generated as linux-amzn64-x86_64

Other changes:
- Support download links for amazon1-2018
- Remove "latest" testing for mmapv1

Tested here: https://evergreen.mongodb.com/version/5cd0bc8a0305b95d4e163494