### PR TITLE
Fix bug to test with Evergreen on 4.2 and MacOS

### DIFF
--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -64,7 +64,7 @@ get_mongodb_download_url_for ()
    case "$_DISTRO" in
       darwin*)
          MONGODB_LATEST="http://downloads.10gen.com/osx/mongodb-macos-x86_64-enterprise-latest.tgz"
-             MONGODB_42="http://downloads.10gen.com/osx/mongodb-osx-x86_64-enterprise-${VERSION_42}.tgz"
+             MONGODB_42="http://downloads.10gen.com/osx/mongodb-macos-x86_64-enterprise-${VERSION_42}.tgz"
              MONGODB_40="http://downloads.10gen.com/osx/mongodb-osx-x86_64-enterprise-${VERSION_40}.tgz"
              MONGODB_36="http://downloads.10gen.com/osx/mongodb-osx-x86_64-enterprise-${VERSION_36}.tgz"
              MONGODB_34="http://downloads.10gen.com/osx/mongodb-osx-x86_64-enterprise-${VERSION_34}.tgz"


### PR DESCRIPTION
They changed the url from osx to macos for 4.2 downloads