### PR TITLE
Bump to 4.2.2; add Ubuntu 18.04 ppc

### DIFF
--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -49,7 +49,7 @@ get_mongodb_download_url_for ()
    _DISTRO=$1
    _VERSION=$2
 
-   VERSION_42="4.2.1"
+   VERSION_42="4.2.2"
    VERSION_40="4.0.13"
    VERSION_36="3.6.15"
    VERSION_34="3.4.23"

--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -284,6 +284,17 @@ get_mongodb_download_url_for ()
              MONGODB_26=""
              MONGODB_24=""
       ;;
+      linux-ubuntu-18.04-ppc64le)
+         MONGODB_LATEST="http://downloads.10gen.com/linux/mongodb-linux-ppc64le-enterprise-ubuntu1804-latest.tgz"
+             MONGODB_42="http://downloads.10gen.com/linux/mongodb-linux-ppc64le-enterprise-ubuntu1804-${VERSION_42}.tgz"
+             MONGODB_40=""
+             MONGODB_36=""
+             MONGODB_34=""
+             MONGODB_32=""
+             MONGODB_30=""
+             MONGODB_26=""
+             MONGODB_24=""
+      ;;
       linux-ubuntu-18.04*)
          MONGODB_LATEST="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-ubuntu1804-latest.tgz"
              MONGODB_42="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-ubuntu1804-${VERSION_42}.tgz"


### PR DESCRIPTION
Two commits: Bump 4.2 to latest version, and add Ubuntu 18.04 PPC64LE download URL. 

Note, https://jira.mongodb.org/browse/SERVER-37774 removed Ubuntu 16.04 PPC64LE, but in favor of Ubuntu 18.04 for 4.2. See the recently updated [production notes](https://docs.mongodb.com/manual/administration/production-notes/#ppc64le-mongodb-enterprise-edition).