### PR TITLE
Stop using nohup 

### DIFF
--- a/.evergreen/run-orchestration.sh
+++ b/.evergreen/run-orchestration.sh
@@ -61,7 +61,13 @@ export ORCHESTRATION_URL="http://localhost:8889/v1/${TOPOLOGY}s"
 sh $DIR/start-orchestration.sh "$MONGO_ORCHESTRATION_HOME"
 
 pwd
-curl --silent --show-error --data @"$ORCHESTRATION_FILE" "$ORCHESTRATION_URL" --max-time 600 --fail -o tmp.json
+if ! curl --silent --show-error --data @"$ORCHESTRATION_FILE" "$ORCHESTRATION_URL" --max-time 600 --fail -o tmp.json; then
+  echo Failed to start cluster, see $MONGO_ORCHESTRATION_HOME/out.log:
+  cat $MONGO_ORCHESTRATION_HOME/out.log
+  echo Failed to start cluster, see $MONGO_ORCHESTRATION_HOME/server.log:
+  cat $MONGO_ORCHESTRATION_HOME/server.log
+  exit 1
+fi
 cat tmp.json
 URI=$(python -c 'import sys, json; j=json.load(open("tmp.json")); print(j["mongodb_auth_uri" if "mongodb_auth_uri" in j else "mongodb_uri"])' | tr -d '\r')
 echo 'MONGODB_URI: "'$URI'"' > mo-expansion.yml

--- a/.evergreen/start-orchestration.sh
+++ b/.evergreen/start-orchestration.sh
@@ -59,7 +59,7 @@ else
   fi
 fi
 
-set -o pipefail && mongo-orchestration $ORCHESTRATION_ARGUMENTS start < /dev/null | tee $MONGO_ORCHESTRATION_HOME/out.log
+mongo-orchestration $ORCHESTRATION_ARGUMENTS start
 
 ls -la $MONGO_ORCHESTRATION_HOME
 

--- a/.evergreen/start-orchestration.sh
+++ b/.evergreen/start-orchestration.sh
@@ -59,7 +59,7 @@ else
   fi
 fi
 
-mongo-orchestration $ORCHESTRATION_ARGUMENTS start > $MONGO_ORCHESTRATION_HOME/out.log 2> $MONGO_ORCHESTRATION_HOME/err.log < /dev/null &
+set -o pipefail && mongo-orchestration $ORCHESTRATION_ARGUMENTS start < /dev/null | tee $MONGO_ORCHESTRATION_HOME/out.log
 
 ls -la $MONGO_ORCHESTRATION_HOME
 

--- a/.evergreen/start-orchestration.sh
+++ b/.evergreen/start-orchestration.sh
@@ -59,10 +59,16 @@ else
   fi
 fi
 
-mongo-orchestration $ORCHESTRATION_ARGUMENTS start
+mongo-orchestration $ORCHESTRATION_ARGUMENTS start > $MONGO_ORCHESTRATION_HOME/out.log 2>&1 < /dev/null &
 
 ls -la $MONGO_ORCHESTRATION_HOME
 
 sleep 5
-curl http://localhost:8889/ --silent --show-error --max-time 120 --fail
+if ! curl http://localhost:8889/ --silent --show-error --max-time 120 --fail; then
+  echo Failed to start mongo-orchestration, see $MONGO_ORCHESTRATION_HOME/out.log:
+  cat $MONGO_ORCHESTRATION_HOME/out.log
+  echo Failed to start mongo-orchestration, see $MONGO_ORCHESTRATION_HOME/server.log:
+  cat $MONGO_ORCHESTRATION_HOME/server.log
+  exit 1
+fi
 sleep 5

--- a/.evergreen/start-orchestration.sh
+++ b/.evergreen/start-orchestration.sh
@@ -59,7 +59,7 @@ else
   fi
 fi
 
-nohup mongo-orchestration $ORCHESTRATION_ARGUMENTS start > $MONGO_ORCHESTRATION_HOME/out.log 2> $MONGO_ORCHESTRATION_HOME/err.log < /dev/null &
+mongo-orchestration $ORCHESTRATION_ARGUMENTS start > $MONGO_ORCHESTRATION_HOME/out.log 2> $MONGO_ORCHESTRATION_HOME/err.log < /dev/null &
 
 ls -la $MONGO_ORCHESTRATION_HOME
 


### PR DESCRIPTION
nohup recently started failing on the macos hosts with:
```
nohup: can't detach from console: Inappropriate ioctl for device
``` 

We don't need to use nohup here as evidenced by this passing python patch build: https://evergreen.mongodb.com/version/5e47126a9ccd4e19cba49c37