### PR TITLE
Sync mock OCSP responder

### DIFF
--- a/.evergreen/ocsp/mock_ocsp_responder.py
+++ b/.evergreen/ocsp/mock_ocsp_responder.py
@@ -403,7 +403,7 @@ class OCSPResponseBuilder(object):
         signature_bytes = sign_func(responder_private_key, response_data.dump(), self._hash_algo)
 
         certs = None
-        if self._certificate_issuer:
+        if self._certificate_issuer and getattr(self._certificate_issuer.public_key, self._key_hash_algo) != responder_key_hash:
             certs = [responder_certificate]
 
         return ocsp.OCSPResponse({
@@ -414,7 +414,7 @@ class OCSPResponseBuilder(object):
                     'tbs_response_data': response_data,
                     'signature_algorithm': {'algorithm': signature_algorithm_id},
                     'signature': signature_bytes,
-                    'certs': certs
+                    'certs': certs,
                 }
             }
         })
@@ -451,7 +451,7 @@ FAULT_UNKNOWN = "unknown"
 class OCSPResponder:
 
     def __init__(self, issuer_cert: str, responder_cert: str, responder_key: str,
-                       fault: str = None, next_update_days: int = 7):
+                       fault: str, next_update_seconds: int):
         """
         Create a new OCSPResponder instance.
 
@@ -465,8 +465,8 @@ class OCSPResponder:
             depending on the status - a revocation datetime.
         :param cert_retrieve_func: A function that - given a certificate serial -
             will return the corresponding certificate as a string.
-        :param next_update_days: The ``nextUpdate`` value that will be written
-            into the response. Default: 7 days.
+        :param next_update_seconds: The ``nextUpdate`` value that will be written
+            into the response. Default: 9 hours.
 
         """
         # Certs and keys
@@ -475,7 +475,7 @@ class OCSPResponder:
         self._responder_key = asymmetric.load_private_key(responder_key)
 
         # Next update
-        self._next_update_days = next_update_days
+        self._next_update_seconds = next_update_seconds
 
         self._fault = fault
 
@@ -596,7 +596,7 @@ class OCSPResponder:
 
         # Set next update date
         now = datetime.now(timezone.utc)
-        builder.next_update = (now + timedelta(days=self._next_update_days)).replace(microsecond=0)
+        builder.next_update = (now + timedelta(seconds=self._next_update_seconds)).replace(microsecond=0)
 
         return builder.build(self._responder_key, self._responder_cert)
 

--- a/.evergreen/ocsp/ocsp_mock.py
+++ b/.evergreen/ocsp/ocsp_mock.py
@@ -27,14 +27,15 @@ def main():
 
     parser.add_argument('--ocsp_responder_key', type=str, required=True, help="OCSP Responder Keyfile")
 
-    parser.add_argument('--fault', choices=[mock_ocsp_responder.FAULT_REVOKED, mock_ocsp_responder.FAULT_UNKNOWN], type=str, help="Specify a specific fault to test")
+    parser.add_argument('--fault', choices=[mock_ocsp_responder.FAULT_REVOKED, mock_ocsp_responder.FAULT_UNKNOWN, None], default=None, type=str, help="Specify a specific fault to test")
 
+    parser.add_argument('--next_update_seconds', type=int, default=32400, help="Specify how long the OCSP response should be valid for")
     args = parser.parse_args()
     if args.verbose:
         logging.basicConfig(level=logging.DEBUG)
 
     print('Initializing OCSP Responder')
-    app = mock_ocsp_responder.OCSPResponder(args.ca_file, args.ocsp_responder_cert, args.ocsp_responder_key, args.fault)
+    app = mock_ocsp_responder.OCSPResponder(issuer_cert=args.ca_file, responder_cert=args.ocsp_responder_cert, responder_key=args.ocsp_responder_key, fault=args.fault, next_update_seconds=args.next_update_seconds)
 
     if args.verbose:
         app.serve(args.port, debug=True)


### PR DESCRIPTION
Syncing mock OCSP responder with what's in current tip of master for the server (https://github.com/mongodb/mongo/commit/78fa0cdbbbaf95f211c12640f4101b9f8c5800e1)

These changes include the ones made in:
https://jira.mongodb.org/browse/SERVER-45671 
https://jira.mongodb.org/browse/SERVER-42938
