### PR TITLE
PYTHON-2238 Archlinux MongoDB <= 3.2 requires LC_ALL=C

### DIFF
--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -343,6 +343,18 @@ get_mongodb_download_url_for ()
       ;;
    esac
 
+   # PYTHON-2238 On Archlinux MongoDB <= 3.2 requires LC_ALL=C.
+   case "$_DISTRO" in
+      linux-arch-*)
+        case "$_VERSION" in
+           3.2) export LC_ALL=C ;;
+           3.0) export LC_ALL=C ;;
+           2.6) export LC_ALL=C ;;
+           2.4) export LC_ALL=C ;;
+        esac
+      ;;
+   esac
+
    case "$_VERSION" in
       latest) MONGODB_DOWNLOAD_URL=$MONGODB_LATEST ;;
       4.4) MONGODB_DOWNLOAD_URL=$MONGODB_44 ;;


### PR DESCRIPTION
This change allows MongoDB 2.6, 3.0, and 3.2 to start on Archlinux, see [PYTHON-2238](https://jira.mongodb.org/browse/PYTHON-2238).

Tested in python here: https://evergreen.mongodb.com/version/5ebb11f832f4174a270b681a