### PR TITLE
Fix typo in OCSP server config file 

### DIFF
--- a/.evergreen/orchestration/configs/servers/ecdsa-basic-tls-ocsp-mustStaple-disableStapling-singleEndpoint.json
+++ b/.evergreen/orchestration/configs/servers/ecdsa-basic-tls-ocsp-mustStaple-disableStapling-singleEndpoint.json
@@ -11,7 +11,7 @@
    },
    "sslParams": {
       "sslOnNormalPorts": true,
-      "sslPEMKeyFile": "ABSOLUTE_PATH_REPLACEMENT_TOKEN/.evergreen/ocsp/ecdsa/server-mustStaple-singlEndpoint.pem",
+      "sslPEMKeyFile": "ABSOLUTE_PATH_REPLACEMENT_TOKEN/.evergreen/ocsp/ecdsa/server-mustStaple-singleEndpoint.pem",
       "sslCAFile": "ABSOLUTE_PATH_REPLACEMENT_TOKEN/.evergreen/ocsp/ecdsa/ca.pem",
       "sslWeakCertificateValidation" : true,
       "sslAllowInvalidCertificates": true


### PR DESCRIPTION
`ecdsa-basic-tls-ocsp-mustStaple-disableStapling-singleEndpoint.json` has a typo on line 14 that is fixed here.