### PR TITLE
DRIVERSEVG-2 Add host check in mock OCSP responder

### DIFF
--- a/.evergreen/ocsp/mock_ocsp_responder.py
+++ b/.evergreen/ocsp/mock_ocsp_responder.py
@@ -599,6 +599,8 @@ def _handle_get(u_path):
     An OCSP GET request contains the DER-in-base64 encoded OCSP request in the
     HTTP request URL.
     """
+    if "Host" not in request.headers:
+        raise ValueError ("Required 'Host' header not present")
     der = base64.b64decode(u_path)
     ocsp_request = responder.parse_ocsp_request(der)
     return responder.build_http_response(ocsp_request)
@@ -610,5 +612,7 @@ def _handle_post():
     An OCSP POST request contains the DER encoded OCSP request in the HTTP
     request body.
     """
+    if "Host" not in request.headers:
+        raise ValueError ("Required 'Host' header not present")
     ocsp_request = responder.parse_ocsp_request(request.data)
     return responder.build_http_response(ocsp_request)


### PR DESCRIPTION
Resync the mock responder per https://jira.mongodb.org/browse/SERVER-49383.

Validated with libmongoc here: https://spruce.mongodb.com/version/5f0ca3d7306615237fb06b7b/tasks