### PR TITLE
Split mongohoused into separate build/run scripts

### DIFF
--- a/.evergreen/atlas_data_lake/README.md
+++ b/.evergreen/atlas_data_lake/README.md
@@ -2,7 +2,13 @@
 
 The files in this directory are required to build and launch a local
 `mongohoused` for testing. In the Evergreen configuration file, execute
-the following command:
+the following command in the foreground to build the server:
+
+```
+sh ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake/build-mongohouse-local.sh
+```
+
+and the following command in the background to run the server:
 
 ```
 sh ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake/run-mongohouse-local.sh

--- a/.evergreen/atlas_data_lake/build-mongohouse-local.sh
+++ b/.evergreen/atlas_data_lake/build-mongohouse-local.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+#
+# This script builds a local mongohoused for testing.
+
+set -o xtrace   # Write all commands first to stderr
+set -o errexit  # Exit the script with error if any of the commands fail
+
+ORIG_DIR="$(pwd)"
+
+# Configure git to use the git protocol
+git config --global url."git@github.com:".insteadof "https://github.com/"
+
+AP_START=$(date +%s)
+
+# Set up environment variables for Go
+GO_VERSION=1.14
+export PATH="/opt/golang/go${GO_VERSION}/bin:$PATH"
+export GOROOT="/opt/golang/go${GO_VERSION}"
+export GOPATH=`pwd`/.gopath
+go version
+
+# Clone the mongohouse repo
+DL_START=$(date +%s)
+cd "$ORIG_DIR"
+rm -rf mongohouse
+git clone git@github.com:10gen/mongohouse.git
+cd mongohouse
+GO111MODULE=on go mod download
+DL_END=$(date +%s)
+
+# Build mqlrun
+./build.sh tools:download:mqlrun
+export MONGOHOUSE_MQLRUN=`pwd`/artifacts/mqlrun
+
+# Build mongohouse
+./build.sh build:mongohoused
+
+sleep 5
+
+AP_END=$(date +%s)
+
+# Write results file
+DL_ELAPSED=$(expr $DL_END - $DL_START)
+AP_ELAPSED=$(expr $AP_END - $AP_START)
+cat <<EOT >> $DRIVERS_TOOLS/results.json
+{"results": [
+  {
+    "status": "PASS",
+    "test_file": "Mongohouse local Start",
+    "start": $AP_START,
+    "end": $AP_END,
+    "elapsed": $AP_ELAPSED
+  },
+  {
+    "status": "PASS",
+    "test_file": "Download Mongohouse",
+    "start": $DL_START,
+    "end": $DL_END,
+    "elapsed": $DL_ELAPSED
+  }
+]}
+
+EOT

--- a/.evergreen/atlas_data_lake/config.yml
+++ b/.evergreen/atlas_data_lake/config.yml
@@ -1,4 +1,4 @@
-environment: development
+environment: local
 
 hosting:
   frontend:

--- a/.evergreen/atlas_data_lake/run-mongohouse-local.sh
+++ b/.evergreen/atlas_data_lake/run-mongohouse-local.sh
@@ -1,69 +1,10 @@
 #!/bin/sh
 #
-# This script builds and launches a local mongohoused for testing.
+# This script launches a pre-built local mongohoused for testing.
 #
 # There is no corresponding 'shutdown' script; this project relies
 # on Evergreen to terminate processes and clean up when tasks end.
 
-set -o xtrace   # Write all commands first to stderr
-set -o errexit  # Exit the script with error if any of the commands fail
-
-ORIG_DIR="$(pwd)"
-
-# Configure git to use the git protocol
-git config --global url."git@github.com:".insteadof "https://github.com/"
-
-AP_START=$(date +%s)
-
-# Set up environment variables for Go
-GO_VERSION=1.14
-export PATH="/opt/golang/go${GO_VERSION}/bin:$PATH"
-export GOROOT="/opt/golang/go${GO_VERSION}"
-export GOPATH=`pwd`/.gopath
-go version
-
-# Clone the mongohouse repo
-DL_START=$(date +%s)
-cd "$ORIG_DIR"
-rm -rf mongohouse
-git clone git@github.com:10gen/mongohouse.git
 cd mongohouse
-GO111MODULE=on go mod download
-DL_END=$(date +%s)
-
-# Build mqlrun
-./build.sh tools:download:mqlrun
 export MONGOHOUSE_MQLRUN=`pwd`/artifacts/mqlrun
-
-# Build mongohouse
-./build.sh build:mongohoused
-
-# Run mongohouse local
 ./artifacts/mongohoused --config ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake/config.yml
-
-sleep 5
-
-AP_END=$(date +%s)
-
-# Write results file
-DL_ELAPSED=$(expr $DL_END - $DL_START)
-AP_ELAPSED=$(expr $AP_END - $AP_START)
-cat <<EOT >> $DRIVERS_TOOLS/results.json
-{"results": [
-  {
-    "status": "PASS",
-    "test_file": "Mongohouse local Start",
-    "start": $AP_START,
-    "end": $AP_END,
-    "elapsed": $AP_ELAPSED
-  },
-  {
-    "status": "PASS",
-    "test_file": "Download Mongohouse",
-    "start": $DL_START,
-    "end": $DL_END,
-    "elapsed": $DL_ELAPSED
-  }
-]}
-
-EOT


### PR DESCRIPTION
The Java Driver commit for ADL testing runs the `bootstrap-mongohoused` Evergreen task in the background (https://github.com/mongodb/mongo-java-driver/commit/7f6e0c3be351e9d586ca4a6271f79af654b03deb#diff-fdcefd1312a87e7c09196afa0f0633a3R227) because otherwise the server would run in the foreground and block progress for the rest of the tasks. When adding this to the Go Driver, I found that the build was taking too long and the Go tests started running before the build was complete, so they failed because there was no server running.

This PR splits the existing `run-mongohouse-local.sh` into separate `build-mongohouse-local.sh` and `run-mongohouse-local.sh` scripts. These first would be called in the foreground and the second would be in the background. The actual server startup is very quick so the drivers tests should discover the server within server selection timeout even if they start running before the server has started. See https://github.com/divjotarora/mongo-go-driver/commit/39969242bbb9d5c1c788884025a231c77bb4e5dd#diff-c291812f12d2ddfd4045a0c39bf9d130R165 for an example invocation of these scripts in the Go Driver.