### PR TITLE
MHOUSE-1776: Remove hosting key from ADL config

### DIFF
--- a/.evergreen/atlas_data_lake/config.yml
+++ b/.evergreen/atlas_data_lake/config.yml
@@ -1,12 +1,12 @@
 environment: local
 
-hosting:
-  frontend:
-    bindAddrs: ["localhost:27017"]
-    cursor:
-      metadata:
-        memory: true
-  showInternalErrors: true
+showInternalErrors: true
+
+frontend:
+  bindAddrs: ["localhost:27017"]
+  cursor:
+    metadata:
+      memory: true
 
 execution:
   mqlrunPath: ${MONGOHOUSE_MQLRUN}


### PR DESCRIPTION
The [MHOUSE-1776 ticket](https://github.com/10gen/mongohouse/commit/99409587bc01707952e68d9b9935be0770b81cad) involved some refactors in `mongohouse`'s config files. Specifically, the `hosting` key has been removed entirely, so `frontend` and `showInternalErrors` are now top-level keys in config files. The updated docs for the new configuration can be found [here](https://github.com/10gen/mongohouse/blob/master/docs/config.md).
To ensure that the `config.yml` file here is compatible with the new ADL config structure, the hosting key has been removed and all of the keys formerly within it are now stored at the top-level. 