### PR TITLE
PYTHON-2298 Reset macOS file descriptor ulimit to 64000 to fix mongod errors

### DIFF
--- a/.evergreen/start-orchestration.sh
+++ b/.evergreen/start-orchestration.sh
@@ -67,8 +67,6 @@ fi
 # TooManyFilesOpen: 24: Too many open files
 if [ "$(uname -s)" = "Darwin" ]; then
   ulimit -a
-  ulimit -n 262144
-  ulimit -a
 fi
 
 

--- a/.evergreen/start-orchestration.sh
+++ b/.evergreen/start-orchestration.sh
@@ -63,6 +63,14 @@ else
   fi
 fi
 
+# Increase file descriptor ulimit to avoid errors like:
+# TooManyFilesOpen: 24: Too many open files
+if [ "$(uname -s)" = "Darwin" ]; then
+  ulimit -a
+  ulimit -n 24000
+fi
+
+
 mongo-orchestration $ORCHESTRATION_ARGUMENTS start > $MONGO_ORCHESTRATION_HOME/out.log 2>&1 < /dev/null &
 
 ls -la $MONGO_ORCHESTRATION_HOME

--- a/.evergreen/start-orchestration.sh
+++ b/.evergreen/start-orchestration.sh
@@ -63,10 +63,12 @@ else
   fi
 fi
 
-# Increase file descriptor ulimit to avoid errors like:
+# PYTHON-2298 Reset the file descriptor ulimit to 64000 to avoid errors like:
 # TooManyFilesOpen: 24: Too many open files
+# Some evergreen task is descreasing the limit to 256.
 if [ "$(uname -s)" = "Darwin" ]; then
   ulimit -a
+  ulimit -n 64000
 fi
 
 

--- a/.evergreen/start-orchestration.sh
+++ b/.evergreen/start-orchestration.sh
@@ -67,7 +67,8 @@ fi
 # TooManyFilesOpen: 24: Too many open files
 if [ "$(uname -s)" = "Darwin" ]; then
   ulimit -a
-  ulimit -n 24000
+  ulimit -n 262144
+  ulimit -a
 fi
 
 


### PR DESCRIPTION
Somewhat frequently we run on a macOS host that has a ulimit -n set to 256 which causes mongod to crash with `Too many open files `. This change resets the limit to the usual 6400.

Here's an example patch that shows the error behavior. Note: when mongod crashes the python test suite times out after 30min so we're only interested in failures due to timeouts (we ignore the other task failures): https://evergreen.mongodb.com/version/5f8a1c1cd6d80a7b025c03cb

An here's a patch that tests the new behavior:
https://evergreen.mongodb.com/version/5f8f4c740ae60616c87a1646