### PR TITLE
Support requireApiVersion parameter for standalone servers

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -314,7 +314,7 @@ functions:
       params:
         script: |
           ${PREPARE_SHELL}
-          MONGODB_VERSION=${VERSION} TOPOLOGY=${TOPOLOGY} AUTH=${AUTH} SSL=${SSL} STORAGE_ENGINE=${STORAGE_ENGINE} sh ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
+          MONGODB_VERSION=${VERSION} TOPOLOGY=${TOPOLOGY} AUTH=${AUTH} SSL=${SSL} STORAGE_ENGINE=${STORAGE_ENGINE} REQUIRE_API_VERSION=${REQUIRE_API_VERSION} sh ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
     # run-orchestration generates expansion file with the MONGODB_URI for the cluster
     - command: expansions.update
       params:

--- a/.evergreen/orchestration/require-api-version.js
+++ b/.evergreen/orchestration/require-api-version.js
@@ -1,0 +1,1 @@
+db.adminCommand({ "setParameter": 1, "requireApiVersion": 1 });

--- a/.evergreen/run-orchestration.sh
+++ b/.evergreen/run-orchestration.sh
@@ -7,6 +7,9 @@ AUTH=${AUTH:-noauth}
 SSL=${SSL:-nossl}
 TOPOLOGY=${TOPOLOGY:-server}
 STORAGE_ENGINE=${STORAGE_ENGINE}
+# Set to a non-empty string to set the requireApiVersion parameter
+# This is currently only supported for standalone servers
+REQUIRE_API_VERSION=${REQUIRE_API_VERSION}
 # Set to a non-empty string to use the <topology>/disableTestCommands.json
 # cluster config, eg DISABLE_TEST_COMMANDS=1
 DISABLE_TEST_COMMANDS=${DISABLE_TEST_COMMANDS}
@@ -95,3 +98,8 @@ cat <<EOT >> $DRIVERS_TOOLS/results.json
 ]}
 
 EOT
+
+# Set the requireApiVersion parameter
+if [ ! -z "$REQUIRE_API_VERSION" ]; then
+  mongo $URI $MONGO_ORCHESTRATION_HOME/require-api-version.js
+fi


### PR DESCRIPTION
This introduces a new `REQUIRE_API_VERSION` variable into the setup process for mongo-orchestration. For now, the run-orchestration.sh script will connect to the started cluster and run a `setParameter` command to enable `requireApiVersion` if the variable is set to a non-zero value.

Once PyMongo and mongo-orchestration are able to deal with the versioned API we can remove the workaround and start clusters from config files that include the requireApiVersion parameter.