### PR TITLE
Add a mongo-orchestration config for versioned API tests

### DIFF
--- a/.evergreen/orchestration/configs/servers/versioned-api-testing.json
+++ b/.evergreen/orchestration/configs/servers/versioned-api-testing.json
@@ -1,0 +1,12 @@
+{
+  "id": "versioned-api-testing",
+  "name": "mongod",
+  "procParams": {
+    "ipv6": true,
+    "bind_ip": "127.0.0.1,::1",
+    "logappend": true,
+    "journal": true,
+    "port": 27017,
+    "setParameter": {"enableTestCommands": 1, "acceptAPIVersion2":  1}
+  }
+}


### PR DESCRIPTION
The new mongo-orchestration config starts a standalone server that enables the `acceptAPIVersion2` parameter. This is required to run the versioned API spec tests that test deprecated commands.

This config is only compatible with server versions 4.9 and newer and will fail to start on older server versions. Drivers can use this config in place of the `basic` config when testing against `latest`, but may also choose to create a separate build config that only tests versioned API tests against this config specifically.

// cc @benjirewis since I can't add you as a reviewer.