### PR TITLE
MHOUSE-1860: reflect bindAddrs array to bindAddr string in mongohouse

### DIFF
--- a/.evergreen/atlas_data_lake/config.yml
+++ b/.evergreen/atlas_data_lake/config.yml
@@ -3,7 +3,7 @@ environment: local
 showInternalErrors: true
 
 frontend:
-  bindAddrs: ["localhost:27017"]
+  bindAddr: "localhost:27017"
   cursor:
     metadata:
       memory: true


### PR DESCRIPTION
MHOUSE-1860 (merged today: https://github.com/10gen/mongohouse/pull/1839) changed the bindAddrs array to a simple string.  atlas_data_lake/config.yml needs to reflect that change to allow continued successful testing  :)