### PR TITLE
Add GitHub Action metadata file to set up MongoDB

### DIFF
--- a/.evergreen/run-orchestration.sh
+++ b/.evergreen/run-orchestration.sh
@@ -74,6 +74,7 @@ fi
 cat tmp.json
 URI=$(python -c 'import sys, json; j=json.load(open("tmp.json")); print(j["mongodb_auth_uri" if "mongodb_auth_uri" in j else "mongodb_uri"])' | tr -d '\r')
 echo 'MONGODB_URI: "'$URI'"' > mo-expansion.yml
+echo $URI > $DRIVERS_TOOLS/uri.txt
 echo "Cluster URI: $URI"
 
 MO_END=$(date +%s)

--- a/.evergreen/start-orchestration.sh
+++ b/.evergreen/start-orchestration.sh
@@ -38,11 +38,17 @@ elif $PYTHON -m virtualenv --system-site-packages --never-download venv || virtu
   elif [ -f venv/Scripts/activate ]; then
     . venv/Scripts/activate
   fi
-  # Install from github to get the latest mongo-orchestration.
-  pip install --upgrade 'git+git://github.com/mongodb/mongo-orchestration@master'
-  pip list
 fi
+
+# Install from github to get the latest mongo-orchestration.
+pip install --upgrade 'git+git://github.com/mongodb/mongo-orchestration@master'
+pip list
 cd -
+
+# Create default config file if it doesn't exist
+if [ ! -f $MONGO_ORCHESTRATION_HOME/orchestration.config ]; then
+  echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" > $MONGO_ORCHESTRATION_HOME/orchestration.config
+fi
 
 ORCHESTRATION_ARGUMENTS="-e default -f $MONGO_ORCHESTRATION_HOME/orchestration.config --socket-timeout-ms=60000 --bind=127.0.0.1 --enable-majority-read-concern"
 if [ "Windows_NT" = "$OS" ]; then # Magic variable in cygwin

--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@
 
 This repo is meant for MongoDB drivers to bootstrap their Evergreen
 configuration files.
-It contains set of scripts for tasks that most drivers will need to perfrom,
+It contains set of scripts for tasks that most drivers will need to perform,
 such as downloading MongoDB for the current platform, and launching various
 topologies.
 
 # Using
+
+## In Evergreen
 
 The bundled [`.evergreen/config.yml`](.evergreen/config.yml) file contains a
 suggested template for drivers to use.
@@ -37,7 +39,48 @@ The `** Release Archive Creator` buildvariant is special, and does not run the "
 See also:
 https://evergreen.mongodb.com/waterfall/drivers-tools
 
-# evergreen_config_generator
+## evergreen_config_generator
 
 This repo also contains a Python package for use in scripts that generate
 Evergreen config files from Python dicts. See evergreen_config_generator/README.
+
+# Using With GitHub Actions
+
+This repository includes a metadata file for GitHub Actions to allow downloading
+MongoDB and launching topologies from a GitHub Action Workflow. To use this
+action, use the following template:
+
+```yaml
+    steps:
+      # [...]
+      - id: setup-mongodb
+        uses: mongodb-labs/drivers-evergreen-tools@master
+        # Set configuration
+        with:
+          version: ${{ matrix.mongodb-version }}
+```
+
+The following inputs exist:
+
+| Name | Description |
+| --- | --- |
+| `version` | MongoDB version to install |
+| `topology` | Topology of the deployment (server, replica_set, sharded_cluster) |
+| `auth` | Whether to enable auth |
+| `ssl` | Whether to enable SSL |
+| `storage-engine` | Storage engine to use |
+| `require-api-version` | Whether to start the server with requireApiVersion enabled (defaults to false) |
+
+These correspond to the respective environment variables that are passed to `run-orchestration.sh`.
+
+After the cluster is started, its URI is exposed via the `cluster-uri` output.
+This configuration snippet sets an environment variable with the cluster URI
+returned from the `setup-mongodb` workflow step when running tests:
+```yaml
+    steps:
+      # [...]
+      - name: "Run Tests"
+        run: "run-tests.sh"
+        env:
+          MONGODB_URI: ${{ steps.setup-mongodb.outputs.cluster-uri }}
+```

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,54 @@
+name: "Set up MongoDB Cluster"
+description: "Downloads MongoDB and runs a cluster using mongo-orchestration"
+inputs:
+  version:
+    description: "MongoDB version to install"
+    required: false
+  topology:
+    description: "Topology of the deployment"
+    required: false
+  auth:
+    description: "Whether to enable auth"
+    required: false
+  ssl:
+    description: "Whether to enable SSL"
+    required: false
+  storage-engine:
+    description: "Storage engine to use"
+    required: false
+  require-api-version:
+    description: "Whether to start the server with requireApiVersion enabled (defaults to false)"
+    required: false
+outputs:
+  cluster-uri:
+    description: "URI of the cluster"
+    value: ${{ steps.get-cluster-uri.outputs.cluster-uri }}
+runs:
+  using: "composite"
+  steps:
+    - id: "add-pip-path"
+      name: "Add PIP install folder to path"
+      run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+      shell: bash
+    - id: "add-mongodb-binary-path"
+      name: "Add PIP install folder to path"
+      run: echo "${{ github.action_path }}/mongodb/bin" >> $GITHUB_PATH
+      shell: bash
+    - id: "run-orchestration"
+      name: "Download MongoDB"
+      run: ${{ github.action_path }}/.evergreen/run-orchestration.sh
+      env:
+        DRIVERS_TOOLS: ${{ github.action_path }}
+        MONGODB_BINARIES: ${{ github.action_path }}/mongodb/bin
+        MONGO_ORCHESTRATION_HOME: ${{ github.action_path }}/.evergreen/orchestration
+        MONGODB_VERSION: ${{ inputs.version }}
+        TOPOLOGY: ${{ inputs.topology }}
+        AUTH: ${{ inputs.auth }}
+        SSL: ${{ inputs.ssl }}
+        STORAGE_ENGINE: ${{ inputs.storage-engine }}
+        REQUIRE_API_VERSION: ${{ inputs.require-api-version }}
+      shell: sh
+    - id: "get-cluster-uri"
+      name: "Expose Cluster URI"
+      run: echo "::set-output name=cluster-uri::$(cat ${{ github.action_path }}/uri.txt)"
+      shell: bash


### PR DESCRIPTION
To help with transitioning away from travis-ci, this PR adds support for installing and launching MongoDB in a GitHub Action workflow.

Usage is documented in the readme. Most settings available to `run-orchestration.sh` are exposed as inputs to the GitHub Action. The URI of the launched cluster is exposed as an output and can be used in a subsequent build step:
```yaml
     - id: setup-mongodb
        uses: mongodb-labs/drivers-evergreen-tools@master
        with:
          version: ${{ matrix.mongodb-version }}

      - name: "Run tests"
        run: "run-tests.sh"
        env:
          MONGODB_URI: ${{ steps.setup-mongodb.outputs.cluster-uri }}
```

As `virtualenv` is not available on GitHub Actions, mongo-orchestration was not installed. I believe that installing it conditionally was not intended. Please let me know if you anticipate that change breaking some functionality.

Link to a build that uses my dev version of this change: https://github.com/alcaeus/mongo-php-library/runs/1694994040