### PR TITLE
Use three-member replica sets for shards

### DIFF
--- a/.evergreen/orchestration/configs/sharded_clusters/auth-ssl.json
+++ b/.evergreen/orchestration/configs/sharded_clusters/auth-ssl.json
@@ -7,14 +7,32 @@
     {
       "id": "sh01",
       "shardParams": {
-        "members": [{
-          "procParams": {
-            "ipv6": true,
-            "bind_ip": "127.0.0.1,::1",
-            "shardsvr": true,
-            "port": 27217
+        "members": [
+          {
+            "procParams": {
+              "ipv6": true,
+              "bind_ip": "127.0.0.1,::1",
+              "shardsvr": true,
+              "port": 27217
+            }
+          },
+          {
+            "procParams": {
+              "ipv6": true,
+              "bind_ip": "127.0.0.1,::1",
+              "shardsvr": true,
+              "port": 27218
+            }
+          },
+          {
+            "procParams": {
+              "ipv6": true,
+              "bind_ip": "127.0.0.1,::1",
+              "shardsvr": true,
+              "port": 27219
+            }
           }
-        }]
+        ]
       }
     }
   ],

--- a/.evergreen/orchestration/configs/sharded_clusters/auth.json
+++ b/.evergreen/orchestration/configs/sharded_clusters/auth.json
@@ -7,14 +7,32 @@
     {
       "id": "sh01",
       "shardParams": {
-        "members": [{
-          "procParams": {
-            "ipv6": true,
-            "bind_ip": "127.0.0.1,::1",
-            "shardsvr": true,
-            "port": 27217
+        "members": [
+          {
+            "procParams": {
+              "ipv6": true,
+              "bind_ip": "127.0.0.1,::1",
+              "shardsvr": true,
+              "port": 27217
+            }
+          },
+          {
+            "procParams": {
+              "ipv6": true,
+              "bind_ip": "127.0.0.1,::1",
+              "shardsvr": true,
+              "port": 27218
+            }
+          },
+          {
+            "procParams": {
+              "ipv6": true,
+              "bind_ip": "127.0.0.1,::1",
+              "shardsvr": true,
+              "port": 27219
+            }
           }
-        }]
+        ]
       }
     }
   ],

--- a/.evergreen/orchestration/configs/sharded_clusters/basic-ssl.json
+++ b/.evergreen/orchestration/configs/sharded_clusters/basic-ssl.json
@@ -4,14 +4,32 @@
     {
       "id": "sh01",
       "shardParams": {
-        "members": [{
-          "procParams": {
-            "ipv6": true,
-            "bind_ip": "127.0.0.1,::1",
-            "shardsvr": true,
-            "port": 27217
+        "members": [
+          {
+            "procParams": {
+              "ipv6": true,
+              "bind_ip": "127.0.0.1,::1",
+              "shardsvr": true,
+              "port": 27217
+            }
+          },
+          {
+            "procParams": {
+              "ipv6": true,
+              "bind_ip": "127.0.0.1,::1",
+              "shardsvr": true,
+              "port": 27218
+            }
+          },
+          {
+            "procParams": {
+              "ipv6": true,
+              "bind_ip": "127.0.0.1,::1",
+              "shardsvr": true,
+              "port": 27219
+            }
           }
-        }]
+        ]
       }
     }
   ],

--- a/.evergreen/orchestration/configs/sharded_clusters/basic.json
+++ b/.evergreen/orchestration/configs/sharded_clusters/basic.json
@@ -4,14 +4,32 @@
     {
       "id": "sh01",
       "shardParams": {
-        "members": [{
-          "procParams": {
-            "ipv6": true,
-            "bind_ip": "127.0.0.1,::1",
-            "shardsvr": true,
-            "port": 27217
+        "members": [
+          {
+            "procParams": {
+              "ipv6": true,
+              "bind_ip": "127.0.0.1,::1",
+              "shardsvr": true,
+              "port": 27217
+            }
+          },
+          {
+            "procParams": {
+              "ipv6": true,
+              "bind_ip": "127.0.0.1,::1",
+              "shardsvr": true,
+              "port": 27218
+            }
+          },
+          {
+            "procParams": {
+              "ipv6": true,
+              "bind_ip": "127.0.0.1,::1",
+              "shardsvr": true,
+              "port": 27219
+            }
           }
-        }]
+        ]
       }
     }
   ],

--- a/.evergreen/orchestration/configs/sharded_clusters/disableTestCommands.json
+++ b/.evergreen/orchestration/configs/sharded_clusters/disableTestCommands.json
@@ -4,15 +4,35 @@
     {
       "id": "sh01",
       "shardParams": {
-        "members": [{
-          "procParams": {
-            "ipv6": true,
-            "bind_ip": "127.0.0.1,::1",
-            "shardsvr": true,
-            "port": 27217,
-            "setParameter" : { "enableTestCommands": 0 }
+        "members": [
+          {
+            "procParams": {
+              "ipv6": true,
+              "bind_ip": "127.0.0.1,::1",
+              "shardsvr": true,
+              "port": 27217,
+              "setParameter" : { "enableTestCommands": 0 }
+            }
+          },
+          {
+            "procParams": {
+              "ipv6": true,
+              "bind_ip": "127.0.0.1,::1",
+              "shardsvr": true,
+              "port": 27218,
+              "setParameter" : { "enableTestCommands": 0 }
+            }
+          },
+          {
+            "procParams": {
+              "ipv6": true,
+              "bind_ip": "127.0.0.1,::1",
+              "shardsvr": true,
+              "port": 27219,
+              "setParameter" : { "enableTestCommands": 0 }
+            }
           }
-        }]
+        ]
       }
     }
   ],

--- a/.evergreen/orchestration/configs/sharded_clusters/mmapv1.json
+++ b/.evergreen/orchestration/configs/sharded_clusters/mmapv1.json
@@ -4,15 +4,35 @@
     {
       "id": "sh01",
       "shardParams": {
-        "members": [{
-          "procParams": {
-            "ipv6": true,
-            "bind_ip": "127.0.0.1,::1",
-            "shardsvr": true,
-            "storageEngine": "mmapv1",
-            "port": 27217
+        "members": [
+          {
+            "procParams": {
+              "ipv6": true,
+              "bind_ip": "127.0.0.1,::1",
+              "shardsvr": true,
+              "storageEngine": "mmapv1",
+              "port": 27217
+            }
+          },
+          {
+            "procParams": {
+              "ipv6": true,
+              "bind_ip": "127.0.0.1,::1",
+              "shardsvr": true,
+              "storageEngine": "mmapv1",
+              "port": 27218
+            }
+          },
+          {
+            "procParams": {
+              "ipv6": true,
+              "bind_ip": "127.0.0.1,::1",
+              "shardsvr": true,
+              "storageEngine": "mmapv1",
+              "port": 27219
+            }
           }
-        }]
+        ]
       }
     }
   ],


### PR DESCRIPTION
After #25, this is the second attempt to introduce three-member replica sets for shards. Note that I've made this a PSS replica set, while the original change used a PSA replica set. Let me know if I should change this.