### PR TITLE
Setup GitHub action testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,43 @@
+name: "Tests"
+
+on:
+  pull_request:
+    branches:
+      - "master"
+  push:
+    branches:
+      - "master"
+
+jobs:
+  tests:
+    name: "Tests"
+    runs-on: "ubuntu-20.04"
+
+    strategy:
+      matrix:
+        mongodb-version:
+          - "4.4"
+        topology:
+          - "server"
+          - "replica_set"
+          - "sharded_cluster"
+        auth:
+          - "noauth"
+          - "auth"
+        ssl:
+          - "nossl"
+          - "ssl"
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v2"
+        with:
+          fetch-depth: 2
+
+      - id: setup-mongodb
+        uses: ./
+        with:
+          version: ${{ matrix.mongodb-version }}
+          topology: ${{ matrix.topology }}
+          auth: ${{ matrix.auth }}
+          ssl: ${{ matrix.ssl }}


### PR DESCRIPTION
I noticed this while verifying changes from #134, we should probably test the GitHub Action portion of the file as well. This sets up a single build that tests the three topologies with auth and ssl. I've cherry-picked a commit from #134 to this PR as well to ensure that we replace absolute path in mo configs when running as GitHub action.