### PR TITLE
DRIVERS-1462 Test Failure - MONGODB-AWS Auth Ubuntu 18.04

### DIFF
--- a/.evergreen/auth_aws/lib/container_tester.py
+++ b/.evergreen/auth_aws/lib/container_tester.py
@@ -190,7 +190,7 @@ def remote_stop_container(cluster, service_name):
     """
     ecs_client = boto3.client('ecs', region_name=_get_region(cluster))
 
-    resp = ecs_client.delete_service(cluster=cluster, service=service_name, force=True)
+    resp = ecs_client.delete_service(cluster=cluster, service=service_name)
     pprint.pprint(resp)
 
     service_arn = resp["service"]["serviceArn"]


### PR DESCRIPTION
@emadum Could you verify this fixes the issue? I'm not able to reproduce this locally. You should just have to point your `$DRIVERS_TOOLS` environment variable ([here](https://github.com/mongodb/node-mongodb-native/blob/3.6/.evergreen/config.yml#L70)) to my fork of this repo with the fix applied -> https://github.com/bazile-clyde/drivers-evergreen-tools/tree/DRIVERS-1462. Then re-run the failing tests. 