### PR TITLE
DRIVERS-1462: Add script for using venv for AWS auth

### DIFF
--- a/.evergreen/auth_aws/activate_venv.sh
+++ b/.evergreen/auth_aws/activate_venv.sh
@@ -1,7 +1,7 @@
 set +x
 
 if [ "Windows_NT" = "$OS" ]; then
-  PYTHON_BINARY=python.exe
+  PYTHON_BINARY=C:/python/Python38/python.exe
 else
   PYTHON_BINARY=python3
 fi

--- a/.evergreen/auth_aws/activate_venv.sh
+++ b/.evergreen/auth_aws/activate_venv.sh
@@ -1,0 +1,25 @@
+set +x
+
+if [ "Windows_NT" = "$OS" ]; then
+  PYTHON_BINARY=python.exe
+else
+  PYTHON_BINARY=python3
+fi
+
+# create venv on first run
+if [ ! -d authawsvenv ]; then
+   FIRST_RUN=1
+   virtualenv -p ${PYTHON_BINARY} authawsvenv
+fi
+
+# always activate venv
+if [ "Windows_NT" = "$OS" ]; then
+  . authawsvenv/Scripts/activate
+else
+  . authawsvenv/bin/activate
+fi
+
+# install dependencies on first run
+if [ -z $FIRST_RUN ]; then
+  pip install --upgrade boto3
+fi


### PR DESCRIPTION
Adds a utility script that can be used to reduce boilerplate around using virtualenv for the AWS auth tests.