### PR TITLE
PYTHON-2537 Fix mongodb download links for Centos 6

### DIFF
--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -10,6 +10,9 @@ get_distro ()
    if [ -f /etc/os-release ]; then
       . /etc/os-release
       DISTRO="${ID}-${VERSION_ID}"
+   elif [ -f /etc/centos-release ]; then
+      version=$(cat /etc/centos-release | tr -dc '0-9.' | cut -d '.' -f1)
+      DISTRO="centos-${version}"
    elif command -v lsb_release >/dev/null 2>&1; then
       name=$(lsb_release -s -i)
       if [ "$name" = "RedHatEnterpriseServer" ]; then # RHEL 6.2 at least
@@ -123,7 +126,7 @@ get_mongodb_download_url_for ()
              MONGODB_36="http://downloads.10gen.com/linux/mongodb-linux-s390x-enterprise-rhel67-${VERSION_36}.tgz"
              MONGODB_34="http://downloads.10gen.com/linux/mongodb-linux-s390x-enterprise-rhel67-${VERSION_34}.tgz"
       ;;
-      linux-rhel-6.2*)
+      linux-rhel-6.2*|linux-centos-6*)
          MONGODB_LATEST="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-rhel62-latest.tgz"
              MONGODB_44="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-rhel62-${VERSION_44}.tgz"
              MONGODB_42="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-rhel62-${VERSION_42}.tgz"


### PR DESCRIPTION
This change fixes the download links for Centos 6 which we use for performance testing. Centos 6 is compatible with the RHEL 6.2 releases. Tested here: https://spruce.mongodb.com/version/601aeb54d1fe0705740e9e26

The old behavior was that Centos 6 used the "generic" linux releases which only support up to MongoDB 4.0. Now all versions are supported (including TLS support). 