### PR TITLE
DRIVERS-1596 Remove usages of xtrace in shell scripts

### DIFF
--- a/.evergreen/atlas_data_lake/build-mongohouse-local.sh
+++ b/.evergreen/atlas_data_lake/build-mongohouse-local.sh
@@ -2,7 +2,6 @@
 #
 # This script builds a local mongohoused for testing.
 
-set -o xtrace   # Write all commands first to stderr
 set -o errexit  # Exit the script with error if any of the commands fail
 
 ORIG_DIR="$(pwd)"

--- a/.evergreen/compile-unix.sh
+++ b/.evergreen/compile-unix.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-set -o xtrace   # Write all commands first to stderr
 set -o errexit  # Exit the script with error if any of the commands fail
 
 # Supported/used environment variables:

--- a/.evergreen/compile-windows.sh
+++ b/.evergreen/compile-windows.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 set -o igncr    # Ignore CR in this script
-set -o xtrace   # Write all commands first to stderr
 set -o errexit  # Exit the script with error if any of the commands fail
 
 # Supported/used environment variables:

--- a/.evergreen/compile.sh
+++ b/.evergreen/compile.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-set -o xtrace   # Write all commands first to stderr
 set -o errexit  # Exit the script with error if any of the commands fail
 
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -69,7 +69,7 @@ functions:
            PROJECT_DIRECTORY: "$PROJECT_DIRECTORY"
            PREPARE_SHELL: |
               set -o errexit
-              set -o xtrace
+              set +o xtrace
               export DRIVERS_TOOLS="$DRIVERS_TOOLS"
               export MONGO_ORCHESTRATION_HOME="$MONGO_ORCHESTRATION_HOME"
               export PROJECT_ORCHESTRATION_HOME="$PROJECT_ORCHESTRATION_HOME"
@@ -141,7 +141,7 @@ functions:
     - command: shell.exec
       params:
         continue_on_err: true
-        script: "set -o xtrace && rm -rf ${PROJECT_DIRECTORY}"
+        script: "rm -rf ${PROJECT_DIRECTORY}"
     - command: s3.get
       params:
         aws_key: ${aws_key}
@@ -153,7 +153,7 @@ functions:
       params:
         continue_on_err: true
         # EVG-1105: Use s3.get extract_to: ./
-        script: "set -o xtrace && cd .. && rm -rf ${PROJECT_DIRECTORY} && mkdir ${PROJECT_DIRECTORY}/ && tar xf build.tar.gz -C ${PROJECT_DIRECTORY}/"
+        script: "cd .. && rm -rf ${PROJECT_DIRECTORY} && mkdir ${PROJECT_DIRECTORY}/ && tar xf build.tar.gz -C ${PROJECT_DIRECTORY}/"
 
   "exec compile script" :
     - command: shell.exec
@@ -421,7 +421,6 @@ tasks:
           type: test
           params:
             script: |
-               set -o xtrace
                . ${DRIVERS_TOOLS}/.evergreen/download-mongodb.sh || true
                get_distro || true
                echo $DISTRO

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -69,7 +69,6 @@ functions:
            PROJECT_DIRECTORY: "$PROJECT_DIRECTORY"
            PREPARE_SHELL: |
               set -o errexit
-              set +o xtrace
               export DRIVERS_TOOLS="$DRIVERS_TOOLS"
               export MONGO_ORCHESTRATION_HOME="$MONGO_ORCHESTRATION_HOME"
               export PROJECT_ORCHESTRATION_HOME="$PROJECT_ORCHESTRATION_HOME"

--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -2,7 +2,6 @@
 
 #For future use the feed to get full list of distros : http://downloads.mongodb.org/full.json
 
-set -o xtrace   # Write all commands first to stderr
 set -o errexit  # Exit the script with error if any of the commands fail
 
 get_distro ()

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-set -o xtrace   # Write all commands first to stderr
 set -o errexit  # Exit the script with error if any of the commands fail
 
 DIR=$(dirname $0)

--- a/.evergreen/make-docs.sh
+++ b/.evergreen/make-docs.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-set -o xtrace   # Write all commands first to stderr
 set -o errexit  # Exit the script with error if any of the commands fail
 
 

--- a/.evergreen/make-release.sh
+++ b/.evergreen/make-release.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-set -o xtrace   # Write all commands first to stderr
 set -o errexit  # Exit the script with error if any of the commands fail
 
 

--- a/.evergreen/run-atlas-proxy.sh
+++ b/.evergreen/run-atlas-proxy.sh
@@ -28,7 +28,6 @@
 # MONGODB_VERSION - version of MongoDB to download and use. For Atlas
 # Proxy, must be "3.4" or "latest".  Defaults to "3.4".
 
-set -o xtrace   # Write all commands first to stderr
 set -o errexit  # Exit the script with error if any of the commands fail
 
 MONGODB_VERSION=${MONGODB_VERSION:-"3.4"}

--- a/.evergreen/run-orchestration.sh
+++ b/.evergreen/run-orchestration.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-set -o xtrace   # Write all commands first to stderr
 set -o errexit  # Exit the script with error if any of the commands fail
 
 

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-set -o xtrace   # Write all commands first to stderr
 set -o errexit  # Exit the script with error if any of the commands fail
 
 # Supported/used environment variables:

--- a/.evergreen/start-orchestration.sh
+++ b/.evergreen/start-orchestration.sh
@@ -6,7 +6,6 @@ if [ "$#" -ne 1 ]; then
   exit 1
 fi
 
-set -o xtrace   # Write all commands first to stderr
 set -o errexit  # Exit the script with error if any of the commands fail
 
 

--- a/.evergreen/stop-orchestration.sh
+++ b/.evergreen/stop-orchestration.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-set -o xtrace   # Write all commands first to stderr
 set -o errexit  # Exit the script with error if any of the commands fail
 
 cd "$MONGO_ORCHESTRATION_HOME"

--- a/evergreen_config_generator/evergreen_config_generator/__init__.py
+++ b/evergreen_config_generator/evergreen_config_generator/__init__.py
@@ -46,7 +46,6 @@ class ConfigObject(object):
 #         params:
 #           script: |-
 #             set -o errexit
-#             set -o xtrace
 #             ...
 #
 # Write values compactly except multiline strings, which use "|" style. Write

--- a/evergreen_config_generator/evergreen_config_generator/functions.py
+++ b/evergreen_config_generator/evergreen_config_generator/functions.py
@@ -66,7 +66,7 @@ def strip_lines(s):
     return '\n'.join(line for line in s.split('\n') if line.strip())
 
 
-def shell_exec(script, test=True, errexit=True, xtrace=True, silent=False,
+def shell_exec(script, test=True, errexit=True, xtrace=False, silent=False,
                continue_on_err=False, working_dir=None, background=False):
     dedented = ''
     if errexit:


### PR DESCRIPTION
DRIVERS-1596

The `xtrace` shell option prints all commands that are executed, which may reveal sensitive information. It also clutters the build logs, making debugging issues a lot harder.

While it's useful to use `xtrace` to ensure commands and options are assembled correctly, this should only be used while developing and not as part of the regular usage.