### PR TITLE
DRIVERS-1603 Introduce scripts for provisioning and reaping serverless instances

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -835,6 +835,9 @@ axes:
       - id: debian92-test
         display_name: "Debian 9.2"
         run_on: debian92-test
+      - id: ubuntu-18.04
+        display_name: "Ubuntu 18.04"
+        run_on: ubuntu1804-test
 
   - id: topology
     display_name: Topology
@@ -1130,9 +1133,9 @@ buildvariants:
 
 - matrix_name: "serverless"
   matrix_spec:
-    os-requires-32:
-      - "ubuntu-16.04"
-  display_name: "Serverless ${os-fully-featured}"
+    os-requires-40:
+      - "ubuntu-18.04"
+  display_name: "Serverless ${os-requires-40}"
   tasks:
     - "serverless_task_group"
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1130,8 +1130,8 @@ buildvariants:
 
 - matrix_name: "serverless"
   matrix_spec:
-    os-fully-featured:
-      - "ubuntu-18.04"
+    os-requires-32:
+      - "ubuntu-16.04"
   display_name: "Serverless ${os-fully-featured}"
   tasks:
     - "serverless_task_group"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -339,6 +339,21 @@ functions:
           ${PREPARE_SHELL}
           AUTH=${AUTH} SSL=${SSL} MONGODB_URI="${MONGODB_URI}" sh ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
 
+  "run serverless tests":
+    - command: shell.exec
+      type: test
+      params:
+        working_dir: "src"
+        script: |
+          ${PREPARE_SHELL}
+          set +o xtrace
+
+          MONGODB_URI="${MONGODB_URI}" \
+          MONGODB_API_VERSION=${MONGODB_API_VERSION} \
+          SERVERLESS_ATLAS_USER="${SERVERLESS_ATLAS_USER}" \
+          SERVERLESS_ATLAS_PASSWORD="${SERVERLESS_ATLAS_PASSWORD}" \
+            sh ${PROJECT_DIRECTORY}/.evergreen/run-serverless-tests.sh
+
   "cleanup":
     - command: shell.exec
       params:
@@ -679,6 +694,11 @@ tasks:
             TOPOLOGY: "sharded_cluster"
         - func: "run tests"
 
+    - name: "test-serverless"
+      tags: ["serverless"]
+      commands:
+        - func: "run serverless tests"
+
 # }}}
 
 
@@ -869,6 +889,39 @@ axes:
         variables:
            STORAGE_ENGINE: "inmemory"
 
+task_groups:
+  - name: serverless_task_group
+    setup_group_can_fail_task: true
+    setup_group_timeout_secs: 1800 # 30 minutes
+    setup_group:
+      - func: "fetch source"
+      - func: "prepare resources"
+      - command: shell.exec
+        params:
+          shell: "bash"
+          script: |
+            ${PREPARE_SHELL}
+            set +o xtrace
+            SERVERLESS_DRIVERS_GROUP=${SERVERLESS_DRIVERS_GROUP} \
+            SERVERLESS_API_PUBLIC_KEY=${SERVERLESS_API_PUBLIC_KEY} \
+            SERVERLESS_API_PRIVATE_KEY=${SERVERLESS_API_PRIVATE_KEY} \
+              bash ${DRIVERS_TOOLS}/.evergreen/serverless/create-instance.sh
+      - command: expansions.update
+        params:
+          file: serverless-expansion.yml
+    teardown_group:
+      - command: shell.exec
+        params:
+          script: |
+            ${PREPARE_SHELL}
+            set +o xtrace
+            SERVERLESS_DRIVERS_GROUP=${SERVERLESS_DRIVERS_GROUP} \
+            SERVERLESS_API_PUBLIC_KEY=${SERVERLESS_API_PUBLIC_KEY} \
+            SERVERLESS_API_PRIVATE_KEY=${SERVERLESS_API_PRIVATE_KEY} \
+            SERVERLESS_INSTANCE_NAME=${SERVERLESS_INSTANCE_NAME} \
+              bash ${DRIVERS_TOOLS}/.evergreen/serverless/delete-instance.sh
+    tasks:
+      - ".serverless"
 
 buildvariants:
 
@@ -1074,6 +1127,14 @@ buildvariants:
            - name: "test-2.4-replica_set"
            - name: "test-2.4-sharded_cluster"
            - name: "test-2.4-standalone"
+
+- matrix_name: "serverless"
+  matrix_spec:
+    os-fully-featured:
+      - "ubuntu-18.04"
+  display_name: "Serverless ${os-fully-featured}"
+  tasks:
+    - "serverless_task_group"
 
       # Platform notes
       # i386 builds of OpenSSL or Cyrus SASL are not available

--- a/.evergreen/serverless/create-instance.sh
+++ b/.evergreen/serverless/create-instance.sh
@@ -24,11 +24,12 @@ if [ -z "$SERVERLESS_API_PUBLIC_KEY" ]; then
     exit 1
 fi
 
+echo "creating new serverless instance \"${INSTANCE_NAME}\"..."
+
 DIR=$(dirname $0)
 API_BASE_URL="https://account-dev.mongodb.com/api/atlas/v1.0/groups/$SERVERLESS_DRIVERS_GROUP"
 
 curl \
-  -i \
   -u "$SERVERLESS_API_PUBLIC_KEY:$SERVERLESS_API_PRIVATE_KEY" \
   --silent \
   --show-error \

--- a/.evergreen/serverless/create-instance.sh
+++ b/.evergreen/serverless/create-instance.sh
@@ -2,25 +2,35 @@
 
 set -o errexit
 
+echo "in create instance"
+
 if [ -z "$1" ]; then
     echo "Instance name must be provided as a command line argument"
     exit 1
 fi
+
+echo "instance name provided"
 
 if [ -z "$SERVERLESS_DRIVERS_GROUP" ]; then
     echo "Drivers Atlas group must be provided via SERVERLESS_DRIVERS_GROUP environment variable"
     exit 1
 fi
 
+echo "group provided"
+
 if [ -z "$SERVERLESS_API_PRIVATE_KEY" ]; then
     echo "Atlas API private key must be provided via SERVERLESS_API_PRIVATE_KEY environment variable"
     exit 1
 fi
 
+echo "private key provideD"
+
 if [ -z "$SERVERLESS_API_PUBLIC_KEY" ]; then
     echo "Atlas API public key must be provided via SERVERLESS_API_PUBLIC_KEY environment variable"
     exit 1
 fi
+
+echo "public key provided"
 
 API_BASE_URL="https://account-dev.mongodb.com/api/atlas/v1.0/groups/$SERVERLESS_DRIVERS_GROUP"
 
@@ -44,6 +54,8 @@ curl \
     }"
 
 echo ""
+
+echo "curl done"
 
 SECONDS=0
 while [ true ]; do

--- a/.evergreen/serverless/create-instance.sh
+++ b/.evergreen/serverless/create-instance.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+set -o errexit
+
+if [ -z "$1" ]; then
+    echo "Instance name must be provided as a command line argument"
+    exit 1
+fi
+
+if [ -z "$SERVERLESS_DRIVERS_GROUP" ]; then
+    echo "Drivers Atlas group must be provided via SERVERLESS_DRIVERS_GROUP environment variable"
+    exit 1
+fi
+
+if [ -z "$SERVERLESS_API_PRIVATE_KEY" ]; then
+    echo "Atlas API private key must be provided via SERVERLESS_API_PRIVATE_KEY environment variable"
+    exit 1
+fi
+
+if [ -z "$SERVERLESS_API_PUBLIC_KEY" ]; then
+    echo "Atlas API public key must be provided via SERVERLESS_API_PUBLIC_KEY environment variable"
+    exit 1
+fi
+
+API_BASE_URL="https://account-dev.mongodb.com/api/atlas/v1.0/groups/$SERVERLESS_DRIVERS_GROUP"
+
+curl \
+  -i \
+  -u "$SERVERLESS_API_PUBLIC_KEY:$SERVERLESS_API_PRIVATE_KEY" \
+  -X POST \
+  --digest \
+  --header "Accept: application/json" \
+  --header "Content-Type: application/json" \
+  "$API_BASE_URL/serverless/instances?pretty=true" \
+  --data "
+    {
+      \"name\" : \"${1}\",
+      \"providerSettings\" : {
+        \"providerName\": \"SERVERLESS\",
+        \"backingProviderName\": \"AWS\",
+        \"instanceSizeName\" : \"SERVERLESS_V1\",
+        \"regionName\" : \"US_EAST_1\"
+      }
+    }"
+
+echo ""
+
+SECONDS=0
+while [ true ]; do
+    echo "checking status of instance..."
+    API_RESPONSE=`bash get-instance.sh $1`
+    STATE_NAME=`echo $API_RESPONSE | python3 -c "import sys, json; print(json.load(sys.stdin)['stateName'])"`
+
+    if [ ${STATE_NAME} == "IDLE" ]; then
+        duration="$SECONDS"
+        echo "setup done! ($(($duration / 60))m $(($duration % 60))s elapsed)"
+        SRV_ADDRESS=$(echo $API_RESPONSE | python3 -c "import sys, json; print(json.load(sys.stdin)['srvAddress'])")
+        echo "MONGODB_SRV_URI=$SRV_ADDRESS"
+        STANDARD_ADDRESS=$(echo $API_RESPONSE | python3 -c "import sys, json; print(json.load(sys.stdin)['mongoURI'])")
+        echo "MONGODB_URI=$STANDARD_ADDRESS"
+        cat <<EOF > serverless-expansion.yml
+MONGODB_URI: "$STANDARD_ADDRESS"
+MONGODB_SRV_URI: "$SRV_ADDRESS"
+SSL: ssl
+AUTH: auth
+TOPOLOGY: sharded_cluster
+SERVERLESS: serverless
+MONGODB_API_VERSION: 1
+EOF
+        exit 0
+    else
+        echo "setup still in progress, status=$STATE_NAME, sleeping for 1 minute..."
+        sleep 60
+    fi
+done

--- a/.evergreen/serverless/delete-instance.sh
+++ b/.evergreen/serverless/delete-instance.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then
+    echo "Instance name must be provided as a command line argument"
+    exit 1
+fi
+
+if [ -z "$SERVERLESS_DRIVERS_GROUP" ]; then
+    echo "Drivers Atlas group must be provided via SERVERLESS_DRIVERS_GROUP environment variable"
+    exit 1
+fi
+
+if [ -z "$SERVERLESS_API_PRIVATE_KEY" ]; then
+    echo "Atlas API private key must be provided via SERVERLESS_API_PRIVATE_KEY environment variable"
+    exit 1
+fi
+
+if [ -z "$SERVERLESS_API_PUBLIC_KEY" ]; then
+    echo "Atlas API public key must be provided via SERVERLESS_API_PUBLIC_KEY environment variable"
+    exit 1
+fi
+
+API_BASE_URL="https://account-dev.mongodb.com/api/atlas/v1.0/groups/$SERVERLESS_DRIVERS_GROUP"
+
+curl \
+  -i \
+  -u "$SERVERLESS_API_PUBLIC_KEY:$SERVERLESS_API_PRIVATE_KEY" \
+  -X DELETE \
+  --digest \
+  --header "Accept: application/json" \
+  --header "Content-Type: application/json" \
+  "$API_BASE_URL/serverless/instances/$1?pretty=true"
+
+echo ""

--- a/.evergreen/serverless/delete-instance.sh
+++ b/.evergreen/serverless/delete-instance.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-if [ -z "$1" ]; then
-    echo "Instance name must be provided as a command line argument"
+if [ -z "$SERVERLESS_INSTANCE_NAME" ]; then
+    echo "Instance name must be provided via SERVERLESS_INSTANCE_NAME environment variable"
     exit 1
 fi
 
@@ -29,6 +29,6 @@ curl \
   --digest \
   --header "Accept: application/json" \
   --header "Content-Type: application/json" \
-  "$API_BASE_URL/serverless/instances/$1?pretty=true"
+  "${API_BASE_URL}/serverless/instances/${SERVERLESS_INSTANCE_NAME}?pretty=true"
 
 echo ""

--- a/.evergreen/serverless/delete-instance.sh
+++ b/.evergreen/serverless/delete-instance.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -o errexit
+set +o xtrace
+
 if [ -z "$SERVERLESS_INSTANCE_NAME" ]; then
     echo "Instance name must be provided via SERVERLESS_INSTANCE_NAME environment variable"
     exit 1
@@ -24,6 +27,8 @@ API_BASE_URL="https://account-dev.mongodb.com/api/atlas/v1.0/groups/$SERVERLESS_
 
 curl \
   -i \
+  --silent \
+  --show-error \
   -u "$SERVERLESS_API_PUBLIC_KEY:$SERVERLESS_API_PRIVATE_KEY" \
   -X DELETE \
   --digest \

--- a/.evergreen/serverless/delete-instance.sh
+++ b/.evergreen/serverless/delete-instance.sh
@@ -23,10 +23,11 @@ if [ -z "$SERVERLESS_API_PUBLIC_KEY" ]; then
     exit 1
 fi
 
+echo "deleting serverless instance \"${SERVERLESS_INSTANCE_NAME}\"..."
+
 API_BASE_URL="https://account-dev.mongodb.com/api/atlas/v1.0/groups/$SERVERLESS_DRIVERS_GROUP"
 
 curl \
-  -i \
   --silent \
   --show-error \
   -u "$SERVERLESS_API_PUBLIC_KEY:$SERVERLESS_API_PRIVATE_KEY" \

--- a/.evergreen/serverless/get-instance.sh
+++ b/.evergreen/serverless/get-instance.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then
+    echo "Instance name must be provided as a command line argument"
+    exit 1
+fi
+
+if [ -z "$SERVERLESS_DRIVERS_GROUP" ]; then
+    echo "Drivers Atlas group must be provided via SERVERLESS_DRIVERS_GROUP environment variable"
+    exit 1
+fi
+
+if [ -z "$SERVERLESS_API_PRIVATE_KEY" ]; then
+    echo "Atlas API private key must be provided via SERVERLESS_API_PRIVATE_KEY environment variable"
+    exit 1
+fi
+
+if [ -z "$SERVERLESS_API_PUBLIC_KEY" ]; then
+    echo "Atlas API public key must be provided via SERVERLESS_API_PUBLIC_KEY environment variable"
+    exit 1
+fi
+
+API_BASE_URL="https://account-dev.mongodb.com/api/atlas/v1.0/groups/$SERVERLESS_DRIVERS_GROUP"
+
+curl \
+  -s \
+  -u "$SERVERLESS_API_PUBLIC_KEY:$SERVERLESS_API_PRIVATE_KEY" \
+  -X GET \
+  --digest \
+  --header "Accept: application/json" \
+  "$API_BASE_URL/serverless/instances/$1?pretty=true" \
+
+echo ""

--- a/.evergreen/serverless/get-instance.sh
+++ b/.evergreen/serverless/get-instance.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-if [ -z "$1" ]; then
-    echo "Instance name must be provided as a command line argument"
+if [ -z "$SERVERLESS_INSTANCE_NAME" ]; then
+    echo "Instance name must be provided via SERVERLESS_INSTANCE_NAME environment variable"
     exit 1
 fi
 
@@ -28,6 +28,6 @@ curl \
   -X GET \
   --digest \
   --header "Accept: application/json" \
-  "$API_BASE_URL/serverless/instances/$1?pretty=true" \
+  "${API_BASE_URL}/serverless/instances/${SERVERLESS_INSTANCE_NAME}?pretty=true" \
 
 echo ""

--- a/.evergreen/serverless/get-instance.sh
+++ b/.evergreen/serverless/get-instance.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -o errexit
+set +o xtrace
+
 if [ -z "$SERVERLESS_INSTANCE_NAME" ]; then
     echo "Instance name must be provided via SERVERLESS_INSTANCE_NAME environment variable"
     exit 1
@@ -23,7 +26,8 @@ fi
 API_BASE_URL="https://account-dev.mongodb.com/api/atlas/v1.0/groups/$SERVERLESS_DRIVERS_GROUP"
 
 curl \
-  -s \
+  --silent \
+  --show-error \
   -u "$SERVERLESS_API_PUBLIC_KEY:$SERVERLESS_API_PRIVATE_KEY" \
   -X GET \
   --digest \


### PR DESCRIPTION
[DRIVERS-1603](https://jira.mongodb.org/browse/DRIVERS-1603)

This PR introduces the scripts necessary for drivers to create and delete serverless instances on demand as part of their test runs, as well as an example evergreen config that uses does so. See [here](https://evergreen.mongodb.com/version/6066352d2a60ed028ace6af7) for an example of the Swift driver using them to run the CRUD tests against a serverless instance.

Once the proxy implements some of the stuff we requested, I'll open up a new PR on the specs repo with drivers instructions on how to use these and what tests to run.