### PR TITLE
DRIVERS-1649 acceptAPIVersion2 -> acceptApiVersion2

### DIFF
--- a/.evergreen/orchestration/configs/servers/versioned-api-testing.json
+++ b/.evergreen/orchestration/configs/servers/versioned-api-testing.json
@@ -7,6 +7,6 @@
     "logappend": true,
     "journal": true,
     "port": 27017,
-    "setParameter": {"enableTestCommands": 1, "acceptAPIVersion2":  1}
+    "setParameter": {"enableTestCommands": 1, "acceptApiVersion2":  1}
   }
 }


### PR DESCRIPTION
[SERVER-55317](https://jira.mongodb.org/browse/SERVER-55317) renamed `acceptAPIVersion2` to `acceptApiVersion2`, so we need to update the config that uses this parameter.

I did a [test patch](https://spruce.mongodb.com/version/6070db205623432f40f2a80c/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) with the Swift driver by switching our config to rely on this branch to confirm the server gets started up correctly with the renamed parameter.

This will "fix" CI for drivers, but they will now start skipping the relevant tests, as the runner will check if the old parameter name was set on the server and find it was not, so as @ShaneHarvey notes on [DRIVERS-1649](https://jira.mongodb.org/browse/DRIVERS-1649) those tests also need to be updated.