### PR TITLE
Bump idle and connect timeouts in run-load-balancer.sh

### DIFF
--- a/.evergreen/run-load-balancer.sh
+++ b/.evergreen/run-load-balancer.sh
@@ -8,9 +8,9 @@ start() {
   cat <<EOF_HAPROXY_CONFIG >> $DRIVERS_TOOLS/haproxy.conf
   defaults
       mode tcp
-      timeout connect 5000ms
-      timeout client 5000ms
-      timeout server 5000ms
+      timeout connect 10s
+      timeout client 30m
+      timeout server 30m
 
   frontend mongos_frontend
       bind *:8000


### PR DESCRIPTION
This PR bumps the connect timeout in `run-load-balancer.sh` to 10 seconds, which matches the driver's default for `connectTimeoutMS` and the idle timeouts to 30 minutes, which should be sufficient to ensure that test runners do not encounter unexpected network errors due to severed connections.