### PR TITLE
DRIVERS-1733 update atlas data lake build script location reference

### DIFF
--- a/.evergreen/atlas_data_lake/build-mongohouse-local.sh
+++ b/.evergreen/atlas_data_lake/build-mongohouse-local.sh
@@ -35,11 +35,11 @@ GO111MODULE=on go mod download
 DL_END=$(date +%s)
 
 # Build mqlrun
-./build.sh tools:download:mqlrun
+./cmd/buildscript/build.sh tools:download:mqlrun
 export MONGOHOUSE_MQLRUN=`pwd`/artifacts/mqlrun
 
 # Build mongohouse
-./build.sh build:mongohoused
+./cmd/buildscript/build.sh build:mongohoused
 
 sleep 5
 

--- a/.evergreen/atlas_data_lake/build-mongohouse-local.sh
+++ b/.evergreen/atlas_data_lake/build-mongohouse-local.sh
@@ -12,7 +12,7 @@ git config --global url."git@github.com:".insteadof "https://github.com/"
 AP_START=$(date +%s)
 
 # Set up environment variables for Go
-GO_VERSION=1.14
+GO_VERSION=1.16
 if [ "Windows_NT" = "$OS" ]; then
   export GOPATH="$(cygpath -m "$(pwd)")/.gopath"
   export GOCACHE="$(cygpath -m "$(pwd)")/.cache"


### PR DESCRIPTION
DRIVERS-1733 Atlas Data Lake build script locations were updated and this change updates the references to match as well as the required go version