### PR TITLE
DRIVERS-1603 Drop API version requirement from serverless testing

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -363,7 +363,6 @@ functions:
           set +o xtrace
 
           MONGODB_URI="${MONGODB_URI}" \
-          MONGODB_API_VERSION=${MONGODB_API_VERSION} \
           SERVERLESS_ATLAS_USER="${SERVERLESS_ATLAS_USER}" \
           SERVERLESS_ATLAS_PASSWORD="${SERVERLESS_ATLAS_PASSWORD}" \
             sh ${PROJECT_DIRECTORY}/.evergreen/run-serverless-tests.sh

--- a/.evergreen/serverless/create-instance.sh
+++ b/.evergreen/serverless/create-instance.sh
@@ -72,7 +72,6 @@ SSL: ssl
 AUTH: auth
 TOPOLOGY: sharded_cluster
 SERVERLESS: serverless
-MONGODB_API_VERSION: 1
 EOF
         exit 0
     else


### PR DESCRIPTION
Tested locally and the tests pass without any API version specified, so this PR updates the serverless expansion to no longer include it.