### PR TITLE
DRIVERS-1603 Update serverless scripts to run on Windows

### DIFF
--- a/.evergreen/serverless/create-instance.sh
+++ b/.evergreen/serverless/create-instance.sh
@@ -51,18 +51,24 @@ curl \
 
 echo ""
 
+if [ "Windows_NT" = "$OS" ]; then
+  PYTHON_BINARY=C:/python/Python38/python.exe
+else
+  PYTHON_BINARY=python3
+fi
+
 SECONDS=0
 while [ true ]; do
     API_RESPONSE=`SERVERLESS_INSTANCE_NAME=$INSTANCE_NAME bash $DIR/get-instance.sh`
-    STATE_NAME=`echo $API_RESPONSE | python3 -c "import sys, json; print(json.load(sys.stdin)['stateName'])"`
+    STATE_NAME=`echo $API_RESPONSE | $PYTHON_BINARY -c "import sys, json; print(json.load(sys.stdin)['stateName'])" | tr -d '\r\n'`
 
-    if [ ${STATE_NAME} == "IDLE" ]; then
+    if [ "$STATE_NAME" = "IDLE" ]; then
         duration="$SECONDS"
         echo "setup done! ($(($duration / 60))m $(($duration % 60))s elapsed)"
         echo "SERVERLESS_INSTANCE_NAME=\"$INSTANCE_NAME\""
-        SRV_ADDRESS=$(echo $API_RESPONSE | python3 -c "import sys, json; print(json.load(sys.stdin)['srvAddress'])")
+        SRV_ADDRESS=$(echo $API_RESPONSE | $PYTHON_BINARY -c "import sys, json; print(json.load(sys.stdin)['srvAddress'])" | tr -d '\r\n')
         echo "MONGODB_SRV_URI=\"$SRV_ADDRESS\""
-        STANDARD_ADDRESS=$(echo $API_RESPONSE | python3 -c "import sys, json; print(json.load(sys.stdin)['mongoURI'])")
+        STANDARD_ADDRESS=$(echo $API_RESPONSE | $PYTHON_BINARY -c "import sys, json; print(json.load(sys.stdin)['mongoURI'])" | tr -d '\r\n')
         echo "MONGODB_URI=\"$STANDARD_ADDRESS\""
         cat <<EOF > serverless-expansion.yml
 MONGODB_URI: "$STANDARD_ADDRESS"


### PR DESCRIPTION
There are several problems on Windows:
1. `python3` call does not work
2. JSON parser adds a `CRLF` into result for some reason
3. Bash equality comparison `==` does not work

Example fail on Windows: https://evergreen.mongodb.com/task_log_raw/dot_net_driver_serverless_tests__os~windows_64_serverless_tests_patch_cf62d156f72a517c4bb61046ddb23104f58ece0c_60ac0c881e2d173e5cf09858_21_05_24_20_29_13/0?type=T#L181
Patch build with the changes: https://evergreen.mongodb.com/task/dot_net_driver_serverless_tests__os~windows_64_serverless_tests_patch_cf62d156f72a517c4bb61046ddb23104f58ece0c_60adb234e3c3312c2ce547fa_21_05_26_02_29_14