### PR TITLE
DRIVERS-1603 Switch instance creation to GCP

### DIFF
--- a/.evergreen/serverless/create-instance.sh
+++ b/.evergreen/serverless/create-instance.sh
@@ -43,9 +43,9 @@ curl \
       \"name\" : \"${INSTANCE_NAME}\",
       \"providerSettings\" : {
         \"providerName\": \"SERVERLESS\",
-        \"backingProviderName\": \"AWS\",
+        \"backingProviderName\": \"GCP\",
         \"instanceSizeName\" : \"SERVERLESS_V2\",
-        \"regionName\" : \"US_EAST_1\"
+        \"regionName\" : \"CENTRAL_US\"
       }
     }"
 


### PR DESCRIPTION
Since the AWS are moving behind a load balancer, we need to temporarily switch to creating the instances on GCP.