### PR TITLE
DRIVERS-1833 do not require MONGODB_URI if stopping load balancer

### DIFF
--- a/.evergreen/run-load-balancer.sh
+++ b/.evergreen/run-load-balancer.sh
@@ -4,16 +4,17 @@ set -o errexit  # Exit the script with error if any of the commands fail
 
 DRIVERS_TOOLS=$(cd "$(dirname "$0")" && pwd)/..
 MONGODB_URI=${MONGODB_URI:-}
-if [ -z "$MONGODB_URI" ]; then
-    echo 'The MONGODB_URI environment variable is required!'
-    echo 'For example: '
-    echo '   MONGODB_URI="mongodb://localhost:27017,localhost:27018/'
-    echo 'or:'
-    echo '   MONGODB_URI="mongodb://user:password@localhost:27017,localhost:27018/?authSource=admin&tls=true'
-    exit 1
-fi
 
 start() {
+  if [ -z "$MONGODB_URI" ]; then
+      echo 'The MONGODB_URI environment variable is required!'
+      echo 'For example: '
+      echo '   MONGODB_URI="mongodb://localhost:27017,localhost:27018/'
+      echo 'or:'
+      echo '   MONGODB_URI="mongodb://user:password@localhost:27017,localhost:27018/?authSource=admin&tls=true'
+      exit 1
+  fi
+
   echo "Starting HAProxy..."
 
   cat <<EOF_HAPROXY_CONFIG > $DRIVERS_TOOLS/haproxy.conf


### PR DESCRIPTION
Since it is easy to forget to set MONGODB_URI if stopping the load balancer as part of an evergreen "post" task, which ignores script errors.