### PR TITLE
DRIVERS-1603 Use private API endpoint in get-instance.sh

### DIFF
--- a/.evergreen/serverless/get-instance.sh
+++ b/.evergreen/serverless/get-instance.sh
@@ -23,7 +23,7 @@ if [ -z "$SERVERLESS_API_PUBLIC_KEY" ]; then
     exit 1
 fi
 
-API_BASE_URL="https://account-dev.mongodb.com/api/atlas/v1.0/groups/$SERVERLESS_DRIVERS_GROUP"
+API_BASE_URL="https://account-dev.mongodb.com/api/private/nds/serverless/groups/$SERVERLESS_DRIVERS_GROUP"
 
 curl \
   --silent \
@@ -32,6 +32,6 @@ curl \
   -X GET \
   --digest \
   --header "Accept: application/json" \
-  "${API_BASE_URL}/serverless/${SERVERLESS_INSTANCE_NAME}?pretty=true" \
+  "${API_BASE_URL}/instances/${SERVERLESS_INSTANCE_NAME}?pretty=true" \
 
 echo ""


### PR DESCRIPTION
This PR updates `get-instance.sh` to use the private API endpoint which exposes the full connection string as opposed to just the SRV one as the public endpoint does.