### PR TITLE
DRIVERS-1858: update mongohouse build script paths

### DIFF
--- a/.evergreen/atlas_data_lake/build-mongohouse-local.sh
+++ b/.evergreen/atlas_data_lake/build-mongohouse-local.sh
@@ -35,11 +35,11 @@ GO111MODULE=on go mod download
 DL_END=$(date +%s)
 
 # Build mqlrun
-./cmd/buildscript/build.sh tools:download:mqlrun
+./build.sh tools:download:mqlrun
 export MONGOHOUSE_MQLRUN=`pwd`/artifacts/mqlrun
 
 # Build mongohouse
-./cmd/buildscript/build.sh build:mongohoused
+./build.sh build:mongohoused
 
 sleep 5
 


### PR DESCRIPTION
Node driver [Evergreen patch](https://spruce.mongodb.com/version/60f6dbeed6d80a28405ea678/tasks)