### PR TITLE
Fix activate_venv shell script typos

### DIFF
--- a/.evergreen/auth_aws/activate_venv.sh
+++ b/.evergreen/auth_aws/activate_venv.sh
@@ -20,6 +20,6 @@ else
 fi
 
 # install dependencies on first run
-if [ ! -n $FIRST_RUN ]; then
+if [ ! -z $FIRST_RUN ]; then
   pip install --upgrade boto3
 fi

--- a/.evergreen/auth_aws/activate_venv.sh
+++ b/.evergreen/auth_aws/activate_venv.sh
@@ -20,6 +20,6 @@ else
 fi
 
 # install dependencies on first run
-if [ -z $FIRST_RUN ]; then
+if [ -n $FIRST_RUN ]; then
   pip install --upgrade boto3
 fi

--- a/.evergreen/auth_aws/activate_venv.sh
+++ b/.evergreen/auth_aws/activate_venv.sh
@@ -20,6 +20,6 @@ else
 fi
 
 # install dependencies on first run
-if [ -n $FIRST_RUN ]; then
+if [ ! -n $FIRST_RUN ]; then
   pip install --upgrade boto3
 fi

--- a/.evergreen/csfle/activate_venv.sh
+++ b/.evergreen/csfle/activate_venv.sh
@@ -20,6 +20,6 @@ else
 fi
 
 # install dependencies on first run
-if [ ! -n $FIRST_RUN ]; then
+if [ ! -z $FIRST_RUN ]; then
   pip install --upgrade boto3
 fi

--- a/.evergreen/csfle/activate_venv.sh
+++ b/.evergreen/csfle/activate_venv.sh
@@ -1,6 +1,6 @@
 if [ "Windows_NT" = "$OS" ]; then
   PYTHON_BINARY=C:/python/Python38/python.exe
-elif [ command -v /opt/python/3.6/bin/python3 ]; then
+elif command -v /opt/python/3.6/bin/python3; then
   PYTHON_BINARY=/opt/python/3.6/bin/python3
 else
   PYTHON_BINARY=python3
@@ -20,6 +20,6 @@ else
 fi
 
 # install dependencies on first run
-if [ -z $FIRST_RUN ]; then
+if [ -n $FIRST_RUN ]; then
   pip install --upgrade boto3
 fi

--- a/.evergreen/csfle/activate_venv.sh
+++ b/.evergreen/csfle/activate_venv.sh
@@ -20,6 +20,6 @@ else
 fi
 
 # install dependencies on first run
-if [ -n $FIRST_RUN ]; then
+if [ ! -n $FIRST_RUN ]; then
   pip install --upgrade boto3
 fi


### PR DESCRIPTION
Actually checks that `$FIRST_RUN` isn't unset in dependency install and removes unnecessary brackets in the `PYTHON_BINARY` if chain.