### PR TITLE
Upgrade pymongo to avoid using 3.5.1 which does not support server 5.1

### DIFF
--- a/.evergreen/start-orchestration.sh
+++ b/.evergreen/start-orchestration.sh
@@ -39,8 +39,8 @@ elif $PYTHON -m virtualenv --system-site-packages --never-download venv || virtu
   fi
 fi
 
-# Install from github to get the latest mongo-orchestration.
-pip install --upgrade 'git+git://github.com/mongodb/mongo-orchestration@master'
+# Install from github to get the latest mongo-orchestration and upgrade pymongo.
+pip install --upgrade 'git+git://github.com/mongodb/mongo-orchestration@master' 'pymongo<4'
 pip list
 cd -
 


### PR DESCRIPTION
MongoDB 5.1 removes support for OP_QUERY so pymongo>=3.6 is required.

Fixes this error:
```
 [2021/08/04 18:51:25.325] 2021-08-04 19:51:25,286 [ERROR] mongo_orchestration.apps:68 - <function rs_create at 0x00000000034C43C8>
 [2021/08/04 18:51:25.325] Traceback (most recent call last):
 [2021/08/04 18:51:25.325]   File "c:\data\mci\33c01593e9035430decf68f05f30768a\drivers-tools\.evergreen\orchestration\venv\lib\site-packages\mongo_orchestration\apps\__init__.py", line 66, in wrap
 [2021/08/04 18:51:25.325]     return f(*arg, **kwd)
 [2021/08/04 18:51:25.325]   File "c:\data\mci\33c01593e9035430decf68f05f30768a\drivers-tools\.evergreen\orchestration\venv\lib\site-packages\mongo_orchestration\apps\replica_sets.py", line 80, in rs_create
 [2021/08/04 18:51:25.325]     result = _rs_create(data)
 [2021/08/04 18:51:25.325]   File "c:\data\mci\33c01593e9035430decf68f05f30768a\drivers-tools\.evergreen\orchestration\venv\lib\site-packages\mongo_orchestration\apps\replica_sets.py", line 37, in _rs_create
 [2021/08/04 18:51:25.325]     rs_id = ReplicaSets().create(params)
 [2021/08/04 18:51:25.325]   File "c:\data\mci\33c01593e9035430decf68f05f30768a\drivers-tools\.evergreen\orchestration\venv\lib\site-packages\mongo_orchestration\replica_sets.py", line 647, in create
 [2021/08/04 18:51:25.325]     repl = ReplicaSet(rs_params)
 [2021/08/04 18:51:25.325]   File "c:\data\mci\33c01593e9035430decf68f05f30768a\drivers-tools\.evergreen\orchestration\venv\lib\site-packages\mongo_orchestration\replica_sets.py", line 87, in __init__
 [2021/08/04 18:51:25.325]     if not self.repl_init(config):
 [2021/08/04 18:51:25.325]   File "c:\data\mci\33c01593e9035430decf68f05f30768a\drivers-tools\.evergreen\orchestration\venv\lib\site-packages\mongo_orchestration\replica_sets.py", line 189, in repl_init
 [2021/08/04 18:51:25.325]     result = self.connection(init_server).admin.command("replSetInitiate", config)
 [2021/08/04 18:51:25.325]   File "C:\Python27\lib\site-packages\pymongo\database.py", line 516, in command
 [2021/08/04 18:51:25.325]     codec_options, **kwargs)
 [2021/08/04 18:51:25.325]   File "C:\Python27\lib\site-packages\pymongo\database.py", line 428, in _command
 [2021/08/04 18:51:25.326]     parse_write_concern_error=parse_write_concern_error)
 [2021/08/04 18:51:25.326]   File "C:\Python27\lib\site-packages\pymongo\pool.py", line 477, in command
 [2021/08/04 18:51:25.326]     collation=collation)
 [2021/08/04 18:51:25.326]   File "C:\Python27\lib\site-packages\pymongo\network.py", line 116, in command
 [2021/08/04 18:51:25.326]     parse_write_concern_error=parse_write_concern_error)
 [2021/08/04 18:51:25.326]   File "C:\Python27\lib\site-packages\pymongo\helpers.py", line 210, in _check_command_response
 [2021/08/04 18:51:25.326]     raise OperationFailure(msg % errmsg, code, response)
 [2021/08/04 18:51:25.326] OperationFailure: Unsupported OP_QUERY command: replSetInitiate
 [2021/08/04 18:51:25.326] 2021-08-04 19:51:25,289 [DEBUG] mongo_orchestration.apps:55 - send_result(500)
```
https://evergreen.mongodb.com/task_log_raw/dot_net_driver_secure_tests__version~latest_os~windows_64_topology~replicaset_auth~auth_ssl~ssl_test_net452_patch_e052620c07c641e735de1f7a02f2049f20a2bcf0_610ae01b0ae606191fe41da2_21_08_04_18_44_44/0?type=T#L745