### PR TITLE
DRIVERS-1882 update serverless scripts to use AWS

### DIFF
--- a/.evergreen/serverless/create-instance.sh
+++ b/.evergreen/serverless/create-instance.sh
@@ -69,7 +69,7 @@ while [ true ]; do
         SRV_ADDRESS=$(echo $API_RESPONSE | $PYTHON_BINARY -c "import sys, json; print(json.load(sys.stdin)['srvAddress'])" | tr -d '\r\n')
         echo "MONGODB_SRV_URI=\"$SRV_ADDRESS\""
         STANDARD_ADDRESS=$(echo $API_RESPONSE | $PYTHON_BINARY -c "import sys, json; print(json.load(sys.stdin)['mongoURI'])" | tr -d '\r\n')
-        echo "MONGODB_URI=\"$STANDARD_ADDRESS\"/?loadBalanced=true"
+        echo "MONGODB_URI=\"$STANDARD_ADDRESS/?loadBalanced=true\""
         cat <<EOF > serverless-expansion.yml
 MONGODB_URI: "$STANDARD_ADDRESS"
 MONGODB_SRV_URI: "$SRV_ADDRESS"

--- a/.evergreen/serverless/create-instance.sh
+++ b/.evergreen/serverless/create-instance.sh
@@ -12,12 +12,12 @@ INSTANCE_NAME="$RANDOM-$PROJECT"
 # Use the LOADBALANCED environment variable to opt-in to testing
 # load balanced serverless instances.
 if [ -z "$LOADBALANCED" ]; then
+    BACKING_PROVIDER_NAME="GCP"
+    INSTANCE_REGION_NAME="CENTRAL_US"
+else
     BACKING_PROVIDER_NAME="AWS"
     INSTANCE_REGION_NAME="US_EAST_1"
     EXTRA_URI_OPTIONS="?loadBalanced=true"
-else
-    BACKING_PROVIDER_NAME="GCP"
-    INSTANCE_REGION_NAME="CENTRAL_US"
 fi
 
 if [ -z "$SERVERLESS_DRIVERS_GROUP" ]; then

--- a/.evergreen/serverless/create-instance.sh
+++ b/.evergreen/serverless/create-instance.sh
@@ -12,12 +12,12 @@ INSTANCE_NAME="$RANDOM-$PROJECT"
 # Set the LOADBALANCED environment variable to "ON" to opt-in to
 # testing load balanced serverless instances.
 if [ "$LOADBALANCED" = "ON" ]; then
-    BACKING_PROVIDER_NAME="GCP"
-    INSTANCE_REGION_NAME="CENTRAL_US"
-else
     BACKING_PROVIDER_NAME="AWS"
     INSTANCE_REGION_NAME="US_EAST_1"
     EXTRA_URI_OPTIONS="?loadBalanced=true"
+else
+    BACKING_PROVIDER_NAME="GCP"
+    INSTANCE_REGION_NAME="CENTRAL_US"
 fi
 
 if [ -z "$SERVERLESS_DRIVERS_GROUP" ]; then

--- a/.evergreen/serverless/create-instance.sh
+++ b/.evergreen/serverless/create-instance.sh
@@ -70,6 +70,11 @@ while [ true ]; do
         echo "MONGODB_SRV_URI=\"$SRV_ADDRESS\""
         STANDARD_ADDRESS=$(echo $API_RESPONSE | $PYTHON_BINARY -c "import sys, json; print(json.load(sys.stdin)['mongoURI'])" | tr -d '\r\n')
         echo "MONGODB_URI=\"$STANDARD_ADDRESS/?loadBalanced=true\""
+        MULTI_ATLASPROXY_SERVERLESS_URI="$SRV_ADDRESS"
+        echo "MULTI_ATLASPROXY_SERVERLESS_URI=\"$MULTI_ATLASPROXY_SERVERLESS_URI\""
+        SINGLE_ATLASPROXY_SERVERLESS_URI=$(echo $STANDARD_ADDRESS | $PYTHON_BINARY -c "import sys; uri=sys.stdin.read(); print (uri[0:uri.find(',')] + '/?loadBalanced=true&tls=true')" | tr -d '\r\n')
+        echo "SINGLE_ATLASPROXY_SERVERLESS_URI=\"$SINGLE_ATLASPROXY_SERVERLESS_URI\""
+
         cat <<EOF > serverless-expansion.yml
 MONGODB_URI: "$STANDARD_ADDRESS"
 MONGODB_SRV_URI: "$SRV_ADDRESS"
@@ -78,6 +83,8 @@ SSL: ssl
 AUTH: auth
 TOPOLOGY: sharded_cluster
 SERVERLESS: serverless
+MULTI_ATLASPROXY_SERVERLESS_URI: "$MULTI_ATLASPROXY_SERVERLESS_URI"
+SINGLE_ATLASPROXY_SERVERLESS_URI: "$SINGLE_ATLASPROXY_SERVERLESS_URI"
 EOF
         exit 0
     else

--- a/.evergreen/serverless/create-instance.sh
+++ b/.evergreen/serverless/create-instance.sh
@@ -69,7 +69,7 @@ while [ true ]; do
         SRV_ADDRESS=$(echo $API_RESPONSE | $PYTHON_BINARY -c "import sys, json; print(json.load(sys.stdin)['srvAddress'])" | tr -d '\r\n')
         echo "MONGODB_SRV_URI=\"$SRV_ADDRESS\""
         STANDARD_ADDRESS=$(echo $API_RESPONSE | $PYTHON_BINARY -c "import sys, json; print(json.load(sys.stdin)['mongoURI'])" | tr -d '\r\n')
-        echo "MONGODB_URI=\"$STANDARD_ADDRESS\""
+        echo "MONGODB_URI=\"$STANDARD_ADDRESS\"/?loadBalanced=true"
         cat <<EOF > serverless-expansion.yml
 MONGODB_URI: "$STANDARD_ADDRESS"
 MONGODB_SRV_URI: "$SRV_ADDRESS"

--- a/.evergreen/serverless/create-instance.sh
+++ b/.evergreen/serverless/create-instance.sh
@@ -43,9 +43,9 @@ curl \
       \"name\" : \"${INSTANCE_NAME}\",
       \"providerSettings\" : {
         \"providerName\": \"SERVERLESS\",
-        \"backingProviderName\": \"GCP\",
+        \"backingProviderName\": \"AWS\",
         \"instanceSizeName\" : \"SERVERLESS_V2\",
-        \"regionName\" : \"CENTRAL_US\"
+        \"regionName\" : \"US_EAST_1\"
       }
     }"
 


### PR DESCRIPTION
This updates scripts in anticipation of GCP being fronted by a load balancer.
Serverless will no longer offer a test instance without a load balancer.

This adds a LOADBALANCED environment variable to opt-in to switching to a load balanced cluster backed by `AWS`. The rationale for making this opt-in is to prevent causing test failures on drivers that already have serverless tests implemented until they implement changes in DRIVERS-1603.

I will merge this before https://github.com/mongodb/specifications/pull/1053.