### PR TITLE
DRIVERS-2001 remove $PROJECT from create-instance

### DIFF
--- a/.evergreen/serverless/create-instance.sh
+++ b/.evergreen/serverless/create-instance.sh
@@ -3,11 +3,9 @@
 set -o errexit
 set +o xtrace # disable xtrace to ensure credentials aren't leaked
 
-if [ -z "$PROJECT" ]; then
-    echo "Project name must be provided via PROJECT environment variable"
-    exit 1
-fi
-INSTANCE_NAME="$RANDOM-$PROJECT"
+# INSTANCE_NAME has the following limitations:
+# https://docs.atlas.mongodb.com/reference/atlas-limits/#label-limits
+INSTANCE_NAME="$RANDOM-DRIVERTEST"
 
 # Set the LOADBALANCED environment variable to "ON" to opt-in to
 # testing load balanced serverless instances.


### PR DESCRIPTION
# Summary
Remove evergreen project name from serverless instance name created in .evergreen/serverless/create-instance.sh

Tested with the Go driver `test-serverless` task:
https://spruce.mongodb.com/version/61b8f3089ccd4e11488b0152

# Rationale
Evergreen project names can conflict with Atlas cluster name limitations: https://docs.atlas.mongodb.com/reference/atlas-limits/#label-limits.

I did not see a clear benefit to including the evergreen project name in the serverless instance name. I chose to use a fixed `DRIVERTEST`.