### PR TITLE
feat(DRIVERS-1983): add load balancer port in config

### DIFF
--- a/.evergreen/orchestration/configs/sharded_clusters/load-balancer-ssl.json
+++ b/.evergreen/orchestration/configs/sharded_clusters/load-balancer-ssl.json
@@ -1,0 +1,56 @@
+{
+  "id": "shard_cluster_1",
+  "shards": [
+    {
+      "id": "sh01",
+      "shardParams": {
+        "members": [
+          {
+            "procParams": {
+              "ipv6": true,
+              "bind_ip": "127.0.0.1,::1",
+              "shardsvr": true,
+              "port": 27217
+            }
+          },
+          {
+            "procParams": {
+              "ipv6": true,
+              "bind_ip": "127.0.0.1,::1",
+              "shardsvr": true,
+              "port": 27218
+            }
+          },
+          {
+            "procParams": {
+              "ipv6": true,
+              "bind_ip": "127.0.0.1,::1",
+              "shardsvr": true,
+              "port": 27219
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "routers": [
+    {
+      "ipv6": true,
+      "bind_ip": "127.0.0.1,::1",
+      "port": 27017,
+      "loadBalancerPort": 27050
+    },
+    {
+      "ipv6": true,
+      "bind_ip": "127.0.0.1,::1",
+      "port": 27018,
+      "loadBalancerPort": 27051
+    }
+  ],
+  "sslParams": {
+      "sslOnNormalPorts": true,
+      "sslPEMKeyFile": "ABSOLUTE_PATH_REPLACEMENT_TOKEN/.evergreen/x509gen/server.pem",
+      "sslCAFile": "ABSOLUTE_PATH_REPLACEMENT_TOKEN/.evergreen/x509gen/ca.pem",
+      "sslWeakCertificateValidation" : true
+  }
+}

--- a/.evergreen/orchestration/configs/sharded_clusters/load-balancer-ssl.json
+++ b/.evergreen/orchestration/configs/sharded_clusters/load-balancer-ssl.json
@@ -38,13 +38,19 @@
       "ipv6": true,
       "bind_ip": "127.0.0.1,::1",
       "port": 27017,
-      "loadBalancerPort": 27050
+      "setParameter": {
+        "featureFlagLoadBalancer": true,
+        "loadBalancerPort": 27050
+      }
     },
     {
       "ipv6": true,
       "bind_ip": "127.0.0.1,::1",
       "port": 27018,
-      "loadBalancerPort": 27051
+      "setParameter": {
+        "featureFlagLoadBalancer": true,
+        "loadBalancerPort": 27051
+      }
     }
   ],
   "sslParams": {

--- a/.evergreen/orchestration/configs/sharded_clusters/load-balancer.json
+++ b/.evergreen/orchestration/configs/sharded_clusters/load-balancer.json
@@ -1,0 +1,50 @@
+{
+  "id": "shard_cluster_1",
+  "shards": [
+    {
+      "id": "sh01",
+      "shardParams": {
+        "members": [
+          {
+            "procParams": {
+              "ipv6": true,
+              "bind_ip": "127.0.0.1,::1",
+              "shardsvr": true,
+              "port": 27217
+            }
+          },
+          {
+            "procParams": {
+              "ipv6": true,
+              "bind_ip": "127.0.0.1,::1",
+              "shardsvr": true,
+              "port": 27218
+            }
+          },
+          {
+            "procParams": {
+              "ipv6": true,
+              "bind_ip": "127.0.0.1,::1",
+              "shardsvr": true,
+              "port": 27219
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "routers": [
+    {
+      "ipv6": true,
+      "bind_ip": "127.0.0.1,::1",
+      "port": 27017,
+      "loadBalancerPort": 27050
+    },
+    {
+      "ipv6": true,
+      "bind_ip": "127.0.0.1,::1",
+      "port": 27018,
+      "loadBalancerPort": 27051
+    }
+  ]
+}

--- a/.evergreen/orchestration/configs/sharded_clusters/load-balancer.json
+++ b/.evergreen/orchestration/configs/sharded_clusters/load-balancer.json
@@ -38,13 +38,19 @@
       "ipv6": true,
       "bind_ip": "127.0.0.1,::1",
       "port": 27017,
-      "loadBalancerPort": 27050
+      "setParameter": {
+        "featureFlagLoadBalancer": true,
+        "loadBalancerPort": 27050
+      }
     },
     {
       "ipv6": true,
       "bind_ip": "127.0.0.1,::1",
       "port": 27018,
-      "loadBalancerPort": 27051
+      "setParameter": {
+        "featureFlagLoadBalancer": true,
+        "loadBalancerPort": 27051
+      }
     }
   ]
 }

--- a/.evergreen/run-load-balancer.sh
+++ b/.evergreen/run-load-balancer.sh
@@ -34,12 +34,12 @@ start() {
 
   backend mongos_backend
       mode tcp
-      server mongos 127.0.0.1:27017 check
+      server mongos 127.0.0.1:27050 check send-proxy-v2
 
   backend mongoses_backend
       mode tcp
-      server mongos_one 127.0.0.1:27017 check
-      server mongos_two 127.0.0.1:27018 check
+      server mongos_one 127.0.0.1:27050 check send-proxy-v2
+      server mongos_two 127.0.0.1:27051 check send-proxy-v2
 EOF_HAPROXY_CONFIG
 
   PREFIX=$(echo $MONGODB_URI | grep -Eo "(.*?)@" | cat)

--- a/.evergreen/run-orchestration.sh
+++ b/.evergreen/run-orchestration.sh
@@ -39,6 +39,10 @@ if [ -z "$ORCHESTRATION_FILE" ]; then
     ORCHESTRATION_FILE="auth"
   fi
 
+  if [ -n "$LOAD_BALANCER" ]; then
+    ORCHESTRATION_FILE="load-balancer"
+  fi
+
   if [ "$SSL" != "nossl" ]; then
     ORCHESTRATION_FILE="${ORCHESTRATION_FILE}-ssl"
   fi

--- a/.evergreen/start-orchestration.sh
+++ b/.evergreen/start-orchestration.sh
@@ -40,7 +40,7 @@ elif $PYTHON -m virtualenv --system-site-packages --never-download venv || virtu
 fi
 
 # Install from github to get the latest mongo-orchestration.
-pip install --upgrade 'https://github.com/10gen/mongo-orchestration/archive/DRIVERS-1983.tar.gz'
+pip install --upgrade 'https://github.com/mongodb/mongo-orchestration/archive/master.tar.gz'
 pip list
 cd -
 

--- a/.evergreen/start-orchestration.sh
+++ b/.evergreen/start-orchestration.sh
@@ -40,7 +40,7 @@ elif $PYTHON -m virtualenv --system-site-packages --never-download venv || virtu
 fi
 
 # Install from github to get the latest mongo-orchestration.
-pip install --upgrade 'https://github.com/mongodb/mongo-orchestration/archive/master.tar.gz'
+pip install --upgrade 'https://github.com/10gen/mongo-orchestration/archive/DRIVERS-1983.tar.gz'
 pip list
 cd -
 


### PR DESCRIPTION
Adds new mongo orchestration configurations for sharded clusters when using a load balancer to specify the load balancer port config option to the mongoses. Requires that a new `LOAD_BALANCER` environment variable is set (to any value) to load the new configs and will configure the mongoses to ports 27050 and 27051, and essentially replaces the old `FAKE_MONGODB_SERVICE_ID` that drivers can now remove and run the lb tests against "latest". Updates the haproxy configuration when running the load balancer to point at these new ports.

Node implementation: https://github.com/mongodb/node-mongodb-native/pull/3089

Current Node patch build: https://spruce.mongodb.com/version/61f09db81e2d1776cfb6c7cf/tasks