### PR TITLE
DRIVERS-2213: Revert "Don't use arbiters in auth configs" since SERVER-34421 has been fixed.

### DIFF
--- a/.evergreen/orchestration/configs/replica_sets/auth-ssl.json
+++ b/.evergreen/orchestration/configs/replica_sets/auth-ssl.json
@@ -42,6 +42,7 @@
         "port": 27019
       },
       "rsParams": {
+        "arbiterOnly": true
       }
     }
   ],

--- a/.evergreen/orchestration/configs/replica_sets/auth.json
+++ b/.evergreen/orchestration/configs/replica_sets/auth.json
@@ -41,6 +41,7 @@
         "port": 27019
       },
       "rsParams": {
+        "arbiterOnly": true
       }
     }
   ],


### PR DESCRIPTION
DRIVERS-2213: Revert "Don't use arbiters in auth configs" since SERVER-34421 has been fixed.

This reverts commit a8723971bb0d9ce6bfefdf3cc42c661b856e4706.