### PR TITLE
DRIVERS-2221 Fix AWS scripts relying on multi-authentication

### DIFF
--- a/.evergreen/auth_aws/aws_e2e_assume_role.js
+++ b/.evergreen/auth_aws/aws_e2e_assume_role.js
@@ -41,7 +41,7 @@ const external = admin.getMongo().getDB("$external");
 assert(admin.auth("bob", "pwd123"));
 assert.commandWorked(external.runCommand({createUser: ASSUMED_ROLE, roles:[{role: 'read', db: "aws"}]}));
 
-const testConn = new Mongo(conn.host);
+const testConn = new Mongo(Mongo().host);
 const testExternal = testConn.getDB('$external');
 assert(testExternal.auth({
     user: credentials["AccessKeyId"],

--- a/.evergreen/auth_aws/aws_e2e_assume_role.js
+++ b/.evergreen/auth_aws/aws_e2e_assume_role.js
@@ -41,7 +41,7 @@ const external = admin.getMongo().getDB("$external");
 assert(admin.auth("bob", "pwd123"));
 assert.commandWorked(external.runCommand({createUser: ASSUMED_ROLE, roles:[{role: 'read', db: "aws"}]}));
 
-const testConn = new Mongo(Mongo().host);
+const testConn = new Mongo();
 const testExternal = testConn.getDB('$external');
 assert(testExternal.auth({
     user: credentials["AccessKeyId"],

--- a/.evergreen/auth_aws/aws_e2e_assume_role.js
+++ b/.evergreen/auth_aws/aws_e2e_assume_role.js
@@ -40,7 +40,10 @@ const external = admin.getMongo().getDB("$external");
 
 assert(admin.auth("bob", "pwd123"));
 assert.commandWorked(external.runCommand({createUser: ASSUMED_ROLE, roles:[{role: 'read', db: "aws"}]}));
-assert(external.auth({
+
+const testConn = new Mongo(conn.host);
+const testExternal = testConn.getDB('$external');
+assert(testExternal.auth({
     user: credentials["AccessKeyId"],
     pwd: credentials["SecretAccessKey"],
     awsIamSessionToken: credentials["SessionToken"],

--- a/.evergreen/auth_aws/aws_e2e_ec2.js
+++ b/.evergreen/auth_aws/aws_e2e_ec2.js
@@ -54,7 +54,7 @@ const smoke = runMongoProgram("mongo",
 assert.eq(smoke, 0, "Could not auth with smoke user");
 
 // Try the auth function
-const testConn = new Mongo(conn.host);
+const testConn = new Mongo(Mongo().host);
 const testExternal = testConn.getDB('$external');
 assert(testExternal.auth({mechanism: 'MONGODB-AWS'}));
 }());

--- a/.evergreen/auth_aws/aws_e2e_ec2.js
+++ b/.evergreen/auth_aws/aws_e2e_ec2.js
@@ -54,7 +54,7 @@ const smoke = runMongoProgram("mongo",
 assert.eq(smoke, 0, "Could not auth with smoke user");
 
 // Try the auth function
-const testConn = new Mongo(Mongo().host);
+const testConn = new Mongo();
 const testExternal = testConn.getDB('$external');
 assert(testExternal.auth({mechanism: 'MONGODB-AWS'}));
 }());

--- a/.evergreen/auth_aws/aws_e2e_ec2.js
+++ b/.evergreen/auth_aws/aws_e2e_ec2.js
@@ -54,5 +54,7 @@ const smoke = runMongoProgram("mongo",
 assert.eq(smoke, 0, "Could not auth with smoke user");
 
 // Try the auth function
-assert(external.auth({mechanism: 'MONGODB-AWS'}));
+const testConn = new Mongo(conn.host);
+const testExternal = testConn.getDB('$external');
+assert(testExternal.auth({mechanism: 'MONGODB-AWS'}));
 }());

--- a/.evergreen/auth_aws/aws_e2e_regular_aws.js
+++ b/.evergreen/auth_aws/aws_e2e_regular_aws.js
@@ -15,7 +15,7 @@ const config = readSetupJson();
 assert.commandWorked(
     external.runCommand({createUser: config["iam_auth_ecs_account_arn"], roles:[{role: 'read', db: "aws"}]}));
 
-const testConn = new Mongo(conn.host);
+const testConn = new Mongo(Mongo().host);
 const testExternal = testConn.getDB('$external');
 assert(testExternal.auth({
     user: config["iam_auth_ecs_account"],

--- a/.evergreen/auth_aws/aws_e2e_regular_aws.js
+++ b/.evergreen/auth_aws/aws_e2e_regular_aws.js
@@ -15,7 +15,7 @@ const config = readSetupJson();
 assert.commandWorked(
     external.runCommand({createUser: config["iam_auth_ecs_account_arn"], roles:[{role: 'read', db: "aws"}]}));
 
-const testConn = new Mongo(Mongo().host);
+const testConn = new Mongo();
 const testExternal = testConn.getDB('$external');
 assert(testExternal.auth({
     user: config["iam_auth_ecs_account"],

--- a/.evergreen/auth_aws/aws_e2e_regular_aws.js
+++ b/.evergreen/auth_aws/aws_e2e_regular_aws.js
@@ -15,7 +15,9 @@ const config = readSetupJson();
 assert.commandWorked(
     external.runCommand({createUser: config["iam_auth_ecs_account_arn"], roles:[{role: 'read', db: "aws"}]}));
 
-assert(external.auth({
+const testConn = new Mongo(conn.host);
+const testExternal = testConn.getDB('$external');
+assert(testExternal.auth({
     user: config["iam_auth_ecs_account"],
     pwd: config["iam_auth_ecs_secret_access_key"],
     mechanism: 'MONGODB-AWS'

--- a/.evergreen/auth_aws/lib/ecs_hosted_test.js
+++ b/.evergreen/auth_aws/lib/ecs_hosted_test.js
@@ -31,7 +31,9 @@ const smoke = runProgram(program, uri);
 assert.eq(smoke, 0, "Could not auth with smoke user");
 
 // Try the auth function
-assert(external.auth({mechanism: 'MONGODB-AWS'}));
+const testConn = new Mongo(conn.host);
+const testExternal = testConn.getDB('$external');
+assert(testExternal.auth({mechanism: 'MONGODB-AWS'}));
 
 MongoRunner.stopMongod(conn);
 }());

--- a/.evergreen/auth_aws/lib/ecs_hosted_test.js
+++ b/.evergreen/auth_aws/lib/ecs_hosted_test.js
@@ -28,7 +28,7 @@ const program = "/root/src/.evergreen/run-mongodb-aws-ecs-test.sh";
 
 // Try the command line
 const smoke = runProgram(program, uri);
-assert.eq(smoke, 0, "Could not auth with smoke user");
+assert.eq(smoke, 0, "Driver .evergreen/run-mongodb-aws-ecs-test.sh script failed");
 
 // Try the auth function
 const testConn = new Mongo(conn.host);


### PR DESCRIPTION
[DRIVERS-2221](https://jira.mongodb.org/browse/DRIVERS-2221)

[SERVER-57369](https://jira.mongodb.org/browse/SERVER-57369) recently removed support for auth as multiple, simultaneous users. Updates our AWS scripts to logout before running authentication functions (as the server did with [this commit](https://github.com/10gen/mongo-enterprise-modules/commit/536a2e918d6fae3334b0ca6cb3d789914db73164)).