### PR TITLE
DRIVERS-2227 Update Go version in ADL build script

### DIFF
--- a/.evergreen/atlas_data_lake/build-mongohouse-local.sh
+++ b/.evergreen/atlas_data_lake/build-mongohouse-local.sh
@@ -12,7 +12,7 @@ git config --global url."git@github.com:".insteadof "https://github.com/"
 AP_START=$(date +%s)
 
 # Set up environment variables for Go
-GO_VERSION=1.16
+GO_VERSION=1.17
 if [ "Windows_NT" = "$OS" ]; then
   export GOPATH="$(cygpath -m "$(pwd)")/.gopath"
   export GOCACHE="$(cygpath -m "$(pwd)")/.cache"


### PR DESCRIPTION
DRIVERS-2227

Updates the Go version in the ADL build script from Go 1.16 to Go 1.17, as ADL now requires 1.17+ to build.

Here is the test [now passing](https://spruce.mongodb.com/version/62261f3f1e2d1705a6e15090/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) in the Go driver.