### PR TITLE
Remove usage of deterministic keyword argument in mongodl.py

### DIFF
--- a/.evergreen/mongodl.py
+++ b/.evergreen/mongodl.py
@@ -265,7 +265,7 @@ class CacheDB:
         db.create_function('mdb_version_not_rc',
                            1,
                            mdb_version_not_rc,
-                           deterministic=True)
+                           )
         return CacheDB(db)
 
     def __call__(


### PR DESCRIPTION
I am running into issues attempting to use mongodl.py on RHEL 70. RHEL 70 only has Python <=3.6 available, and the deterministic parameter was added in version 3.8 (https://docs.python.org/3/library/sqlite3.html#sqlite3.Connection.create_function). Given that this parameter only performs optimizations, and does not effect the output, it seems sensible to remove it so that mongodl.py can be used on more platforms. 