### PR TITLE
update download for rc8

### DIFF
--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -54,7 +54,7 @@ get_mongodb_download_url_for ()
    # Set VERSION_RAPID to the latest rapid release each quarter.
    VERSION_RAPID="5.3.1"
    VERSION_60_LATEST="v6.0-latest"
-   VERSION_60="6.0.0-rc5"
+   VERSION_60="6.0.0-rc8"
    VERSION_50="5.0.8"
    VERSION_44="4.4.13"
    VERSION_42="4.2.19"


### PR DESCRIPTION
This will be ready for review once 6.0.0-rc8 is released.

6.0.0-rc8 will be required for drivers to test https://github.com/mongodb/specifications/pull/1235.