### PR TITLE
DRIVERS-2346 Use venv instead of virtualenv

### DIFF
--- a/.evergreen/auth_aws/activate_venv.sh
+++ b/.evergreen/auth_aws/activate_venv.sh
@@ -9,11 +9,14 @@ fi
 # create venv on first run
 if [ ! -d authawsvenv ]; then
    FIRST_RUN=1
-   virtualenv -p ${PYTHON_BINARY} authawsvenv
+   ${PYTHON_BINARY} -m venv authawsvenv
 fi
 
 # always activate venv
 if [ "Windows_NT" = "$OS" ]; then
+  # Workaround https://bugs.python.org/issue32451:
+  # authawsvenv/Scripts/activate: line 3: $'\r': command not found
+  dos2unix authawsvenv/Scripts/activate || true
   . authawsvenv/Scripts/activate
 else
   . authawsvenv/bin/activate

--- a/.evergreen/csfle/activate_venv.sh
+++ b/.evergreen/csfle/activate_venv.sh
@@ -18,6 +18,9 @@ fi
 
 # always activate venv
 if [ "Windows_NT" = "$OS" ]; then
+  # Workaround https://bugs.python.org/issue32451:
+  # kmstlsvenv/Scripts/activate: line 3: $'\r': command not found
+  dos2unix kmstlsvenv/Scripts/activate || true
   . kmstlsvenv/Scripts/activate
 else
   . kmstlsvenv/bin/activate

--- a/.evergreen/csfle/activate_venv.sh
+++ b/.evergreen/csfle/activate_venv.sh
@@ -13,7 +13,7 @@ fi
 # create venv on first run
 if [ ! -d kmstlsvenv ]; then
    FIRST_RUN=1
-   virtualenv -p ${PYTHON_BINARY} kmstlsvenv
+   ${PYTHON_BINARY} -m venv kmstlsvenv
 fi
 
 # always activate venv


### PR DESCRIPTION
Attempting to fix https://jira.mongodb.org/browse/DRIVERS-2346

Testing here: https://spruce.mongodb.com/version/6297f4961e2d1748f0c12306