### PR TITLE
Bump VERSION_60 to 6.0.0-rc10

### DIFF
--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -54,7 +54,7 @@ get_mongodb_download_url_for ()
    # Set VERSION_RAPID to the latest rapid release each quarter.
    VERSION_RAPID="5.3.1"
    VERSION_60_LATEST="v6.0-latest"
-   VERSION_60="6.0.0-rc8"
+   VERSION_60="6.0.0-rc10"
    VERSION_50="5.0.8"
    VERSION_44="4.4.13"
    VERSION_42="4.2.19"


### PR DESCRIPTION
6.0.0-rc10 includes [SERVER-66901](https://jira.mongodb.org/browse/SERVER-66901), which is needed for [PHPLIB-884](https://jira.mongodb.org/browse/PHPLIB-884).

