### PR TITLE
update 6.0.0 version to rc11

### DIFF
--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -54,7 +54,7 @@ get_mongodb_download_url_for ()
    # Set VERSION_RAPID to the latest rapid release each quarter.
    VERSION_RAPID="5.3.1"
    VERSION_60_LATEST="v6.0-latest"
-   VERSION_60="6.0.0-rc10"
+   VERSION_60="6.0.0-rc11"
    VERSION_50="5.0.8"
    VERSION_44="4.4.13"
    VERSION_42="4.2.19"


### PR DESCRIPTION
6.0.0-rc11 is available for download. See https://jira.mongodb.org/browse/STAR-2918.

This may be necessary to test changes with https://jira.mongodb.org/browse/SERVER-66663.