### PR TITLE
Sensible default for MONGODB_BINARIES

### DIFF
--- a/.evergreen/start-orchestration.sh
+++ b/.evergreen/start-orchestration.sh
@@ -46,6 +46,7 @@ cd -
 
 # Create default config file if it doesn't exist
 if [ ! -f $MONGO_ORCHESTRATION_HOME/orchestration.config ]; then
+  MONGODB_BINARIES=${MONGODB_BINARIES:-$(dirname "$(dirname "$0")")/mongodb/bin}
   echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" > $MONGO_ORCHESTRATION_HOME/orchestration.config
 fi
 


### PR DESCRIPTION
This change makes it easier to use run-orchestration.sh locally by making MONGODB_BINARIES default to the place that download-mongodb.sh downloads to.

For example:
```
$ LOAD_BALANCER=true TOPOLOGY=sharded_cluster MONGODB_VERSION=6.0 DRIVERS_TOOLS=/Users/shane/git/drivers-evergreen-tools MONGO_ORCHESTRATION_HOME=/Users/shane/git/drivers-evergreen-tools/.evergreen/orchestration ~/git/drivers-evergreen-tools/.evergreen/run-orchestration.sh
+ AUTH=noauth
+ SSL=nossl
+ TOPOLOGY=sharded_cluster
+ LOAD_BALANCER=true
+ STORAGE_ENGINE=
+ REQUIRE_API_VERSION=
+ DISABLE_TEST_COMMANDS=
+ MONGODB_VERSION=6.0
+ MONGODB_DOWNLOAD_URL=
+ ORCHESTRATION_FILE=
++ date +%s
+ DL_START=1657227910
++ dirname /Users/shane/git/drivers-evergreen-tools/.evergreen/run-orchestration.sh
+ DIR=/Users/shane/git/drivers-evergreen-tools/.evergreen
+ . /Users/shane/git/drivers-evergreen-tools/.evergreen/download-mongodb.sh
++ set -o errexit
+ get_distro
+ '[' -f /etc/os-release ']'
+ '[' -f /etc/centos-release ']'
+ command -v lsb_release
+ '[' -f /etc/redhat-release ']'
+ '[' -f /etc/lsb-release ']'
+ grep -R 'Amazon Linux' /etc/system-release
++ uname -s
+ OS_NAME=Darwin
++ uname -m
+ MARCH=x86_64
++ echo Darwin--x86_64
++ tr '[:upper:]' '[:lower:]'
+ DISTRO=darwin--x86_64
+ echo darwin--x86_64
darwin--x86_64
+ '[' -z '' ']'
+ get_mongodb_download_url_for darwin--x86_64 6.0
+ _DISTRO=darwin--x86_64
+ _VERSION=6.0
+ VERSION_RAPID=5.3.1
+ VERSION_60_LATEST=v6.0-latest
+ VERSION_60=6.0.0-rc8
+ VERSION_50=5.0.9
+ VERSION_44=4.4.15
+ VERSION_42=4.2.21
+ VERSION_40=4.0.28
+ VERSION_36=3.6.23
+ VERSION_34=3.4.24
+ VERSION_32=3.2.22
+ VERSION_30=3.0.15
+ VERSION_26=2.6.12
+ VERSION_24=2.4.14
+ EXTRACT='tar zxf'
+ case "$_DISTRO" in
+ MONGODB_LATEST=http://downloads.10gen.com/osx/mongodb-macos-x86_64-enterprise-latest.tgz
+ MONGODB_RAPID=http://downloads.10gen.com/osx/mongodb-macos-x86_64-enterprise-5.3.1.tgz
+ MONGODB_60_LATEST=http://downloads.10gen.com/osx/mongodb-macos-x86_64-enterprise-v6.0-latest.tgz
+ MONGODB_60=http://downloads.10gen.com/osx/mongodb-macos-x86_64-enterprise-6.0.0-rc8.tgz
+ MONGODB_50=http://downloads.10gen.com/osx/mongodb-macos-x86_64-enterprise-5.0.9.tgz
+ MONGODB_44=http://downloads.10gen.com/osx/mongodb-macos-x86_64-enterprise-4.4.15.tgz
+ MONGODB_42=http://downloads.10gen.com/osx/mongodb-macos-x86_64-enterprise-4.2.21.tgz
+ MONGODB_40=http://downloads.10gen.com/osx/mongodb-osx-x86_64-enterprise-4.0.28.tgz
+ MONGODB_36=http://downloads.10gen.com/osx/mongodb-osx-x86_64-enterprise-3.6.23.tgz
+ MONGODB_34=http://downloads.10gen.com/osx/mongodb-osx-x86_64-enterprise-3.4.24.tgz
+ MONGODB_32=http://downloads.10gen.com/osx/mongodb-osx-x86_64-enterprise-3.2.22.tgz
+ MONGODB_30=https://fastdl.mongodb.org/osx/mongodb-osx-x86_64-3.0.15.tgz
+ MONGODB_26=https://fastdl.mongodb.org/osx/mongodb-osx-x86_64-2.6.12.tgz
+ MONGODB_24=https://fastdl.mongodb.org/osx/mongodb-osx-x86_64-2.4.14.tgz
+ case "$_DISTRO" in
+ case "$_DISTRO" in
+ case "$_VERSION" in
+ MONGODB_DOWNLOAD_URL=http://downloads.10gen.com/osx/mongodb-macos-x86_64-enterprise-6.0.0-rc8.tgz
+ '[' -z http://downloads.10gen.com/osx/mongodb-macos-x86_64-enterprise-6.0.0-rc8.tgz ']'
+ echo http://downloads.10gen.com/osx/mongodb-macos-x86_64-enterprise-6.0.0-rc8.tgz
http://downloads.10gen.com/osx/mongodb-macos-x86_64-enterprise-6.0.0-rc8.tgz
+ download_and_extract http://downloads.10gen.com/osx/mongodb-macos-x86_64-enterprise-6.0.0-rc8.tgz 'tar zxf'
+ MONGODB_DOWNLOAD_URL=http://downloads.10gen.com/osx/mongodb-macos-x86_64-enterprise-6.0.0-rc8.tgz
+ EXTRACT='tar zxf'
+ download_and_extract_package http://downloads.10gen.com/osx/mongodb-macos-x86_64-enterprise-6.0.0-rc8.tgz 'tar zxf'
+ MONGODB_DOWNLOAD_URL=http://downloads.10gen.com/osx/mongodb-macos-x86_64-enterprise-6.0.0-rc8.tgz
+ EXTRACT='tar zxf'
+ cd /Users/shane/git/drivers-evergreen-tools
+ curl --retry 8 -sS http://downloads.10gen.com/osx/mongodb-macos-x86_64-enterprise-6.0.0-rc8.tgz --max-time 300 --output mongodb-binaries.tgz
+ tar zxf mongodb-binaries.tgz
+ rm -f mongodb-binaries.tgz
+ mv mongodb-macos-x86_64-enterprise-6.0.0-rc8 mongodb
+ chmod -R +x mongodb
+ find . -name vcredist_x64.exe -exec '{}' /install /quiet ';'
+ ./mongodb/bin/mongod --version
db version v6.0.0-rc8
Build Info: {
    "version": "6.0.0-rc8",
    "gitVersion": "86cb7ea3649b2190958a1645de9d3df4a529fc90",
    "modules": [
        "enterprise"
    ],
    "allocator": "system",
    "environment": {
        "distarch": "x86_64",
        "target_arch": "x86_64"
    }
}
+ cd -
/Users/shane/tmp-test
+ '[' '!' -e /Users/shane/git/drivers-evergreen-tools/mongodb/bin/mongo -a '!' -e /Users/shane/git/drivers-evergreen-tools/mongodb/bin/mongo.exe ']'
+ echo 'Legacy '\''mongo'\'' shell not detected.'
Legacy 'mongo' shell not detected.
+ echo 'Download legacy shell from 5.0 ... begin'
Download legacy shell from 5.0 ... begin
+ get_mongodb_download_url_for darwin--x86_64 5.0
+ _DISTRO=darwin--x86_64
+ _VERSION=5.0
+ VERSION_RAPID=5.3.1
+ VERSION_60_LATEST=v6.0-latest
+ VERSION_60=6.0.0-rc8
+ VERSION_50=5.0.9
+ VERSION_44=4.4.15
+ VERSION_42=4.2.21
+ VERSION_40=4.0.28
+ VERSION_36=3.6.23
+ VERSION_34=3.4.24
+ VERSION_32=3.2.22
+ VERSION_30=3.0.15
+ VERSION_26=2.6.12
+ VERSION_24=2.4.14
+ EXTRACT='tar zxf'
+ case "$_DISTRO" in
+ MONGODB_LATEST=http://downloads.10gen.com/osx/mongodb-macos-x86_64-enterprise-latest.tgz
+ MONGODB_RAPID=http://downloads.10gen.com/osx/mongodb-macos-x86_64-enterprise-5.3.1.tgz
+ MONGODB_60_LATEST=http://downloads.10gen.com/osx/mongodb-macos-x86_64-enterprise-v6.0-latest.tgz
+ MONGODB_60=http://downloads.10gen.com/osx/mongodb-macos-x86_64-enterprise-6.0.0-rc8.tgz
+ MONGODB_50=http://downloads.10gen.com/osx/mongodb-macos-x86_64-enterprise-5.0.9.tgz
+ MONGODB_44=http://downloads.10gen.com/osx/mongodb-macos-x86_64-enterprise-4.4.15.tgz
+ MONGODB_42=http://downloads.10gen.com/osx/mongodb-macos-x86_64-enterprise-4.2.21.tgz
+ MONGODB_40=http://downloads.10gen.com/osx/mongodb-osx-x86_64-enterprise-4.0.28.tgz
+ MONGODB_36=http://downloads.10gen.com/osx/mongodb-osx-x86_64-enterprise-3.6.23.tgz
+ MONGODB_34=http://downloads.10gen.com/osx/mongodb-osx-x86_64-enterprise-3.4.24.tgz
+ MONGODB_32=http://downloads.10gen.com/osx/mongodb-osx-x86_64-enterprise-3.2.22.tgz
+ MONGODB_30=https://fastdl.mongodb.org/osx/mongodb-osx-x86_64-3.0.15.tgz
+ MONGODB_26=https://fastdl.mongodb.org/osx/mongodb-osx-x86_64-2.6.12.tgz
+ MONGODB_24=https://fastdl.mongodb.org/osx/mongodb-osx-x86_64-2.4.14.tgz
+ case "$_DISTRO" in
+ case "$_DISTRO" in
+ case "$_VERSION" in
+ MONGODB_DOWNLOAD_URL=http://downloads.10gen.com/osx/mongodb-macos-x86_64-enterprise-5.0.9.tgz
+ '[' -z http://downloads.10gen.com/osx/mongodb-macos-x86_64-enterprise-5.0.9.tgz ']'
+ echo http://downloads.10gen.com/osx/mongodb-macos-x86_64-enterprise-5.0.9.tgz
http://downloads.10gen.com/osx/mongodb-macos-x86_64-enterprise-5.0.9.tgz
+ SAVED_DRIVERS_TOOLS=/Users/shane/git/drivers-evergreen-tools
+ mkdir /Users/shane/git/drivers-evergreen-tools/legacy-shell-download
+ DRIVERS_TOOLS=/Users/shane/git/drivers-evergreen-tools/legacy-shell-download
+ download_and_extract_package http://downloads.10gen.com/osx/mongodb-macos-x86_64-enterprise-5.0.9.tgz 'tar zxf'
+ MONGODB_DOWNLOAD_URL=http://downloads.10gen.com/osx/mongodb-macos-x86_64-enterprise-5.0.9.tgz
+ EXTRACT='tar zxf'
+ cd /Users/shane/git/drivers-evergreen-tools/legacy-shell-download
+ curl --retry 8 -sS http://downloads.10gen.com/osx/mongodb-macos-x86_64-enterprise-5.0.9.tgz --max-time 300 --output mongodb-binaries.tgz
+ tar zxf mongodb-binaries.tgz
+ rm -f mongodb-binaries.tgz
+ mv mongodb-macos-x86_64-enterprise-5.0.9 mongodb
+ chmod -R +x mongodb
+ find . -name vcredist_x64.exe -exec '{}' /install /quiet ';'
+ ./mongodb/bin/mongod --version
db version v5.0.9
Build Info: {
    "version": "5.0.9",
    "gitVersion": "6f7dae919422dcd7f4892c10ff20cdc721ad00e6",
    "modules": [
        "enterprise"
    ],
    "allocator": "system",
    "environment": {
        "distarch": "x86_64",
        "target_arch": "x86_64"
    }
}
+ cd -
/Users/shane/tmp-test
+ '[' -e /Users/shane/git/drivers-evergreen-tools/legacy-shell-download/mongodb/bin/mongo ']'
+ cp /Users/shane/git/drivers-evergreen-tools/legacy-shell-download/mongodb/bin/mongo /Users/shane/git/drivers-evergreen-tools/mongodb/bin
+ DRIVERS_TOOLS=/Users/shane/git/drivers-evergreen-tools
+ rm -rf /Users/shane/git/drivers-evergreen-tools/legacy-shell-download
+ echo 'Download legacy shell from 5.0 ... end'
Download legacy shell from 5.0 ... end
++ date +%s
+ DL_END=1657227919
++ date +%s
+ MO_START=1657227919
+ '[' -z '' ']'
+ ORCHESTRATION_FILE=basic
+ '[' noauth = auth ']'
+ '[' nossl '!=' nossl ']'
+ '[' -n true ']'
+ ORCHESTRATION_FILE=basic-load-balancer
+ '[' '!' -z '' ']'
+ '[' '!' -z '' ']'
+ ORCHESTRATION_FILE=basic-load-balancer.json
+ ORCHESTRATION_FILE=configs/sharded_clusters/basic-load-balancer.json
+ '[' -f /configs/sharded_clusters/basic-load-balancer.json ']'
+ '[' -f /Users/shane/git/drivers-evergreen-tools/.evergreen/orchestration/configs/sharded_clusters/basic-load-balancer.json ']'
+ export ORCHESTRATION_FILE=/Users/shane/git/drivers-evergreen-tools/.evergreen/orchestration/configs/sharded_clusters/basic-load-balancer.json
+ ORCHESTRATION_FILE=/Users/shane/git/drivers-evergreen-tools/.evergreen/orchestration/configs/sharded_clusters/basic-load-balancer.json
+ perl -p -i -e 's|ABSOLUTE_PATH_REPLACEMENT_TOKEN|/Users/shane/git/drivers-evergreen-tools|g' /Users/shane/git/drivers-evergreen-tools/.evergreen/orchestration/configs/sharded_clusters/basic-load-balancer.json
+ export ORCHESTRATION_URL=http://localhost:8889/v1/sharded_clusters
+ ORCHESTRATION_URL=http://localhost:8889/v1/sharded_clusters
+ sh /Users/shane/git/drivers-evergreen-tools/.evergreen/start-orchestration.sh /Users/shane/git/drivers-evergreen-tools/.evergreen/orchestration
3.9.8 (v3.9.8:bb3fdcfe95, Nov  5 2021, 16:40:46)
[Clang 13.0.0 (clang-1300.0.29.3)]
OpenSSL 1.1.1l  24 Aug 2021
Collecting https://github.com/mongodb/mongo-orchestration/archive/master.tar.gz
  Using cached https://github.com/mongodb/mongo-orchestration/archive/master.tar.gz (75 kB)
Requirement already satisfied: bottle<0.12.20 in ./venv/lib/python3.9/site-packages (0.12.19)
Requirement already satisfied: pymongo<4,>=3.6 in /Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages (from mongo-orchestration==0.7.1.dev0) (3.11.4)
Requirement already satisfied: CherryPy<9.0.0,>=3.5.0 in ./venv/lib/python3.9/site-packages (from mongo-orchestration==0.7.1.dev0) (8.9.1)
Requirement already satisfied: six in /Users/shane/Library/Python/3.9/lib/python/site-packages (from CherryPy<9.0.0,>=3.5.0->mongo-orchestration==0.7.1.dev0) (1.15.0)
WARNING: You are using pip version 21.0.1; however, version 22.1.2 is available.
You should consider upgrading via the '/Users/shane/git/drivers-evergreen-tools/.evergreen/orchestration/venv/bin/python -m pip install --upgrade pip' command.
Package             Version
------------------- ----------
appdirs             1.4.4
astroid             2.4.2
bleach              3.3.0
bottle              0.12.19
certifi             2021.10.8
chardet             3.0.4
CherryPy            8.9.1
colorama            0.4.4
distlib             0.3.1
docutils            0.17
filelock            3.0.12
idna                2.10
importlib-metadata  3.10.0
isort               5.5.3
Jinja2              3.0.3
keyring             23.0.1
lazy-object-proxy   1.4.3
MarkupSafe          2.1.1
mccabe              0.6.1
mongo-orchestration 0.7.1.dev0
packaging           20.9
pip                 21.0.1
pkginfo             1.7.0
pyelftools          0.27
Pygments            2.8.1
pylint              2.6.0
pymongo             3.11.4
pyparsing           2.4.7
readme-renderer     29.0
requests            2.24.0
requests-toolbelt   0.9.1
rfc3986             1.4.0
setuptools          52.0.0
six                 1.15.0
toml                0.10.1
tqdm                4.60.0
twine               3.4.1
urllib3             1.25.10
virtualenv          20.4.2
webencodings        0.5.1
wheel               0.36.2
wrapt               1.12.1
zipp                3.4.1
WARNING: You are using pip version 21.0.1; however, version 22.1.2 is available.
You should consider upgrading via the '/Users/shane/git/drivers-evergreen-tools/.evergreen/orchestration/venv/bin/python -m pip install --upgrade pip' command.
/Users/shane/tmp-test
total 24
drwxr-xr-x  10 shane  staff  320 Jul  7 14:05 .
drwxr-xr-x  27 shane  staff  864 Jul  6 12:40 ..
drwxr-xr-x   5 shane  staff  160 Nov 30  2016 configs
drwxr-xr-x   3 shane  staff   96 Nov 30  2016 db
drwxr-xr-x   3 shane  staff   96 Nov 30  2016 lib
-rw-r--r--   1 shane  staff   85 Jul  7 14:05 orchestration.config
-rw-r--r--   1 shane  staff    0 Jul  7 14:05 out.log
-rw-r--r--   1 shane  staff   64 Dec 15  2020 require-api-version.js
-rw-r--r--   1 shane  staff   39 Jul  7 14:05 server.log
drwxr-xr-x   6 shane  staff  192 Jul  6 12:54 venv
{"service": "mongo-orchestration", "version": "0.9", "links": [{"rel": "get-releases", "href": "/v1/releases", "method": "GET"}, {"rel": "self", "href": "/v1", "method": "GET"}, {"method": "GET", "href": "/v1/servers", "rel": "get-servers"}, {"method": "POST", "href": "/v1/servers", "rel": "add-server"}, {"method": "POST", "href": "/v1/replica_sets", "rel": "add-replica-set"}, {"method": "GET", "href": "/v1/replica_sets", "rel": "get-replica-sets"}, {"method": "POST", "href": "/v1/sharded_clusters", "rel": "add-sharded-cluster"}, {"method": "GET", "href": "/v1/sharded_clusters", "rel": "get-sharded-clusters"}]}+ pwd
/Users/shane/tmp-test
+ curl --silent --show-error --data @/Users/shane/git/drivers-evergreen-tools/.evergreen/orchestration/configs/sharded_clusters/basic-load-balancer.json http://localhost:8889/v1/sharded_clusters --max-time 600 --fail -o tmp.json
+ cat tmp.json
{"id": "shard_cluster_1", "shards": [{"isReplicaSet": true, "_id": "9d21730f-f239-427a-a2f3-7ba698de9a6c", "id": "sh01", "tags": [], "links": [{"method": "GET", "href": "/v1/sharded_clusters/shard_cluster_1/shards/sh01", "rel": "get-shard-info"}, {"method": "GET", "href": "/v1/replica_sets/9d21730f-f239-427a-a2f3-7ba698de9a6c", "rel": "get-replica-set-info"}]}], "configsvrs": [{"id": "399a9d34-650d-42bd-a750-cab95c626b31", "mongodb_uri": "mongodb://localhost:1026/?replicaSet=399a9d34-650d-42bd-a750-cab95c626b31", "links": [{"method": "GET", "href": "/v1/servers/399a9d34-650d-42bd-a750-cab95c626b31", "rel": "get-server-info"}]}], "routers": [{"id": "32818458-5315-478d-839e-d616f0ef41f6", "hostname": "localhost:27017", "links": [{"method": "GET", "href": "/v1/servers/32818458-5315-478d-839e-d616f0ef41f6", "rel": "get-server-info"}]}, {"id": "9f2c1c93-676f-4de9-a2c5-8e708d2f7288", "hostname": "localhost:27018", "links": [{"method": "GET", "href": "/v1/servers/9f2c1c93-676f-4de9-a2c5-8e708d2f7288", "rel": "get-server-info"}]}], "mongodb_uri": "mongodb://localhost:27017,localhost:27018", "orchestration": "sharded_clusters", "links": [{"method": "GET", "href": "/v1/sharded_clusters", "rel": "get-sharded-clusters"}, {"method": "GET", "href": "/v1/sharded_clusters/shard_cluster_1", "rel": "get-sharded-cluster-info"}, {"method": "POST", "href": "/v1/sharded_clusters/shard_cluster_1", "rel": "sharded-cluster-command"}, {"method": "DELETE", "href": "/v1/sharded_clusters/shard_cluster_1", "rel": "delete-sharded-cluster"}, {"method": "POST", "href": "/v1/sharded_clusters/shard_cluster_1/shards", "rel": "add-shard"}, {"method": "GET", "href": "/v1/sharded_clusters/shard_cluster_1/shards", "rel": "get-shards"}, {"method": "GET", "href": "/v1/sharded_clusters/shard_cluster_1/configsvrs", "rel": "get-configsvrs"}, {"method": "GET", "href": "/v1/sharded_clusters/shard_cluster_1/routers", "rel": "get-routers"}, {"method": "POST", "href": "/v1/sharded_clusters/shard_cluster_1/routers", "rel": "add-router"}, {"rel": "service", "href": "/v1", "method": "GET"}, {"rel": "get-releases", "href": "/v1/releases", "method": "GET"}, {"method": "GET", "href": "/v1/sharded_clusters", "rel": "get-sharded-clusters"}, {"method": "POST", "href": "/v1/sharded_clusters", "rel": "self"}, {"method": "GET", "href": "/v1/replica_sets", "rel": "get-replica-sets"}, {"method": "GET", "href": "/v1/servers", "rel": "get-servers"}]}++ python -c 'import sys, json; j=json.load(open("tmp.json")); print(j["mongodb_auth_uri" if "mongodb_auth_uri" in j else "mongodb_uri"])'
++ tr -d '\r'
```

Before this change the script above would use the system installed mongodb (4.0 on my machine) and would fail:
```
...
2022-07-07 13:30:02,756 [DEBUG] mongo_orchestration.process:229 - execute process: mongos --config /var/folders/t0/h63967912lv9gj5m78g80wk80000gp/T/mongo-jkz03cy2 --port 27017
2022-07-07 13:30:02,759 [DEBUG] mongo_orchestration.process:166 - wait for 27017
BadValue: Illegal --setParameter parameter: "featureFlagLoadBalancer"
try 'mongos --help' for more information
2022-07-07 13:30:02,785 [DEBUG] mongo_orchestration.process:171 - process is not alive
2022-07-07 13:30:02,785 [ERROR] mongo_orchestration.servers:370 - Could not start Server. Please find server log below.
=====================================================
2022-07-07 13:30:02,786 [ERROR] mongo_orchestration.apps:68 - <function sh_create at 0x1022dfd30>
Traceback (most recent call last):
  File "/Users/shane/git/drivers-evergreen-tools/.evergreen/orchestration/venv/lib/python3.9/site-packages/mongo_orchestration/servers.py", line 345, in start
    self.proc, self.hostname = process.mprocess(
  File "/Users/shane/git/drivers-evergreen-tools/.evergreen/orchestration/venv/lib/python3.9/site-packages/mongo_orchestration/process.py", line 245, in mprocess
    if wait_for(proc, port, timeout):
  File "/Users/shane/git/drivers-evergreen-tools/.evergreen/orchestration/venv/lib/python3.9/site-packages/mongo_orchestration/process.py", line 172, in wait_for
    raise OSError("Process started, but died immediately")
OSError: Process started, but died immediately

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/shane/git/drivers-evergreen-tools/.evergreen/orchestration/venv/lib/python3.9/site-packages/mongo_orchestration/apps/__init__.py", line 66, in wrap
    return f(*arg, **kwd)
  File "/Users/shane/git/drivers-evergreen-tools/.evergreen/orchestration/venv/lib/python3.9/site-packages/mongo_orchestration/apps/sharded_clusters.py", line 68, in sh_create
    result = _sh_create(data)
  File "/Users/shane/git/drivers-evergreen-tools/.evergreen/orchestration/venv/lib/python3.9/site-packages/mongo_orchestration/apps/sharded_clusters.py", line 44, in _sh_create
    cluster_id = ShardedClusters().create(params)
  File "/Users/shane/git/drivers-evergreen-tools/.evergreen/orchestration/venv/lib/python3.9/site-packages/mongo_orchestration/sharded_clusters.py", line 498, in create
    cluster = ShardedCluster(params)
  File "/Users/shane/git/drivers-evergreen-tools/.evergreen/orchestration/venv/lib/python3.9/site-packages/mongo_orchestration/sharded_clusters.py", line 86, in __init__
    self.router_add(r)
  File "/Users/shane/git/drivers-evergreen-tools/.evergreen/orchestration/venv/lib/python3.9/site-packages/mongo_orchestration/sharded_clusters.py", line 287, in router_add
    self._routers.append(Servers().create(
  File "/Users/shane/git/drivers-evergreen-tools/.evergreen/orchestration/venv/lib/python3.9/site-packages/mongo_orchestration/servers.py", line 521, in create
    server.start(timeout)
  File "/Users/shane/git/drivers-evergreen-tools/.evergreen/orchestration/venv/lib/python3.9/site-packages/mongo_orchestration/servers.py", line 373, in start
    with open(logpath) as lp:
FileNotFoundError: [Errno 2] No such file or directory: '/var/folders/t0/h63967912lv9gj5m78g80wk80000gp/T/mongos-pk01l5vy/mongos.log'
2022-07-07 13:30:02,787 [DEBUG] mongo_orchestration.apps:55 - send_result(500)
```