### PR TITLE
Support "latest-build" version in mongodl

### DIFF
--- a/.evergreen/mongodl.py
+++ b/.evergreen/mongodl.py
@@ -236,7 +236,7 @@ def collate_mdb_version(left: str, right: str) -> int:
 
 def mdb_version_not_rc(version: str) -> bool:
     tup = version_tup(version)
-    return version[-1] == STABLE_MAX_RC
+    return tup[-1] == STABLE_MAX_RC
 
 
 class CacheDB:
@@ -262,10 +262,7 @@ class CacheDB:
             last_modified TEXT
         )''')
         db.create_collation('mdb_version', collate_mdb_version)
-        db.create_function('mdb_version_not_rc',
-                           1,
-                           mdb_version_not_rc,
-                           )
+        db.create_function('mdb_version_not_rc', 1, mdb_version_not_rc)
         return CacheDB(db)
 
     def __call__(

--- a/.evergreen/mongodl.py
+++ b/.evergreen/mongodl.py
@@ -491,7 +491,8 @@ class Cache:
             resp = urllib.request.urlopen(req)
         except urllib.error.HTTPError as e:
             if e.code != 304:
-                raise
+                raise RuntimeError(
+                    'Failed to download [{u}]'.format(u=url)) from e
             assert dest.is_file(), (
                 'The download cache is missing an expected file', dest)
             return DownloadResult(False, dest)

--- a/.evergreen/mongodl.py
+++ b/.evergreen/mongodl.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-
 """
 Download and extract MongoDB components.
 
@@ -33,7 +32,6 @@ from collections import namedtuple
 from contextlib import contextmanager
 from fnmatch import fnmatch
 from pathlib import Path, PurePath, PurePosixPath
-import re
 
 try:
     # We want to support Python3.4 for now, which does not have a 'typing' module

--- a/.evergreen/mongodl.py
+++ b/.evergreen/mongodl.py
@@ -761,14 +761,14 @@ def _expand_zip(ar: Path, dest: Path, pattern: 'str | None',
                 strip_components: int, test: bool) -> int:
     'Expand a .zip archive.'
     n_extracted = 0
-    with zipfile.ZipFile(ar, 'r') as zf:
+    with zipfile.ZipFile(str(ar), 'r') as zf:
         for item in zf.infolist():
             n_extracted += _maybe_extract_member(
                 dest,
                 PurePath(item.filename),
                 pattern,
                 strip_components,
-                item.is_dir(),
+                item.filename.endswith('/'),  ## Equivalent to: item.is_dir(),
                 lambda: zf.open(item, 'r'),
                 0o655,
                 test=test,


### PR DESCRIPTION
We cannot _perfectly_ reliably guess the URL to the latest builds, but we can usually get it right.