### PR TITLE
DRIVERS-2388 Remove journal from all configs.

### DIFF
--- a/.evergreen/orchestration/configs/replica_sets/auth-ssl.json
+++ b/.evergreen/orchestration/configs/replica_sets/auth-ssl.json
@@ -8,7 +8,6 @@
       "procParams": {
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
-        "journal": true,
         "oplogSize": 500,
         "port": 27017
       },
@@ -23,7 +22,6 @@
       "procParams": {
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
-        "journal": true,
         "oplogSize": 500,
         "port": 27018
       },
@@ -38,7 +36,6 @@
       "procParams": {
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
-        "journal": true,
         "port": 27019
       },
       "rsParams": {

--- a/.evergreen/orchestration/configs/replica_sets/auth.json
+++ b/.evergreen/orchestration/configs/replica_sets/auth.json
@@ -7,7 +7,6 @@
       "procParams": {
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
-        "journal": true,
         "oplogSize": 500,
         "port": 27017
       },
@@ -22,7 +21,6 @@
       "procParams": {
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
-        "journal": true,
         "oplogSize": 500,
         "port": 27018
       },
@@ -37,7 +35,6 @@
       "procParams": {
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
-        "journal": true,
         "port": 27019
       },
       "rsParams": {

--- a/.evergreen/orchestration/configs/replica_sets/basic-ssl.json
+++ b/.evergreen/orchestration/configs/replica_sets/basic-ssl.json
@@ -5,7 +5,6 @@
       "procParams": {
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
-        "journal": true,
         "oplogSize": 500,
         "port": 27017
       },
@@ -20,7 +19,6 @@
       "procParams": {
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
-        "journal": true,
         "oplogSize": 500,
         "port": 27018
       },
@@ -35,7 +33,6 @@
       "procParams": {
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
-        "journal": true,
         "port": 27019
       },
       "rsParams": {

--- a/.evergreen/orchestration/configs/replica_sets/basic.json
+++ b/.evergreen/orchestration/configs/replica_sets/basic.json
@@ -5,7 +5,6 @@
       "procParams": {
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
-        "journal": true,
         "oplogSize": 500,
         "port": 27017
       },
@@ -20,7 +19,6 @@
       "procParams": {
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
-        "journal": true,
         "oplogSize": 500,
         "port": 27018
       },
@@ -35,7 +33,6 @@
       "procParams": {
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
-        "journal": true,
         "port": 27019
       },
       "rsParams": {

--- a/.evergreen/orchestration/configs/replica_sets/disableTestCommands.json
+++ b/.evergreen/orchestration/configs/replica_sets/disableTestCommands.json
@@ -5,7 +5,6 @@
       "procParams": {
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
-        "journal": true,
         "oplogSize": 500,
         "port": 27017,
         "setParameter": {"enableTestCommands": 0}
@@ -21,7 +20,6 @@
       "procParams": {
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
-        "journal": true,
         "oplogSize": 500,
         "port": 27018,
         "setParameter": {"enableTestCommands": 0}
@@ -37,7 +35,6 @@
       "procParams": {
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
-        "journal": true,
         "port": 27019,
         "setParameter": {"enableTestCommands": 0}
       },

--- a/.evergreen/orchestration/configs/replica_sets/mmapv1.json
+++ b/.evergreen/orchestration/configs/replica_sets/mmapv1.json
@@ -5,7 +5,6 @@
       "procParams": {
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
-        "journal": true,
         "oplogSize": 500,
         "storageEngine": "mmapv1",
         "port": 27017
@@ -21,7 +20,6 @@
       "procParams": {
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
-        "journal": true,
         "oplogSize": 500,
         "storageEngine": "mmapv1",
         "port": 27018
@@ -37,7 +35,6 @@
       "procParams": {
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
-        "journal": true, 
         "port": 27019
       },
       "rsParams": {

--- a/.evergreen/orchestration/configs/replica_sets/single-node-auth-ssl.json
+++ b/.evergreen/orchestration/configs/replica_sets/single-node-auth-ssl.json
@@ -8,7 +8,6 @@
       "procParams": {
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
-        "journal": true,
         "oplogSize": 500,
         "port": 27017
       },

--- a/.evergreen/orchestration/configs/replica_sets/single-node-auth.json
+++ b/.evergreen/orchestration/configs/replica_sets/single-node-auth.json
@@ -8,7 +8,6 @@
       "procParams": {
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
-        "journal": true,
         "oplogSize": 500,
         "port": 27017
       },

--- a/.evergreen/orchestration/configs/servers/auth-aws.json
+++ b/.evergreen/orchestration/configs/servers/auth-aws.json
@@ -8,7 +8,6 @@
     "ipv6": true,
     "bind_ip": "127.0.0.1,::1",
     "logappend": true,
-    "journal": true,
     "port": 27017,
     "setParameter": {"enableTestCommands": 1, "authenticationMechanisms": "MONGODB-AWS,SCRAM-SHA-256,SCRAM-SHA-1"}
   }

--- a/.evergreen/orchestration/configs/servers/auth-ssl.json
+++ b/.evergreen/orchestration/configs/servers/auth-ssl.json
@@ -7,7 +7,6 @@
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
         "logappend": true,
-        "journal": true,
         "port": 27017
     },
     "sslParams": {

--- a/.evergreen/orchestration/configs/servers/auth.json
+++ b/.evergreen/orchestration/configs/servers/auth.json
@@ -8,7 +8,6 @@
     "ipv6": true,
     "bind_ip": "127.0.0.1,::1",
     "logappend": true,
-    "journal": true,
     "port": 27017
   }
 }

--- a/.evergreen/orchestration/configs/servers/basic-ssl.json
+++ b/.evergreen/orchestration/configs/servers/basic-ssl.json
@@ -5,7 +5,6 @@
       "ipv6": true,
       "bind_ip": "127.0.0.1,::1",
       "logappend": true,
-      "journal": true,
       "port": 27017
    },
    "sslParams": {

--- a/.evergreen/orchestration/configs/servers/basic.json
+++ b/.evergreen/orchestration/configs/servers/basic.json
@@ -4,7 +4,6 @@
     "ipv6": true,
     "bind_ip": "127.0.0.1,::1",
     "logappend": true,
-    "journal": true,
     "port": 27017
   }
 }

--- a/.evergreen/orchestration/configs/servers/disableTestCommands.json
+++ b/.evergreen/orchestration/configs/servers/disableTestCommands.json
@@ -4,7 +4,6 @@
     "ipv6": true,
     "bind_ip": "127.0.0.1,::1",
     "logappend": true,
-    "journal": true,
     "port": 27017,
     "setParameter": {"enableTestCommands": 0}
   }

--- a/.evergreen/orchestration/configs/servers/ecdsa-basic-tls-ocsp-disableStapling-singleEndpoint.json
+++ b/.evergreen/orchestration/configs/servers/ecdsa-basic-tls-ocsp-disableStapling-singleEndpoint.json
@@ -5,7 +5,6 @@
       "ipv6": true,
       "bind_ip": "127.0.0.1,::1",
       "logappend": true,
-      "journal": true,
       "port": 27017,
       "setParameter": {"failpoint.disableStapling":"{\"mode\":\"alwaysOn\"}}"}
    },

--- a/.evergreen/orchestration/configs/servers/ecdsa-basic-tls-ocsp-disableStapling.json
+++ b/.evergreen/orchestration/configs/servers/ecdsa-basic-tls-ocsp-disableStapling.json
@@ -5,7 +5,6 @@
       "ipv6": true,
       "bind_ip": "127.0.0.1,::1",
       "logappend": true,
-      "journal": true,
       "port": 27017,
       "setParameter": {"failpoint.disableStapling":"{\"mode\":\"alwaysOn\"}}"}
    },

--- a/.evergreen/orchestration/configs/servers/ecdsa-basic-tls-ocsp-mustStaple-disableStapling-singleEndpoint.json
+++ b/.evergreen/orchestration/configs/servers/ecdsa-basic-tls-ocsp-mustStaple-disableStapling-singleEndpoint.json
@@ -5,7 +5,6 @@
       "ipv6": true,
       "bind_ip": "127.0.0.1,::1",
       "logappend": true,
-      "journal": true,
       "port": 27017,
       "setParameter": {"failpoint.disableStapling":"{\"mode\":\"alwaysOn\"}}"}
    },

--- a/.evergreen/orchestration/configs/servers/ecdsa-basic-tls-ocsp-mustStaple-disableStapling.json
+++ b/.evergreen/orchestration/configs/servers/ecdsa-basic-tls-ocsp-mustStaple-disableStapling.json
@@ -5,7 +5,6 @@
       "ipv6": true,
       "bind_ip": "127.0.0.1,::1",
       "logappend": true,
-      "journal": true,
       "port": 27017,
       "setParameter": {"failpoint.disableStapling":"{\"mode\":\"alwaysOn\"}}"}
    },

--- a/.evergreen/orchestration/configs/servers/ecdsa-basic-tls-ocsp-mustStaple-singleEndpoint.json
+++ b/.evergreen/orchestration/configs/servers/ecdsa-basic-tls-ocsp-mustStaple-singleEndpoint.json
@@ -5,7 +5,6 @@
       "ipv6": true,
       "bind_ip": "127.0.0.1,::1",
       "logappend": true,
-      "journal": true,
       "port": 27017,
       "setParameter": {"ocspEnabled": true}
    },

--- a/.evergreen/orchestration/configs/servers/ecdsa-basic-tls-ocsp-mustStaple.json
+++ b/.evergreen/orchestration/configs/servers/ecdsa-basic-tls-ocsp-mustStaple.json
@@ -5,7 +5,6 @@
       "ipv6": true,
       "bind_ip": "127.0.0.1,::1",
       "logappend": true,
-      "journal": true,
       "port": 27017,
       "setParameter": {"ocspEnabled": true}
    },

--- a/.evergreen/orchestration/configs/servers/inmemory.json
+++ b/.evergreen/orchestration/configs/servers/inmemory.json
@@ -4,7 +4,6 @@
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
         "logappend": true,
-        "journal": true,
         "storageEngine": "inMemory",
         "port": 27017
     }

--- a/.evergreen/orchestration/configs/servers/mmapv1.json
+++ b/.evergreen/orchestration/configs/servers/mmapv1.json
@@ -4,7 +4,6 @@
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
         "logappend": true,
-        "journal": true,
         "storageEngine": "mmapv1",
         "port": 27017
     }

--- a/.evergreen/orchestration/configs/servers/rsa-basic-tls-ocsp-disableStapling-singleEndpoint.json
+++ b/.evergreen/orchestration/configs/servers/rsa-basic-tls-ocsp-disableStapling-singleEndpoint.json
@@ -5,7 +5,6 @@
       "ipv6": true,
       "bind_ip": "127.0.0.1,::1",
       "logappend": true,
-      "journal": true,
       "port": 27017,
       "setParameter": {"failpoint.disableStapling":"{\"mode\":\"alwaysOn\"}}"}
    },

--- a/.evergreen/orchestration/configs/servers/rsa-basic-tls-ocsp-disableStapling.json
+++ b/.evergreen/orchestration/configs/servers/rsa-basic-tls-ocsp-disableStapling.json
@@ -5,7 +5,6 @@
       "ipv6": true,
       "bind_ip": "127.0.0.1,::1",
       "logappend": true,
-      "journal": true,
       "port": 27017,
       "setParameter": {"failpoint.disableStapling":"{\"mode\":\"alwaysOn\"}}"}
    },

--- a/.evergreen/orchestration/configs/servers/rsa-basic-tls-ocsp-mustStaple-disableStapling-singleEndpoint.json
+++ b/.evergreen/orchestration/configs/servers/rsa-basic-tls-ocsp-mustStaple-disableStapling-singleEndpoint.json
@@ -5,7 +5,6 @@
       "ipv6": true,
       "bind_ip": "127.0.0.1,::1",
       "logappend": true,
-      "journal": true,
       "port": 27017,
       "setParameter": {"failpoint.disableStapling":"{\"mode\":\"alwaysOn\"}}"}
    },

--- a/.evergreen/orchestration/configs/servers/rsa-basic-tls-ocsp-mustStaple-disableStapling.json
+++ b/.evergreen/orchestration/configs/servers/rsa-basic-tls-ocsp-mustStaple-disableStapling.json
@@ -5,7 +5,6 @@
       "ipv6": true,
       "bind_ip": "127.0.0.1,::1",
       "logappend": true,
-      "journal": true,
       "port": 27017,
       "setParameter": {"failpoint.disableStapling":"{\"mode\":\"alwaysOn\"}}"}
    },

--- a/.evergreen/orchestration/configs/servers/rsa-basic-tls-ocsp-mustStaple-singleEndpoint.json
+++ b/.evergreen/orchestration/configs/servers/rsa-basic-tls-ocsp-mustStaple-singleEndpoint.json
@@ -5,7 +5,6 @@
       "ipv6": true,
       "bind_ip": "127.0.0.1,::1",
       "logappend": true,
-      "journal": true,
       "port": 27017,
       "setParameter": {"ocspEnabled": true}
    },

--- a/.evergreen/orchestration/configs/servers/rsa-basic-tls-ocsp-mustStaple.json
+++ b/.evergreen/orchestration/configs/servers/rsa-basic-tls-ocsp-mustStaple.json
@@ -5,7 +5,6 @@
       "ipv6": true,
       "bind_ip": "127.0.0.1,::1",
       "logappend": true,
-      "journal": true,
       "port": 27017,
       "setParameter": {"ocspEnabled": true}
    },

--- a/.evergreen/orchestration/configs/servers/versioned-api-testing.json
+++ b/.evergreen/orchestration/configs/servers/versioned-api-testing.json
@@ -5,7 +5,6 @@
     "ipv6": true,
     "bind_ip": "127.0.0.1,::1",
     "logappend": true,
-    "journal": true,
     "port": 27017,
     "setParameter": {"enableTestCommands": 1, "acceptApiVersion2":  1}
   }

--- a/.evergreen/orchestration/configs/servers/wiredtiger.json
+++ b/.evergreen/orchestration/configs/servers/wiredtiger.json
@@ -4,7 +4,6 @@
         "ipv6": true,
         "bind_ip": "127.0.0.1,::1",
         "logappend": true,
-        "journal": true,
         "storageEngine": "wiredTiger",
         "port": 27017
     }


### PR DESCRIPTION
DRIVERS-2388

Removes the `journal` option from all mongo-orchestration configs. Server version v6.1.0-rc0 no longer supports the `journal` configuration block, so specifying `journal` in these configs causes system failures with the latest server version. `journal` always defaults to `true`, so explicitly specifying it is also redundant.