### PR TITLE
DRIVERS-2405 Do not include crypt_shared on latest when less than 6.0.

### DIFF
--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -472,7 +472,11 @@ get_mongodb_download_url_for ()
    # The crypt_shared package is available on server 6.0 and newer.
    VERSION_INCLUDES_CRYPT_SHARED=YES
    case "$_VERSION" in
-      latest) MONGODB_DOWNLOAD_URL=$MONGODB_LATEST ;;
+      latest) MONGODB_DOWNLOAD_URL=$MONGODB_LATEST
+         # If latest is not at least 6.0 on this OS, the crypt_shared package will not be available.
+         if [ -z $MONGODB_60 ]; then
+           VERSION_INCLUDES_CRYPT_SHARED=NO
+         fi ;;
       rapid) MONGODB_DOWNLOAD_URL=$MONGODB_RAPID
          VERSION_INCLUDES_CRYPT_SHARED=NO ;;
       v6.0-latest) MONGODB_DOWNLOAD_URL=$MONGODB_60_LATEST ;;


### PR DESCRIPTION
[DRIVERS-2405](https://jira.mongodb.org/browse/DRIVERS-2405)

Enterprise auth tests were [failing](https://evergreen.mongodb.com/task/mongo_go_driver_enterprise_auth_tests__os_ssl_32~ubuntu1604_64_go_1_17_test_enterprise_auth_gssapi_a0066218d8942310155b64057c094448e90e3356_22_07_28_16_22_22) on Ubuntu 16.04 in the Go driver because we were unable to fetch the `crypt_shared` package on "latest". "latest" on Ubuntu 16.04 is less than 6.0, so crypt_shared is not even available. We should not fetch crypt_shared on OSes where "latest" is less than 6.0.

Here's a [patch](https://spruce.mongodb.com/version/62e424579ccd4e1b430c6cf7/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) of these changes fixing the auth tests in Go.