### PR TITLE
MONGOCRYPT-457 do not print newline in set-temp-creds.sh

### DIFF
--- a/.evergreen/csfle/set-temp-creds.sh
+++ b/.evergreen/csfle/set-temp-creds.sh
@@ -28,7 +28,7 @@ import boto3
 
 client = boto3.client('sts')
 credentials = client.get_session_token()["Credentials"]
-print (credentials["AccessKeyId"] + " " + credentials["SecretAccessKey"] + " " + credentials["SessionToken"])
+print (credentials["AccessKeyId"] + " " + credentials["SecretAccessKey"] + " " + credentials["SessionToken"], end="")
 EOF
 }
 


### PR DESCRIPTION
# Summary
- Do not print newline in `set-temp-creds.sh`.

# Background & Motivation

This [patch build](https://spruce.mongodb.com/task/mongo_go_driver_tests_42_plus_zlib_zstd_support__version~latest_os_ssl_40~windows_64_go_1_17_test_replicaset_auth_ssl_patch_f87317a97462447361004797b2e6d1023c61eaf4_62e805a0e3c3313b75ef96fb_22_08_01_16_56_02/tests?execution=0&sortBy=STATUS&sortDir=ASC) in the Go driver reproduces an HTTP 400 reported in PYTHON-3384.

[The logs](https://evergreen.mongodb.com/lobster/evergreen/test/mongo_go_driver_tests_42_plus_zlib_zstd_support__version~latest_os_ssl_40~windows_64_go_1_17_test_replicaset_auth_ssl_patch_f87317a97462447361004797b2e6d1023c61eaf4_62e805a0e3c3313b75ef96fb_22_08_01_16_56_02/0/test/#bookmarks=0%2C61&l=1&shareLine=16) show an extra `\r` appended to the session token header: `X-Amz-Security-Token:(redacted)\r\r\nX-Amz-Target:TrentService.Decrypt\r\n`.

This is due to the `set-temp-creds.sh` script including the trailing `\r` in the output.

This was not an error before the changes of [MONGOCRYPT-457](https://jira.mongodb.org/browse/MONGOCRYPT-457). [MONGOCRYPT-457](https://jira.mongodb.org/browse/MONGOCRYPT-457) only used `\n` to delimit headers.

Using this branch, this [patch build](https://spruce.mongodb.com/version/62e8178e562343662d8f6f30/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) in the Go driver passes.