### PR TITLE
MONGOCRYPT-457 Add back Python 2 support for CSFLE test setup

### DIFF
--- a/.evergreen/csfle/set-temp-creds.sh
+++ b/.evergreen/csfle/set-temp-creds.sh
@@ -24,11 +24,12 @@ set +o xtrace # Disable tracing.
 
 get_creds() {
     $PYTHON - "$@" << 'EOF'
+import sys
 import boto3
 
 client = boto3.client('sts')
 credentials = client.get_session_token()["Credentials"]
-print (credentials["AccessKeyId"] + " " + credentials["SecretAccessKey"] + " " + credentials["SessionToken"], end="")
+sys.stdout.write(credentials["AccessKeyId"] + " " + credentials["SecretAccessKey"] + " " + credentials["SessionToken"])
 EOF
 }
 


### PR DESCRIPTION
This improves https://github.com/mongodb-labs/drivers-evergreen-tools/pull/220 by adding back Python 2 support for CSFLE test setup. This is needed for maximum compat. For example the legacy python driver v3 still tests with Python 2.