### PR TITLE
DRIVERS-2377 use devprod-drivers project

### DIFF
--- a/.evergreen/csfle/gcpkms/create-and-setup-instance.sh
+++ b/.evergreen/csfle/gcpkms/create-and-setup-instance.sh
@@ -10,7 +10,7 @@ if [ -z "$GCPKMS_KEYFILE" -o -z "$GCPKMS_DRIVERS_TOOLS" -o -z "$GCPKMS_SERVICEAC
 fi
 
 # Set defaults.
-export GCPKMS_PROJECT=${GCPKMS_PROJECT:-"csfle-poc"}
+export GCPKMS_PROJECT=${GCPKMS_PROJECT:-"devprod-drivers"}
 export GCPKMS_ZONE=${GCPKMS_ZONE:-"us-east1-b"}
 export GCPKMS_IMAGEPROJECT=${GCPKMS_IMAGEPROJECT:-"debian-cloud"}
 export GCPKMS_IMAGEFAMILY=${GCPKMS_IMAGEFAMILY:-"debian-11"}


### PR DESCRIPTION
# Summary
- Use devprod-drivers as default GCP project.

# Background & Motivation
The integration tests added in DRIVERS-2377 were relying on a personal account.
https://jira.mongodb.org/browse/BUILD-15386 provided a service account with necessary permissions.
The project associated with the account is different.
