### PR TITLE
DRIVERS-2377 Specify a non-root ssh user

### DIFF
--- a/.evergreen/csfle/gcpkms/create-and-setup-instance.sh
+++ b/.evergreen/csfle/gcpkms/create-and-setup-instance.sh
@@ -32,14 +32,14 @@ echo "create-instance.sh ... end"
 # Otherwise SSH may fail. See https://cloud.google.com/compute/docs/troubleshooting/troubleshooting-ssh.
 wait_for_server () {
     for i in $(seq 300); do
-        if $GCPKMS_GCLOUD compute ssh "$GCPKMS_INSTANCENAME" --zone $GCPKMS_ZONE --project $GCPKMS_PROJECT --command "echo 'ping'" >/dev/null 2>&1; then
+        if SSHOUTPUT=$($GCPKMS_GCLOUD compute ssh "$GCPKMS_INSTANCENAME" --zone $GCPKMS_ZONE --project $GCPKMS_PROJECT --command "echo 'ping'" 2>&1); then
             echo "ssh succeeded"
             return 0
         else
             sleep 1
         fi
     done
-    echo "failed to ssh into '$GCPKMS_INSTANCENAME'"
+    echo "failed to ssh into '$GCPKMS_INSTANCENAME'. Output of last attempt: $SSHOUTPUT"
     return 1
 }
 echo "waiting for server to start ... begin"

--- a/.evergreen/csfle/gcpkms/create-and-setup-instance.sh
+++ b/.evergreen/csfle/gcpkms/create-and-setup-instance.sh
@@ -32,7 +32,8 @@ echo "create-instance.sh ... end"
 # Otherwise SSH may fail. See https://cloud.google.com/compute/docs/troubleshooting/troubleshooting-ssh.
 wait_for_server () {
     for i in $(seq 300); do
-        if SSHOUTPUT=$($GCPKMS_GCLOUD compute ssh "$GCPKMS_INSTANCENAME" --zone $GCPKMS_ZONE --project $GCPKMS_PROJECT --command "echo 'ping'" 2>&1); then
+        # Specify the non-root username "gcpkms". The instance may be configured to not permit root login.
+        if SSHOUTPUT=$($GCPKMS_GCLOUD compute ssh "gcpkms@$GCPKMS_INSTANCENAME" --zone $GCPKMS_ZONE --project $GCPKMS_PROJECT --command "echo 'ping'" 2>&1); then
             echo "ssh succeeded"
             return 0
         else


### PR DESCRIPTION
# Summary
- Specify a non-root ssh user for GCP script.
- Capture output of last failed ssh attempt.

# Background & Motivation

The GCE `debian-11` instance disables root login over ssh. The contents of `/etc/ssh/sshd_config` contain `PermitRootLogin no`.
The default user on the Evergreen distro `rhel70-small` is `root`. This appears to be the cause of observed [task failures on the ssh command](https://spruce.mongodb.com/task/mongo_java_driver_testgcpkms_variant_testgcpkms_task_patch_6a2389083a9b744bb771fdf2ce767d84adda7803_62f256f10ae606469f19ddb6_22_08_09_12_45_37/logs?execution=0) with the message `Permission denied (publickey)`.


