### PR TITLE
CSHARP-4254 use pwd for download_and_extract_crypt_shared

### DIFF
--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -586,5 +586,5 @@ download_and_extract_crypt_shared ()
    rm -rf crypt_shared_download
 
    RELATIVE_CRYPT_SHARED_LIB_PATH="$(find . -maxdepth 1 -type f \( -name "$LIBRARY_NAME.dll" -o -name "$LIBRARY_NAME.so" -o -name "$LIBRARY_NAME.dylib" \))"
-   eval $__CRYPT_SHARED_LIB_PATH=$DRIVERS_TOOLS/../$(basename $RELATIVE_CRYPT_SHARED_LIB_PATH)
+   eval $__CRYPT_SHARED_LIB_PATH=$(pwd)/$(basename $RELATIVE_CRYPT_SHARED_LIB_PATH)
 }

--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -586,5 +586,10 @@ download_and_extract_crypt_shared ()
    rm -rf crypt_shared_download
 
    RELATIVE_CRYPT_SHARED_LIB_PATH="$(find . -maxdepth 1 -type f \( -name "$LIBRARY_NAME.dll" -o -name "$LIBRARY_NAME.so" -o -name "$LIBRARY_NAME.dylib" \))"
-   eval $__CRYPT_SHARED_LIB_PATH=$(pwd)/$(basename $RELATIVE_CRYPT_SHARED_LIB_PATH)
+   ABSOLUTE_CRYPT_SHARED_LIB_PATH=$(pwd)/$(basename $RELATIVE_CRYPT_SHARED_LIB_PATH)
+   if [ "Windows_NT" = "$OS" ]; then
+      # If we're on Windows, convert the "cygdrive" path to Windows-style paths.
+      ABSOLUTE_CRYPT_SHARED_LIB_PATH=$(cygpath -m $ABSOLUTE_CRYPT_SHARED_LIB_PATH)
+   fi
+   eval $__CRYPT_SHARED_LIB_PATH=$ABSOLUTE_CRYPT_SHARED_LIB_PATH
 }


### PR DESCRIPTION
# Summary
- Fix `CRYPT_SHARED_LIB_PATH` expansion for any working directory.

# Background & Motivation
`download_and_extract_crypt_shared` downloads the shared library to the current working directory.
The `CRYPT_SHARED_LIB_PATH` expansion added in https://github.com/mongodb-labs/drivers-evergreen-tools/pull/221/files assumes `run-orchestration.sh` is run from a directory containing `drivers-evergreen-tools`.
The Go driver does not run `run-orchestration.sh` from a directory containing `drivers-evergreen-tools`. From inspecting a patch build:
- `run-orchestration.sh` is run from this directory: `/data/mci/d5418d166b5347697731a2d43e6fae62`
- `drivers-evergreen-tools` is located in this directory: `/data/mci/d5418d166b5347697731a2d43e6fae62/src/go.mongodb.org/mongo-driver/../drivers-tools`
This results in an incorrect `CRYPT_SHARED_LIB_PATH` expansion when `run-orchestration.sh`.

Tested with the Go driver in this [patch build](https://spruce.mongodb.com/task/mongo_go_driver_tests_42_plus_zlib_zstd_support__version~6.0_os_ssl_40~windows_64_go_1_17_test_replicaset_auth_ssl_patch_ea15bb40a6b4b5f179a633108d4005e1bb9077e0_62fa78d62a60ed361620e456_22_08_15_16_48_23/logs?execution=0).