### PR TITLE
DRIVERS-2400 add SERVERLESS_MONGODB_VERSION to serverless-expansion

### DIFF
--- a/.evergreen/serverless/create-instance.sh
+++ b/.evergreen/serverless/create-instance.sh
@@ -88,6 +88,7 @@ DIR=$(dirname $0)
 while [ true ]; do
     API_RESPONSE=`SERVERLESS_INSTANCE_NAME=$SERVERLESS_INSTANCE_NAME bash $DIR/get-instance.sh`
     STATE_NAME=`echo $API_RESPONSE | $PYTHON_BINARY -c "import sys, json; print(json.load(sys.stdin)['stateName'])" | tr -d '\r\n'`
+    SERVERLESS_MONGODB_VERSION=`echo $API_RESPONSE | $PYTHON_BINARY -c "import sys, json; print(json.load(sys.stdin)['mongoDBVersion'])" | tr -d '\r\n'`
 
     if [ "$STATE_NAME" = "IDLE" ]; then
         duration="$SECONDS"
@@ -110,6 +111,7 @@ TOPOLOGY: "sharded_cluster"
 SERVERLESS: "serverless"
 SINGLE_ATLASPROXY_SERVERLESS_URI: "$SERVERLESS_URI"
 MULTI_ATLASPROXY_SERVERLESS_URI: "$SERVERLESS_URI"
+SERVERLESS_MONGODB_VERSION: "$SERVERLESS_MONGODB_VERSION"
 EOF
         exit 0
     else


### PR DESCRIPTION
# Summary
- add SERVERLESS_MONGODB_VERSION to serverless-expansion

# Background & Motivation
Testing Client Side Encryption with Serverless requires downloading a version of the `mongo_crypt` shared library matching the version of the MongoDB Server.