### PR TITLE
DRIVERS-2450: bump ADL golang version to 1.18

### DIFF
--- a/.evergreen/atlas_data_lake/build-mongohouse-local.sh
+++ b/.evergreen/atlas_data_lake/build-mongohouse-local.sh
@@ -12,7 +12,7 @@ git config --global url."git@github.com:".insteadof "https://github.com/"
 AP_START=$(date +%s)
 
 # Set up environment variables for Go
-GO_VERSION=1.19
+GO_VERSION=1.18
 if [ "Windows_NT" = "$OS" ]; then
   export GOPATH="$(cygpath -m "$(pwd)")/.gopath"
   export GOCACHE="$(cygpath -m "$(pwd)")/.cache"

--- a/.evergreen/atlas_data_lake/build-mongohouse-local.sh
+++ b/.evergreen/atlas_data_lake/build-mongohouse-local.sh
@@ -12,7 +12,7 @@ git config --global url."git@github.com:".insteadof "https://github.com/"
 AP_START=$(date +%s)
 
 # Set up environment variables for Go
-GO_VERSION=1.17
+GO_VERSION=1.19
 if [ "Windows_NT" = "$OS" ]; then
   export GOPATH="$(cygpath -m "$(pwd)")/.gopath"
   export GOCACHE="$(cygpath -m "$(pwd)")/.cache"


### PR DESCRIPTION
Patch on node using this branch: https://spruce.mongodb.com/task/mongo_node_driver_next_ubuntu_18.04_gallium_test_atlas_data_lake_patch_8c63447f8bcfb6a71d1838444fd87d9c251106b0_6331ee6956234317acab0ba2_22_09_26_18_24_53/logs?execution=1
ADL requires 18+, I put 19 to hopefully kick bumping this again a little further down the road.

edit: Could not use 19, wasn't available on the host