### PR TITLE
Move dos2unix from venvactivate to venvcreate

### DIFF
--- a/.evergreen/utils.sh
+++ b/.evergreen/utils.sh
@@ -17,6 +17,13 @@ venvcreate () {
         exit 1
     fi
     $VENV "$VENVPATH"
+
+    # Workaround https://bugs.python.org/issue32451:
+    # mongovenv/Scripts/activate: line 3: $'\r': command not found
+    if [ "Windows_NT" = "$OS" ]; then
+        dos2unix "$VENVPATH/Scripts/activate" || true
+    fi
+
     venvactivate "$VENVPATH"
 
     python -m pip install --upgrade pip
@@ -29,9 +36,6 @@ venvcreate () {
 venvactivate () {
     VENVPATH="$1"
     if [ "Windows_NT" = "$OS" ]; then
-        # Workaround https://bugs.python.org/issue32451:
-        # mongovenv/Scripts/activate: line 3: $'\r': command not found
-        dos2unix "$VENVPATH/Scripts/activate" || true
         . $VENVPATH/Scripts/activate
     else
         . $VENVPATH/bin/activate


### PR DESCRIPTION
If two or more tasks on Evergreen invokes `venvactivate` in parallel, there is the possibility that the call to `dos2unix` may race and subsequently fail with the following error:
```
dos2unix: problems renaming 'kmstlsvenv/Scripts/d2utmpDAd1Fo' to 'kmstlsvenv/Scripts/activate': Permission denied
          output file remains in 'kmstlsvenv/Scripts/d2utmpDAd1Fo'
dos2unix: problems converting file kmstlsvenv/Scripts/activate
```
This PR proposes moving the `dos2unix` call into `venvcreate` immediately after creation of `$VENVPATH` to allow for safe subsequent parallel invocations of `venvactivate`.