### PR TITLE
Add hygienic alternatives to Python virtual environment scripts

### DIFF
--- a/.evergreen/csfle/activate-kmstlsvenv.sh
+++ b/.evergreen/csfle/activate-kmstlsvenv.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# activate-kmstlsvenv.sh
+#
+# Usage:
+#   . ./activate-kmstlsvenv.sh
+#
+# This file creates and activates the kmstlsvenv virtual environment in the
+# current working directory. This file must be invoked from within the
+# .evergreen/csfle directory in the Drivers Evergreen Tools repository.
+
+# Automatically invoked by activate-kmstlsvenv.sh.
+activate_kmstlsvenv() {
+  # shellcheck source=.evergreen/venv-utils.sh
+  . ../venv-utils.sh || return 1
+
+  if [[ -d kmstlsvenv ]]; then
+    venvactivate kmstlsvenv
+  else
+    # shellcheck source=.evergreen/find-python3.sh
+    . ../find-python3.sh || return 1
+
+    venvcreate "$(find_python3)" kmstlsvenv || return 1
+
+    CRYPTOGRAPHY_DONT_BUILD_RUST=1 python -m pip install --upgrade boto3~=1.19 cryptography~=3.4.8 pykmip~=0.10.0
+  fi
+}
+
+activate_kmstlsvenv

--- a/.evergreen/csfle/activate-kmstlsvenv.sh
+++ b/.evergreen/csfle/activate-kmstlsvenv.sh
@@ -12,15 +12,15 @@
 # Automatically invoked by activate-kmstlsvenv.sh.
 activate_kmstlsvenv() {
   # shellcheck source=.evergreen/venv-utils.sh
-  . ../venv-utils.sh || return 1
+  . ../venv-utils.sh || return
 
   if [[ -d kmstlsvenv ]]; then
     venvactivate kmstlsvenv
   else
     # shellcheck source=.evergreen/find-python3.sh
-    . ../find-python3.sh || return 1
+    . ../find-python3.sh || return
 
-    venvcreate "$(find_python3)" kmstlsvenv || return 1
+    venvcreate "$(find_python3)" kmstlsvenv || return
 
     CRYPTOGRAPHY_DONT_BUILD_RUST=1 python -m pip install --upgrade boto3~=1.19 cryptography~=3.4.8 pykmip~=0.10.0
   fi

--- a/.evergreen/find-python3.sh
+++ b/.evergreen/find-python3.sh
@@ -184,8 +184,14 @@ find_python3() (
     append_bins "/opt/mongodbtoolchain" "v[0-9]*" "bin/python3" "bin/python"
   } 1>&2
 
-  # For diagnostic purposes.
   {
+    # Some environments trigger an unbound variable error if "${bins[@]}" is empty when used below.
+    if (("${#bins[@]}" == 0)); then
+      echo "Could not find any python3 binaries!"
+      return 1
+    fi
+
+    # For diagnostic purposes.
     echo "List of python3 binaries to test:"
     for bin in "${bins[@]}"; do
       echo " - $bin"

--- a/.evergreen/find-python3.sh
+++ b/.evergreen/find-python3.sh
@@ -35,14 +35,10 @@ is_python3() (
   local -r bin="${1:?'is_python3 requires a name or path of a python binary to test'}"
 
   # Binary must be executable.
-  if ! command -V "$bin" &>/dev/null; then
-    return 1
-  fi
+  command -V "$bin" &>/dev/null || return 1
 
   # Reject binaries that do not support argument "-V".
-  if ! "$bin" -V &>/dev/null; then
-    return 1
-  fi
+  "$bin" -V &>/dev/null || return 1
 
   # Expect an output of the form: "Python x.y.z".
   # Note: Python 2 binaries output to stderr rather than stdout.

--- a/.evergreen/find-python3.sh
+++ b/.evergreen/find-python3.sh
@@ -44,12 +44,15 @@ is_python3() (
   # Note: Python 2 binaries output to stderr rather than stdout.
   local -r version_output="$("$bin" -V 2>&1)"
 
+  # For diagnostic purposes.
+  echo " - $bin: $version_output"
+
   # "Python x.y.z" -> "x.y.z"
   local -r version_str="$(perl -lne 'print $1 if m/.*([0-9]+\.[0-9]+\.[0-9]*)/' -- <(printf "%s" "$version_output"))"
 
   # Evaluate 3.0.0 <= x.y.z.
   sort -CV -- <(printf "%s\n%s\n" "3.0.0" "$version_str")
-)
+) 1>&2
 
 # is_venv_capable
 #
@@ -152,6 +155,8 @@ find_python3() (
   # The list of Python binaries to test for venv or virtualenv support.
   # The binaries are tested in the order of their position in the array.
   {
+    echo "Finding python3 binaries to test..."
+
     append_bins() {
       local -r path="${1:?'missing path'}"
       shift

--- a/.evergreen/find-python3.sh
+++ b/.evergreen/find-python3.sh
@@ -66,6 +66,7 @@ is_python3() (
 # Return 0 (true) if the given argument "$1" can successfully evaluate the
 # command:
 #   "$1" -m venv venv
+# and activate the created virtual environment.
 # Return a non-zero value (false) otherwise.
 #
 # Diagnostic messages may be printed to stderr (pipe 2). Redirect to /dev/null
@@ -81,8 +82,16 @@ is_venv_capable() (
   local -r tmp="$(mktemp -d)"
   trap 'rm -rf "$tmp"' EXIT
 
-  # Evaluate the result of this function.
-  "$bin" -m venv "$tmp" 1>&2
+  "$bin" -m venv "$tmp" || return 1
+
+  if [[ -f "$tmp/bin/activate" ]]; then
+    # shellcheck source=/dev/null
+    . "$tmp/bin/activate"
+  else
+    dos2unix "$tmp/Scripts/activate" || true
+    # shellcheck source=/dev/null
+    . "$tmp/Scripts/activate"
+  fi
 ) 1>&2
 
 # is_virtualenv_capable
@@ -97,6 +106,7 @@ is_venv_capable() (
 # Return 0 (true) if the given argument $1 can successfully evaluate the
 # command:
 #   "$1" -m virtualenv -p "$1" venv
+# and activate the created virtual environment.
 # Return a non-zero value (false) otherwise.
 #
 # Diagnostic messages may be printed to stderr (pipe 2). Redirect to /dev/null
@@ -112,8 +122,16 @@ is_virtualenv_capable() (
   local -r tmp="$(mktemp -d)"
   trap 'rm -rf "$tmp"' EXIT
 
-  # Evaluate the result of this function.
-  "$bin" -m virtualenv -p "$bin" "$tmp" 1>&2
+  "$bin" -m virtualenv -p "$bin" "$tmp" || return 1
+
+  if [[ -f "$tmp/bin/activate" ]]; then
+    # shellcheck source=/dev/null
+    . "$tmp/bin/activate"
+  else
+    dos2unix "$tmp/Scripts/activate" || true
+    # shellcheck source=/dev/null
+    . "$tmp/Scripts/activate"
+  fi
 ) 1>&2
 
 # find_python3

--- a/.evergreen/find-python3.sh
+++ b/.evergreen/find-python3.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 #
-# find-python.sh
+# find-python3.sh
 #
 # Usage:
-#   . /path/to/find-python.sh
+#   . /path/to/find-python3.sh
 #
 # This file defines the following utility functions:
 #   - is_python3
@@ -78,7 +78,7 @@ is_venv_capable() (
 
   local -r bin="${1:?'is_venv_capable requires a name or path of a python binary to test'}"
 
-  # Use a temporary directory to avoid polluting the caller's enviornment.
+  # Use a temporary directory to avoid polluting the caller's environment.
   local -r tmp="$(mktemp -d)"
   trap 'rm -rf "$tmp"' EXIT
 
@@ -109,7 +109,7 @@ is_virtualenv_capable() (
 
   local -r bin="${1:?'is_virtualenv_capable requires a name or path of a python binary to test'}"
 
-  # Use a temporary directory to avoid polluting the caller's enviornment.
+  # Use a temporary directory to avoid polluting the caller's environment.
   local -r tmp="$(mktemp -d)"
   trap 'rm -rf "$tmp"' EXIT
 

--- a/.evergreen/find-python3.sh
+++ b/.evergreen/find-python3.sh
@@ -47,7 +47,9 @@ is_python3() (
   # For diagnostic purposes.
   echo " - $bin: $version_output"
 
-  # Evaluate result of this function (zero == true).
+  # Evaluate result of this function.
+  # Note: Python True (1) and False (0) is treated as fail (1) and success (0)
+  # by Bash; therefore `is_python3` returns "true" when `v < 3` is false.
   "$bin" -c "import sys; exit(sys.version_info[0] < 3)"
 ) 1>&2
 

--- a/.evergreen/find-python3.sh
+++ b/.evergreen/find-python3.sh
@@ -47,11 +47,8 @@ is_python3() (
   # For diagnostic purposes.
   echo " - $bin: $version_output"
 
-  # "Python x.y.z" -> "x.y.z"
-  local -r version_str="$(perl -lne 'print $1 if m/.*([0-9]+\.[0-9]+\.[0-9]*)/' -- <(printf "%s" "$version_output"))"
-
-  # Evaluate 3.0.0 <= x.y.z.
-  sort -CV -- <(printf "%s\n%s\n" "3.0.0" "$version_str")
+  # Evaluate result of this function (zero == true).
+  "$bin" -c "import sys; exit(sys.version_info[0] < 3)"
 ) 1>&2
 
 # is_venv_capable

--- a/.evergreen/find-python3.sh
+++ b/.evergreen/find-python3.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+#
+# find-python.sh
+#
+# Usage:
+#   . /path/to/find-python.sh
+#
+# This file defines the following utility functions:
+#   - is_python3
+#   - is_venv_capable
+#   - is_virtualenv_capable
+#   - find_python3
+# These functions may be invoked from any working directory.
+
+# is_python3
+#
+# Usage:
+#   is_python3 python
+#   is_python3 /path/to/python
+#
+# Parameters:
+#   "$1": The name or path of the python binary to test.
+#
+# Return 0 (true) if the given argument "$1" is a Python 3 binary.
+# Return a non-zero value (false) otherwise.
+#
+# Diagnostic messages may be printed to stderr (pipe 2). Redirect to /dev/null
+# to silence these messages.
+is_python3() (
+  set -o errexit
+  set -o nounset
+  set -o pipefail
+
+  # Binary to use, e.g. "python".
+  local -r bin="${1:?'is_python requires a name or path of a python binary to test'}"
+
+  # Binary must be executable.
+  if ! command -V "$bin" &>/dev/null; then
+    return 1
+  fi
+
+  # Reject binaries that do not support argument "-V".
+  if ! "$bin" -V &>/dev/null; then
+    return 1
+  fi
+
+  # Expect an output of the form: "Python x.y.z".
+  # Note: Python 2 binaries output to stderr rather than stdout.
+  local -r version_output="$("$bin" -V 2>&1)"
+
+  # "Python x.y.z" -> "x.y.z"
+  local -r version_str="$(perl -lne 'print $1 if m/.*([0-9]+\.[0-9]+\.[0-9]*)/' -- <(printf "%s" "$version_output"))"
+
+  # Evaluate 3.0.0 <= x.y.z.
+  sort -CV -- <(printf "%s\n%s\n" "3.0.0" "$version_str")
+)
+
+# is_venv_capable
+#
+# Usage:
+#   is_venv_capable python
+#   is_venv_capable /path/to/python
+#
+# Parameters:
+#   "$1": The name or path of the python binary to test.
+#
+# Return 0 (true) if the given argument "$1" can successfully evaluate the
+# command:
+#   "$1" -m venv venv
+# Return a non-zero value (false) otherwise.
+#
+# Diagnostic messages may be printed to stderr (pipe 2). Redirect to /dev/null
+# to silence these messages.
+is_venv_capable() (
+  set -o errexit
+  set -o nounset
+  set -o pipefail
+
+  local -r bin="${1:?'is_venv_capable requires a name or path of a python binary to test'}"
+
+  # Use a temporary directory to avoid polluting the caller's enviornment.
+  local -r tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' EXIT
+
+  # Evaluate the result of this function.
+  "$bin" -m venv "$tmp" 1>&2
+) 1>&2
+
+# is_virtualenv_capable
+#
+# Usage:
+#   is_virtualenv_capable python
+#   is_virtualenv_capable /path/to/python
+#
+# Parameters:
+#   "$1": The name or path of the python binary to test.
+#
+# Return 0 (true) if the given argument $1 can successfully evaluate the
+# command:
+#   "$1" -m virtualenv -p "$1" venv
+# Return a non-zero value (false) otherwise.
+#
+# Diagnostic messages may be printed to stderr (pipe 2). Redirect to /dev/null
+# to silence these messages.
+is_virtualenv_capable() (
+  set -o errexit
+  set -o nounset
+  set -o pipefail
+
+  local -r bin="${1:?'is_virtualenv_capable requires a name or path of a python binary to test'}"
+
+  # Use a temporary directory to avoid polluting the caller's enviornment.
+  local -r tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' EXIT
+
+  # Evaluate the result of this function.
+  "$bin" -m virtualenv -p "$bin" "$tmp" 1>&2
+) 1>&2
+
+# find_python3
+#
+# Usage:
+#   find_python3
+#   PYTHON_BINARY=$(find_python3)
+#   PYTHON_BINARY=$(find_python3 2>/dev/null)
+#
+# Return 0 (true) if a Python 3 binary capable of creating a virtual environment
+# with either venv or virtualenv can be found.
+# Return a non-zero (false) value otherwise.
+#
+# If successful, print the name of the binary stdout (pipe 1).
+# Otherwise, no output is printed to stdout (pipe 1).
+#
+# Diagnostic messages may be printed to stderr (pipe 2). Redirect to /dev/null
+# with `2>/dev/null` to silence these messages.
+#
+# Example:
+#   PYTHON_BINARY=$(find_python3)
+#   if [[ -z "$PYTHON_BINARY" ]]; then
+#     # Handle missing Python binary situation.
+#   fi
+#
+#   if "$PYTHON_BINARY" -m venv -h; then
+#     "$PYTHON_BINARY" -m venv venv
+#   else
+#     "$PYTHON_BINARY" -m virtualenv -p "$PYTHON_BINARY" venv
+#   fi
+find_python3() (
+  set -o errexit
+  set -o nounset
+  set -o pipefail
+
+  local -a bins=()
+  local bin=""
+
+  # The list of Python binaries to test for venv or virtualenv support.
+  # The binaries are tested in the order of their position in the array.
+  {
+    append_bins() {
+      local -r path="${1:?'missing path'}"
+      shift
+      local -r pattern="${1:?'missing pattern'}"
+      shift
+      local -ar suffixes=("${@:?'missing suffixes'}")
+
+      for dir in $(find "$path" -maxdepth 1 -name "$pattern" -type d 2>/dev/null | sort -rV); do
+        for bin in "${suffixes[@]}"; do
+          if is_python3 "$dir/$bin"; then
+            bins+=("$dir/$bin")
+          fi
+        done
+      done
+    }
+
+    # /opt/mongodbtoolchain/vX/bin/python
+    append_bins "/opt/mongodbtoolchain" "v[0-9]*" "bin/python3" "bin/python"
+
+    # /opt/python/3.X/bin/python
+    append_bins "/opt/python" "3.[0-9]*" "bin/python3" "bin/python"
+
+    # C:/python/Python3X/bin/python
+    append_bins "C:/python" "Python3[0-9]*" "python3.exe" "python.exe"
+
+    bin="python3"
+    if is_python3 "$bin"; then bins+=("$bin"); fi
+
+    bin="python"
+    if is_python3 "$bin"; then bins+=("$bin"); fi
+  } 1>&2
+
+  # For diagnostic purposes.
+  {
+    echo "List of python3 binaries to test:"
+    for bin in "${bins[@]}"; do
+      echo " - $bin"
+    done
+  } 1>&2
+
+  # Find a binary that is capable of venv or virtualenv and set it as `res`.
+  local res=""
+  {
+    echo "Testing python3 binaries..."
+    for bin in "${bins[@]}"; do
+      {
+        if ! is_venv_capable "$bin"; then
+          echo " - $bin is not capable of venv"
+
+          if ! is_virtualenv_capable "$bin"; then
+            echo " - $bin is not capable of virtualenv"
+            continue
+          else
+            echo " - $bin is capable of virtualenv"
+          fi
+        else
+          echo " - $bin is capable of venv"
+        fi
+      } 1>&2
+
+      res="$bin"
+      break
+    done
+
+    if [[ -z "$res" ]]; then
+      echo "Could not find a python3 binary capable of creating a virtual environment!"
+      return 1
+    fi
+  } 1>&2
+
+  echo "$res"
+
+  return 0
+)

--- a/.evergreen/find-python3.sh
+++ b/.evergreen/find-python3.sh
@@ -35,10 +35,10 @@ is_python3() (
   local -r bin="${1:?'is_python3 requires a name or path of a python binary to test'}"
 
   # Binary must be executable.
-  command -V "$bin" &>/dev/null || return 1
+  command -V "$bin" &>/dev/null || return
 
   # Reject binaries that do not support argument "-V".
-  "$bin" -V &>/dev/null || return 1
+  "$bin" -V &>/dev/null || return
 
   # Expect an output of the form: "Python x.y.z".
   # Note: Python 2 binaries output to stderr rather than stdout.
@@ -82,7 +82,7 @@ is_venv_capable() (
   local -r tmp="$(mktemp -d)"
   trap 'rm -rf "$tmp"' EXIT
 
-  "$bin" -m venv "$tmp" || return 1
+  "$bin" -m venv "$tmp" || return
 
   if [[ -f "$tmp/bin/activate" ]]; then
     # shellcheck source=/dev/null
@@ -122,7 +122,7 @@ is_virtualenv_capable() (
   local -r tmp="$(mktemp -d)"
   trap 'rm -rf "$tmp"' EXIT
 
-  "$bin" -m virtualenv -p "$bin" "$tmp" || return 1
+  "$bin" -m virtualenv -p "$bin" "$tmp" || return
 
   if [[ -f "$tmp/bin/activate" ]]; then
     # shellcheck source=/dev/null

--- a/.evergreen/find-python3.sh
+++ b/.evergreen/find-python3.sh
@@ -32,7 +32,7 @@ is_python3() (
   set -o pipefail
 
   # Binary to use, e.g. "python".
-  local -r bin="${1:?'is_python requires a name or path of a python binary to test'}"
+  local -r bin="${1:?'is_python3 requires a name or path of a python binary to test'}"
 
   # Binary must be executable.
   if ! command -V "$bin" &>/dev/null; then

--- a/.evergreen/find-python3.sh
+++ b/.evergreen/find-python3.sh
@@ -168,20 +168,20 @@ find_python3() (
       done
     }
 
-    # /opt/mongodbtoolchain/vX/bin/python
-    append_bins "/opt/mongodbtoolchain" "v[0-9]*" "bin/python3" "bin/python"
-
-    # /opt/python/3.X/bin/python
-    append_bins "/opt/python" "3.[0-9]*" "bin/python3" "bin/python"
-
-    # C:/python/Python3X/bin/python
-    append_bins "C:/python" "Python3[0-9]*" "python3.exe" "python.exe"
+    bin="python"
+    if is_python3 "$bin"; then bins+=("$bin"); fi
 
     bin="python3"
     if is_python3 "$bin"; then bins+=("$bin"); fi
 
-    bin="python"
-    if is_python3 "$bin"; then bins+=("$bin"); fi
+    # C:/python/Python3X/bin/python
+    append_bins "C:/python" "Python3[0-9]*" "python3.exe" "python.exe"
+
+    # /opt/python/3.X/bin/python
+    append_bins "/opt/python" "3.[0-9]*" "bin/python3" "bin/python"
+
+    # /opt/mongodbtoolchain/vX/bin/python
+    append_bins "/opt/mongodbtoolchain" "v[0-9]*" "bin/python3" "bin/python"
   } 1>&2
 
   # For diagnostic purposes.

--- a/.evergreen/find-python3.sh
+++ b/.evergreen/find-python3.sh
@@ -88,7 +88,7 @@ is_venv_capable() (
     # shellcheck source=/dev/null
     . "$tmp/bin/activate"
   else
-    dos2unix "$tmp/Scripts/activate" || true
+    dos2unix "$tmp/Scripts/activate" || return
     # shellcheck source=/dev/null
     . "$tmp/Scripts/activate"
   fi
@@ -128,7 +128,7 @@ is_virtualenv_capable() (
     # shellcheck source=/dev/null
     . "$tmp/bin/activate"
   else
-    dos2unix "$tmp/Scripts/activate" || true
+    dos2unix "$tmp/Scripts/activate" || return
     # shellcheck source=/dev/null
     . "$tmp/Scripts/activate"
   fi

--- a/.evergreen/find-python3.sh
+++ b/.evergreen/find-python3.sh
@@ -191,12 +191,6 @@ find_python3() (
       done
     }
 
-    bin="python3"
-    if is_python3 "$bin"; then bins+=("$bin"); fi
-
-    bin="python"
-    if is_python3 "$bin"; then bins+=("$bin"); fi
-
     # C:/python/Python3X/bin/python
     append_bins "C:/python" "Python3[0-9]*" "python3.exe" "python.exe"
 
@@ -205,6 +199,12 @@ find_python3() (
 
     # /opt/mongodbtoolchain/vX/bin/python
     append_bins "/opt/mongodbtoolchain" "v[0-9]*" "bin/python3" "bin/python"
+
+    bin="python3"
+    if is_python3 "$bin"; then bins+=("$bin"); fi
+
+    bin="python"
+    if is_python3 "$bin"; then bins+=("$bin"); fi
   } 1>&2
 
   {

--- a/.evergreen/find-python3.sh
+++ b/.evergreen/find-python3.sh
@@ -168,10 +168,10 @@ find_python3() (
       done
     }
 
-    bin="python"
+    bin="python3"
     if is_python3 "$bin"; then bins+=("$bin"); fi
 
-    bin="python3"
+    bin="python"
     if is_python3 "$bin"; then bins+=("$bin"); fi
 
     # C:/python/Python3X/bin/python

--- a/.evergreen/venv-utils.sh
+++ b/.evergreen/venv-utils.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# venv-utils.sh
+#
+# Usage:
+#   . /path/to/venv-utils.sh
+#
+# This file defines the following functions:
+#   - venvcreate
+#   - venvactivate
+# These functions may be invoked from any working directory.
+
+# venvcreate
+#
+# Usage:
+#   venvcreate python venv
+#   venvcreate /path/to/python /path/to/venv/dir
+#
+# Parameters:
+#   "$1": The Python binary to use for the virtual environment.
+#   "$2": The path to the virtual environment (directory) to create.
+#
+# Return 0 (true) if the virtual environment has been successfully created,
+# activated, and the pip package upgraded.
+# Return a non-zero value (false) otherwise.
+venvcreate() {
+  local -r bin="${1:?'venvcreate requires a Python binary to use for the virtual environment'}"
+  local -r path="${2:?'venvcreate requires a path to the virtual environment to create'}"
+
+  if "$bin" -m venv -h &>/dev/null; then
+    "$bin" -m venv "$path" || return 1
+  elif "$bin" -m virtualenv --version &>/dev/null; then
+    # Ensure the correct binary is used for the virtual environment with the
+    # '-p` argument. System-installed virtualenv on Debian 10 is buggy and
+    # may default to creating a python2 environment otherwise.
+    "$bin" -m virtualenv -p "$bin" "$path" || return 1
+  else
+    echo "Could not use either venv or virtualenv to create the virtual environment at $path!" 1>&2
+    return 1
+  fi
+
+  # Workaround https://bugs.python.org/issue32451:
+  # mongovenv/Scripts/activate: line 3: $'\r': command not found
+  if [[ -f "$path/Scripts/activate" ]]; then
+    dos2unix "$path/Scripts/activate" || true
+  fi
+
+  venvactivate "$path" || return 1
+
+  python -m pip install --upgrade pip
+}
+
+# venvactivate
+#
+# Usage:
+#   venvactivate venv
+#   venvactivate /path/to/venv/dir
+#
+# Parameters:
+#   "$1": The path to an existing virtual environment (directory).
+#
+# Activate the virtual environment "$1". Designed to work regardless of the
+# target environment.
+venvactivate() {
+  local -r path="${1:?'venvactivate requires a path to an existing virtual environment'}"
+
+  if [[ -f "$path/bin/activate" ]]; then
+    # shellcheck source=/dev/null
+    . "$path/bin/activate"
+  elif [[ -f "$path/Scripts/activate" ]]; then
+    # shellcheck source=/dev/null
+    . "$path/Scripts/activate"
+  else
+    echo "Could not find the script to activate the virtual environment at $path!" 1>&2
+    return 1
+  fi
+}

--- a/.evergreen/venv-utils.sh
+++ b/.evergreen/venv-utils.sh
@@ -55,7 +55,7 @@ venvcreate() {
     fi
   done
 
-  echo "Could not use either venv or virtualenv to create the virtual environment at $path!" 1>&2
+  echo "Could not use either venv or virtualenv with $bin to create a virtual environment at $path!" 1>&2
   return 1
 }
 

--- a/.evergreen/venv-utils.sh
+++ b/.evergreen/venv-utils.sh
@@ -39,7 +39,7 @@ venvcreate() {
       # Workaround https://bugs.python.org/issue32451:
       # mongovenv/Scripts/activate: line 3: $'\r': command not found
       if [[ -f "$path/Scripts/activate" ]]; then
-        dos2unix "$path/Scripts/activate" || true
+        dos2unix "$path/Scripts/activate" || return
       fi
 
       if venvactivate "$path"; then


### PR DESCRIPTION
## Description

This PR is the first of several PRs whose goal is to improve the robustness and hygiene of DET shell scripts by taking full advantage of the features provided by Bash.

This PR is focused on providing improved alternatives to scripts that pertain to Python virtual environment creation and activation. This PR does _not_ change the behavior of any existing scripts. Followup PRs will attempt to incorporate these new scripts into existing scripts, which may change their behavior.

## find-python3.sh

This file defines four functions:

- is_python3
- is_venv_capable
- is_virtualenv_capable
- find_python3

The primary purpose of this file is to provide `find_python3`, which is implemented in terms of the other three functions.

`find_python3` aims to serve as a reliable and comprehensive utility function to replace the numerous instances of "find a python3 binary capable of creating a virtual environment" conditional logic found in many Evergreen scripts, both in the DET repository (e.g. [activate_venv.sh](https://github.com/mongodb-labs/drivers-evergreen-tools/blob/2443440ca69bcdba825eb0b43f874006ae3b5bca/.evergreen/csfle/activate_venv.sh#L1)) and in many other Drivers repositories. All demonstrate discrepancies from one another and are often not comprehensive in their handling of various variant-specific idiosyncracies.

Most notably, `find_python3` and other functions provided by `find-python3.sh` ensure no variables used within the functions are leaked into the parent shell. The name of the resulting python3 binary (and _only_ the name) is printed to `stdout` on success; all diagnostic and error messages are printed to `stderr` and may be silenced by redirecting `2>/dev/null`. This allows for convenient patterns such as the following:

```bash
$ cd ./.evergreen/csfle
$ . ../find-python3.sh
$ PYTHON="$(find_python3)" ./activate_venv.sh
```

This is unlike, for example, the current [utils.sh](https://github.com/mongodb-labs/drivers-evergreen-tools/blob/2443440ca69bcdba825eb0b43f874006ae3b5bca/.evergreen/utils.sh#L6), which "leaks" the `$PYTHON` variable upon invocation of `venvcreate` and can inadvertently affect the behavior of other scripts if one is not careful, such as when subsequently using [set-temp-creds.sh](https://github.com/mongodb-labs/drivers-evergreen-tools/blob/2443440ca69bcdba825eb0b43f874006ae3b5bca/.evergreen/csfle/set-temp-creds.sh#L36):

```bash
$ cd ./.evergreen/csfle
$ . ./activate-venv.sh  # Sets `PYTHON=/path/to/python` within venvcreate; installs boto3 package to venv.
$ . ./set-temp-creds.sh # Uses PYTHON set by venvcreate instead of virtual environment's python!
                        # boto3 package was installed using venv, not the system!
...
ModuleNotFoundError: No module named 'boto3'
```

This error can be worked-around by explicitly setting `PYTHON=python` after `activate_venv.sh` to ensure the venv python is used instead of any prior value of `$PYTHON`. However, it is preferable if such variable leaks did not occur in the first place.

## venv-utils.sh

This file is a hygienic alternative to [utils.sh](https://github.com/mongodb-labs/drivers-evergreen-tools/blob/2443440ca69bcdba825eb0b43f874006ae3b5bca/.evergreen/utils.sh).

As described above, the `$PYTHON` variable (among others) is leaked by the `venvcreate` and `venvactivate` functions defined by `utils.sh`. Furthermore, their behavior is affected by the `$OS` environment variable parameter, which is often set and used by other Evergreen scripts in manners inconsistent to what `utils.sh` expects. This can have the effect of indirectly breaking the behavior of `utils.sh` functions. Lastly, `venvcreate` is defined to `exit 1` on error (terminates the _shell_), which limits error handling options by the user.

The `venvcreate` and `venvactivate` functions provided by `venv-utils.sh` resolves each of these issues. All parameters to each function is explicitly documented and asserted. The function's behavior depends solely on the provided arguments with no dependency on environment variables. On error, each function _immediately_ returns a non-zero exit code to allow callers to handle errors as appropriate to their needs.

## activate-kmstlsvenv.sh

This file is a hygienic alternative to [activate_venv.sh](https://github.com/mongodb-labs/drivers-evergreen-tools/blob/2443440ca69bcdba825eb0b43f874006ae3b5bca/.evergreen/csfle/activate_venv.sh).

As with `activate_venv.sh`, this script is meant to be invoked by the caller to create and activate the `kmstlsvenv` virtual environment. It is implemented in terms of both `find-python3.sh` and `venv-utils.sh` to avoid the variable leakage problems described above. Furthermore, on error, it immediately returns a non-zero exit code instead of continuing execution as is currently done by `activate_venv.sh`.

## ShellCheck

All three files were analyzed by [ShellCheck](https://www.shellcheck.net/) using the command `shellcheck -x ./path/to/file.sh` from the root directory of the DET repository. Automated ShellCheck integration is outside the scope of this PR, but hopefully in the near future more DET scripts will be analyzed by ShellCheck to improve their quality.