### PR TITLE
Additional mongodl Linux Support

### DIFF
--- a/.evergreen/mongodl.py
+++ b/.evergreen/mongodl.py
@@ -52,6 +52,7 @@ DISTRO_ID_MAP = {
     'fedora': 'rhel',
     'centos': 'rhel',
     'mint': 'ubuntu',
+    'linuxmint': 'ubuntu',
     'opensuse-leap': 'sles',
     'opensuse': 'sles',
     'redhat': 'rhel',
@@ -69,7 +70,15 @@ DISTRO_VERSION_MAP = {
         '34': '8',
         '35': '8',
         '36': '8',
-    }
+    },
+    'linuxmint': {
+        '19': '18.04',
+        '19.*': '18.04',
+        '20': '20.04',
+        '20.*': '20.04',
+        '21': '22.04',
+        '21.*': '22.04',
+    },
 }
 
 #: Map distribution IDs with version fnmatch() patterns to download platform targets

--- a/.evergreen/mongodl.py
+++ b/.evergreen/mongodl.py
@@ -63,6 +63,13 @@ DISTRO_VERSION_MAP = {
     'elementary': {
         '6': '20.04'
     },
+    'fedora': {
+        '32': '8',
+        '33': '8',
+        '34': '8',
+        '35': '8',
+        '36': '8',
+    }
 }
 
 #: Map distribution IDs with version fnmatch() patterns to download platform targets


### PR DESCRIPTION
This changeset brings additional platform support to mongodl.py, which were identified and submitted externally for the mongo-c-driver project. These changes are relatively minor, and have no functional impact on most environments.