### PR TITLE
PYTHON-3487 Fix usage of venv

### DIFF
--- a/.evergreen/start-orchestration.sh
+++ b/.evergreen/start-orchestration.sh
@@ -31,7 +31,7 @@ if [ -f venv/bin/activate ]; then
   . venv/bin/activate
 elif [ -f venv/Scripts/activate ]; then
   . venv/Scripts/activate
-elif $PYTHON -m virtualenv --system-site-packages --never-download venv || $PYTHON -m venv  --system-site-packages || virtualenv --system-site-packages --never-download venv; then
+elif $PYTHON -m virtualenv --system-site-packages --never-download venv || $PYTHON -m venv --system-site-packages venv || virtualenv --system-site-packages --never-download venv; then
   if [ -f venv/bin/activate ]; then
     . venv/bin/activate
   elif [ -f venv/Scripts/activate ]; then


### PR DESCRIPTION
```
 [2022/10/26 19:18:18.612] usage: venv [-h] [--system-site-packages] [--symlinks | --copies] [--clear]
 [2022/10/26 19:18:18.612]             [--upgrade] [--without-pip] [--prompt PROMPT]
 [2022/10/26 19:18:18.612]             ENV_DIR [ENV_DIR ...]
 [2022/10/26 19:18:18.612] venv: error: the following arguments are required: ENV_DIR
```