### PR TITLE
DRIVERS-2459: Add script to download mongocryptd and crypt_shared

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -365,6 +365,7 @@ functions:
           MONGODB_URI="${MONGODB_URI}" \
           SERVERLESS_ATLAS_USER="${SERVERLESS_ATLAS_USER}" \
           SERVERLESS_ATLAS_PASSWORD="${SERVERLESS_ATLAS_PASSWORD}" \
+          CRYPT_SHARED_LIB_PATH="${CRYPT_SHARED_LIB_PATH}" \
             sh ${PROJECT_DIRECTORY}/.evergreen/run-serverless-tests.sh
 
   "cleanup":

--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -494,8 +494,7 @@ get_mongodb_download_url_for ()
          if [ -z $MONGODB_60 ]; then
            VERSION_INCLUDES_CRYPT_SHARED=NO
          fi ;;
-      rapid) MONGODB_DOWNLOAD_URL=$MONGODB_RAPID
-         VERSION_INCLUDES_CRYPT_SHARED=NO ;;
+      rapid) MONGODB_DOWNLOAD_URL=$MONGODB_RAPID ;;
       v6.0-latest) MONGODB_DOWNLOAD_URL=$MONGODB_60_LATEST ;;
       6.0) MONGODB_DOWNLOAD_URL=$MONGODB_60 ;;
       5.0) MONGODB_DOWNLOAD_URL=$MONGODB_50

--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -520,7 +520,10 @@ get_mongodb_download_url_for ()
          VERSION_INCLUDES_CRYPT_SHARED=NO ;;
    esac
 
-   [ -z "$MONGODB_DOWNLOAD_URL" ] && MONGODB_DOWNLOAD_URL="Unknown version: $_VERSION for $_DISTRO"
+   if [ -z "$MONGODB_DOWNLOAD_URL" ]; then
+     echo "Unknown version: $_VERSION for $_DISTRO"
+     exit 1
+   fi
 
    if [ "$VERSION_INCLUDES_CRYPT_SHARED" = "YES" ]; then
       # The crypt_shared package is simply the same file URL with the "mongodb-"

--- a/.evergreen/serverless/create-instance.sh
+++ b/.evergreen/serverless/create-instance.sh
@@ -9,7 +9,7 @@ set +o xtrace # Disable xtrace to ensure credentials aren't leaked
 #   SERVERLESS_DRIVERS_GROUP    Required. Atlas group for drivers testing.
 #   SERVERLESS_API_PUBLIC_KEY   Required. Public key for Atlas API request.
 #   SERVERLESS_API_PRIVATE_KEY  Required. Private key for Atlas API request.
-#   SERVERLESS_SKIP_CRYPT       Optional. If set, skips installing mongocryptd and crypt_shared (defaults to true)
+#   SERVERLESS_SKIP_CRYPT       Optional. If set, skips installing mongocryptd and crypt_shared (defaults to "ON")
 #
 # On success, this script will output serverless-expansion.yml with the
 # following expansions:

--- a/.evergreen/serverless/create-instance.sh
+++ b/.evergreen/serverless/create-instance.sh
@@ -9,6 +9,7 @@ set +o xtrace # Disable xtrace to ensure credentials aren't leaked
 #   SERVERLESS_DRIVERS_GROUP    Required. Atlas group for drivers testing.
 #   SERVERLESS_API_PUBLIC_KEY   Required. Public key for Atlas API request.
 #   SERVERLESS_API_PRIVATE_KEY  Required. Private key for Atlas API request.
+#   SERVERLESS_SKIP_CRYPT       Optional. If set, skips installing mongocryptd and crypt_shared (defaults to true)
 #
 # On success, this script will output serverless-expansion.yml with the
 # following expansions:
@@ -113,6 +114,12 @@ SINGLE_ATLASPROXY_SERVERLESS_URI: "$SERVERLESS_URI"
 MULTI_ATLASPROXY_SERVERLESS_URI: "$SERVERLESS_URI"
 SERVERLESS_MONGODB_VERSION: "$SERVERLESS_MONGODB_VERSION"
 EOF
+
+        if [ "$SERVERLESS_SKIP_CRYPT" != "OFF" ]; then
+          # Download binaries and crypt_shared
+          MONGODB_VERSION=rapid sh $DIR/download-crypt.sh
+        fi
+
         exit 0
     else
         echo "Setup still in progress, status=$STATE_NAME, sleeping for 1 minute..."

--- a/.evergreen/serverless/download-crypt.sh
+++ b/.evergreen/serverless/download-crypt.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+MONGODB_VERSION=${MONGODB_VERSION:-latest}
+
+DIR=$(dirname $0)
+# Functions to fetch MongoDB binaries
+. $DIR/../download-mongodb.sh
+
+get_distro
+get_mongodb_download_url_for "$DISTRO" "$MONGODB_VERSION"
+
+# Don't need to install the legacy shell
+download_and_extract_package "$MONGODB_DOWNLOAD_URL" "$EXTRACT"
+
+if [ -z $MONGO_CRYPT_SHARED_DOWNLOAD_URL ]; then
+  echo "There is no crypt_shared library for distro='$DISTRO' and version='$MONGODB_VERSION'".
+else
+  echo "Downloading crypt_shared package from $MONGO_CRYPT_SHARED_DOWNLOAD_URL"
+  download_and_extract_crypt_shared "$MONGO_CRYPT_SHARED_DOWNLOAD_URL" "$EXTRACT" CRYPT_SHARED_LIB_PATH
+  echo "CRYPT_SHARED_LIB_PATH:" $CRYPT_SHARED_LIB_PATH
+  if [ -z $CRYPT_SHARED_LIB_PATH ]; then
+    echo "CRYPT_SHARED_LIB_PATH must be assigned, but wasn't" 1>&2 # write to stderr"
+    exit 1
+  fi
+cat <<EOT >> serverless-expansion.yml
+CRYPT_SHARED_LIB_PATH: "$CRYPT_SHARED_LIB_PATH"
+EOT
+
+fi


### PR DESCRIPTION
[DRIVERS-2459](https://jira.mongodb.org/browse/DRIVERS-2459)

[DRIVERS-2400](https://jira.mongodb.org/browse/2400) asks drivers to run CSFLE tests on Serverless, which require mongocryptd or crypt_shared to run. Since this is installed in run-orchestration.sh which isn't invoked on Serverless, this PR adds the necessary download steps to create-instance.sh. A new environment variable allows disabling this download in case people want to test this locally (where they typically would have mongocryptd or crypt_shared installed already).

For now the script always downloads the rapid release version - this is to avoid parsing the reported Serverless version and deducing the correct version string to pass along (e.g. `6.1.3` would have to be replaced with `rapid`). This can be added in a separate step if deemed necessary.

* [Patch build](https://spruce.mongodb.com/version/635b93b39ccd4e5dcf2654f6/tasks)
* [PHPLIB changes](https://github.com/mongodb/mongo-php-library/commit/c0ae6cfc9f4f990b93949fa181e9517e917ee661) to remove manual download and use this PR version of drivers-evergreen-tools