### PR TITLE
DRIVERS-2411 fix handling of `AZUREKMS_IMAGE`

### DIFF
--- a/.evergreen/csfle/azurekms/README.md
+++ b/.evergreen/csfle/azurekms/README.md
@@ -4,4 +4,11 @@ Use create-and-setup-vm.sh to create the remote Azure Virtual Machine.
 Use delete-vm.sh to delete the remote Azure Virtual Machine.
 The install-az.sh script installs the `az` command-line on the host (not the remote Virtual Machine). The host is assumed to be Ubuntu or Debian versions supported by the [Install the Azure CLI on Linux](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt#option-2-step-by-step-installation-instructions) instructions.
 
-The image of the remote Virtual Machine defaults to `Debian`. It may be overridden with the environment variable `AZUREKMS_IMAGE` set to the value of `--image` in `az vm create`. See [Azure documentation](https://learn.microsoft.com/en-us/cli/azure/vm?view=azure-cli-latest#az-vm-create) for valid values (e.g. `UbuntuLTS`).
+The image of the remote Virtual Machine defaults to the URN `Debian:debian-11:11:0.20221020.1174`. It may be overridden with the environment variable `AZUREKMS_IMAGE` set to the value of `--image` in `az vm create`. See [Azure documentation](https://learn.microsoft.com/en-us/cli/azure/vm?view=azure-cli-latest#az-vm-create) for valid values.
+
+The list of images may be determined with `az vm image --list`. The following script can get the latest version of the `debian-11` image:
+```
+LATEST_DEBIAN_URN=$(az vm image list -p Debian -s 11 --all --query "[?offer=='debian-11'].urn" -o tsv | sort -u | tail -n 1)
+echo "LATEST_DEBIAN_URN=$LATEST_DEBIAN_URN"
+```
+The URN may be passed as `AZUREKMS_IMAGE`.

--- a/.evergreen/csfle/azurekms/create-and-setup-vm.sh
+++ b/.evergreen/csfle/azurekms/create-and-setup-vm.sh
@@ -25,7 +25,7 @@ if [ -z "${AZUREKMS_VMNAME_PREFIX:-}" ] || \
 fi
 
 # Set defaults.
-export AZUREKMS_IMAGE=${AZUREKMS_IMAGE:-"Debian"}
+export AZUREKMS_IMAGE=${AZUREKMS_IMAGE:-"Debian:debian-11:11:0.20221020.1174"}
 # Install az.
 "$AZUREKMS_DRIVERS_TOOLS"/.evergreen/csfle/azurekms/install-az.sh
 # Login.

--- a/.evergreen/csfle/azurekms/create-vm.sh
+++ b/.evergreen/csfle/azurekms/create-vm.sh
@@ -25,7 +25,7 @@ echo "Creating a Virtual Machine ($AZUREKMS_VMNAME) ... begin"
 az vm create \
     --resource-group "$AZUREKMS_RESOURCEGROUP" \
     --name "$AZUREKMS_VMNAME" \
-    --image Debian \
+    --image "$AZUREKMS_IMAGE" \
     --admin-username azureuser \
     --ssh-key-values "$AZUREKMS_PUBLICKEYPATH" \
     --public-ip-sku Standard \


### PR DESCRIPTION
# Summary
- Respect environment variable `AZUREKMS_IMAGE`.
- Change default Azure VM image to latest version of Debian 11.

# Background & Motivation

Debian 10 does not have packages for Java 17. Using Debian 11 is [consistent with GCP testing](https://github.com/mongodb-labs/drivers-evergreen-tools/blob/51de752387e2c0873702d054e92440807d1c0aa8/.evergreen/csfle/gcpkms/create-and-setup-instance.sh#L16).

If a driver requires Debian 10, set the environment variable `AZUREKMS_IMAGE=Debian:debian-10:10:0.20220911.1135`.

Tested with the C driver patch build: https://spruce.mongodb.com/version/6363b6402a60ed60575d1fb6