### PR TITLE
DRIVERS-2497 Fix paths on Cygwin and Python package dependencies

### DIFF
--- a/.evergreen/csfle/activate-kmstlsvenv.sh
+++ b/.evergreen/csfle/activate-kmstlsvenv.sh
@@ -5,9 +5,17 @@
 # Usage:
 #   . ./activate-kmstlsvenv.sh
 #
-# This file creates and activates the kmstlsvenv virtual environment in the
+# This file creates and/or activates the kmstlsvenv virtual environment in the
 # current working directory. This file must be invoked from within the
 # .evergreen/csfle directory in the Drivers Evergreen Tools repository.
+#
+# If a kmstlsvenv virtual environment already exists, it will be activated and
+# no further action will be taken. If a kmstlsvenv virtual environment must be
+# created, required packages will also be installed.
+
+# If an error occurs during creation, activation, or installation of packages,
+# the kmstlsvenv virtual environment will be deactivated and activate_kmstlsvenv
+# will return a non-zero value.
 
 # Automatically invoked by activate-kmstlsvenv.sh.
 activate_kmstlsvenv() {
@@ -15,14 +23,75 @@ activate_kmstlsvenv() {
   . ../venv-utils.sh || return
 
   if [[ -d kmstlsvenv ]]; then
-    venvactivate kmstlsvenv
+    venvactivate kmstlsvenv || return
   else
     # shellcheck source=.evergreen/find-python3.sh
     . ../find-python3.sh || return
 
     venvcreate "$(find_python3)" kmstlsvenv || return
 
-    CRYPTOGRAPHY_DONT_BUILD_RUST=1 python -m pip install --upgrade boto3~=1.19 cryptography~=3.4.8 pykmip~=0.10.0
+    local packages=(
+      "boto3~=1.19.0"
+      "pykmip~=0.10.0"
+    )
+
+    if [[ "$OSTYPE" == darwin16 && "$HOSTTYPE" == x86_64 ]]; then
+      # Avoid `error: thread-local storage is not supported for the current
+      # target` on macos-1012.
+      packages+=("greenlet<2.0")
+    fi
+
+    if [[ "$OSTYPE" == cygwin && "$HOSTTYPE" == x86_64 ]]; then
+      local -r is_win_2016="$(systeminfo.exe /FO LIST | perl -lne 'print $1 if m/^OS Name:\s+(.*)$/' || true)"
+
+      if [[ "$is_win_2016" =~ 2016 ]]; then
+        # Avoid `RuntimeError: Could not determine home directory.` on
+        # windows-64-2016. See BUILD-16233.
+        python -m pip install -U "setuptools<65.0" || {
+          local -r ret="$?"
+          deactivate || return 1 # Deactivation should never fail!
+          return "$ret"
+        }
+      fi
+    fi
+
+    # Avoid `error: can't find Rust compiler`.
+    if [[ "$OSTYPE" =~ linux && ! -f /etc/os-release ]]; then
+      # rhel62-* is the only suppoerted Linux-like distro that does not provide
+      # /etc/os-release. Remove this condition once support for rhel62 is
+      # dropped.
+      packages+=("cryptography<3.4")
+    elif [[ "$OSTYPE" =~ linux ]]; then
+      local -r os_id="$(perl -lne 'print $1 if m/^ID="?([^"]+)"?/' /etc/os-release || true)"
+      local -r os_ver="$(perl -lne 'print $1 if m/^VERSION_ID="?([^"]+)"?/' /etc/os-release || true)"
+
+      case "$os_id" in
+      rhel)
+        if [[ "$HOSTTYPE" =~ (powerpc64le|s390x) ]]; then
+          # rhelXY-power8-* and rhelXY-zseries-*
+          packages+=("cryptography<3.4")
+        fi
+        ;;
+      sles)
+        if [[ "$os_ver" == 12.3 && "$HOSTTYPE" == s390x ]]; then
+          # suse12-zseries-*
+          packages+=("cryptography<3.4")
+        fi
+        ;;
+      ubuntu)
+        if [[ "$os_ver" == 18.04 && "$HOSTTYPE" =~ (s390x|powerpc64le) ]]; then
+          # ubuntu1804-power8-* and ubuntu1804-zseries-*
+          packages+=("cryptography<3.4")
+        fi
+        ;;
+      esac
+    fi
+
+    python -m pip install -U "${packages[@]}" || {
+      local -r ret="$?"
+      deactivate || return 1 # Deactivation should never fail!
+      return "$ret"
+    }
   fi
 }
 

--- a/.evergreen/csfle/activate-kmstlsvenv.sh
+++ b/.evergreen/csfle/activate-kmstlsvenv.sh
@@ -57,7 +57,7 @@ activate_kmstlsvenv() {
 
     # Avoid `error: can't find Rust compiler`.
     if [[ "$OSTYPE" =~ linux && ! -f /etc/os-release ]]; then
-      # rhel62-* is the only suppoerted Linux-like distro that does not provide
+      # rhel62-* is the only supported Linux-like distro that does not provide
       # /etc/os-release. Remove this condition once support for rhel62 is
       # dropped.
       packages+=("cryptography<3.4")

--- a/.evergreen/csfle/activate-kmstlsvenv.sh
+++ b/.evergreen/csfle/activate-kmstlsvenv.sh
@@ -42,9 +42,9 @@ activate_kmstlsvenv() {
     fi
 
     if [[ "$OSTYPE" == cygwin && "$HOSTTYPE" == x86_64 ]]; then
-      local -r is_win_2016="$(systeminfo.exe /FO LIST | perl -lne 'print $1 if m/^OS Name:\s+(.*)$/' || true)"
+      local -r windows_os_name="$(systeminfo.exe /FO LIST | perl -lne 'print $1 if m/^OS Name:\s+(.*)$/' || true)"
 
-      if [[ "$is_win_2016" =~ 2016 ]]; then
+      if [[ "$windows_os_name" =~ 2016 ]]; then
         # Avoid `RuntimeError: Could not determine home directory.` on
         # windows-64-2016. See BUILD-16233.
         python -m pip install -U "setuptools<65.0" || {

--- a/.evergreen/find-python3.sh
+++ b/.evergreen/find-python3.sh
@@ -136,6 +136,9 @@ is_virtualenv_capable() (
     local -r real_path="$tmp"
   fi
 
+  # -p: some old versions of virtualenv (e.g. installed on Debian 10) are buggy.
+  # Without -p, the created virtual environment may use the wrong Python binary
+  # (such as a Python 2 binary) even if it was created by a Python 3 binary.
   "$bin" -m virtualenv -p "$bin" "$real_path" || return
 
   if [[ -f "$tmp/bin/activate" ]]; then

--- a/.evergreen/find-python3.sh
+++ b/.evergreen/find-python3.sh
@@ -81,7 +81,13 @@ is_venv_capable() (
   local -r tmp="$(mktemp -d)"
   trap 'rm -rf "$tmp"' EXIT
 
-  "$bin" -m venv "$tmp" || return
+  if [[ "$OSTYPE" == cygwin ]]; then
+    local -r real_path="$(cygpath -aw "$tmp")" || return
+    "$bin" -m venv "$real_path" || return
+  else
+    "$bin" -m venv "$tmp" || return
+  fi
+
 
   if [[ -f "$tmp/bin/activate" ]]; then
     # shellcheck source=/dev/null
@@ -121,7 +127,13 @@ is_virtualenv_capable() (
   local -r tmp="$(mktemp -d)"
   trap 'rm -rf "$tmp"' EXIT
 
-  "$bin" -m virtualenv -p "$bin" "$tmp" || return
+  if [[ "$OSTYPE" == cygwin ]]; then
+    local -r real_path="$(cygpath -aw "$tmp")" || return
+    "$bin" -m virtualenv -p "$bin" "$real_path" || return
+  else
+    "$bin" -m virtualenv -p "$bin" "$tmp" || return
+  fi
+
 
   if [[ -f "$tmp/bin/activate" ]]; then
     # shellcheck source=/dev/null

--- a/.evergreen/find-python3.sh
+++ b/.evergreen/find-python3.sh
@@ -42,7 +42,7 @@ is_python3() (
 
   # Expect an output of the form: "Python x.y.z".
   # Note: Python 2 binaries output to stderr rather than stdout.
-  local -r version_output="$("$bin" -V 2>&1)"
+  local -r version_output="$("$bin" -V 2>&1 | tr -d '\n')"
 
   # For diagnostic purposes.
   echo " - $bin: $version_output"

--- a/.evergreen/find-python3.sh
+++ b/.evergreen/find-python3.sh
@@ -89,13 +89,6 @@ is_venv_capable() (
 
   "$bin" -m venv "$real_path" || return
 
-  # Sanity check: on some environments (such as Cygwin) creation of the virtual
-  # environment may succeed but place the environment in an unexpected location.
-  if [[ -n "$(find "$tmp" -maxdepth 0 -type d -empty 2>/dev/null)" ]]; then
-    echo "$tmp is empty despite successful creation of virtual environment!"
-    return 1
-  fi
-
   if [[ -f "$tmp/bin/activate" ]]; then
     # shellcheck source=/dev/null
     . "$tmp/bin/activate"
@@ -144,13 +137,6 @@ is_virtualenv_capable() (
   fi
 
   "$bin" -m virtualenv -p "$bin" "$real_path" || return
-
-  # Sanity check: on some environments (such as Cygwin) creation of the virtual
-  # environment may succeed but place the environment in an unexpected location.
-  if [[ -n "$(find "$tmp" -maxdepth 0 -type d -empty 2>/dev/null)" ]]; then
-    echo "$tmp is empty despite successful creation of virtual environment!"
-    return 1
-  fi
 
   if [[ -f "$tmp/bin/activate" ]]; then
     # shellcheck source=/dev/null

--- a/.evergreen/find-python3.sh
+++ b/.evergreen/find-python3.sh
@@ -83,10 +83,11 @@ is_venv_capable() (
 
   if [[ "$OSTYPE" == cygwin ]]; then
     local -r real_path="$(cygpath -aw "$tmp")" || return
-    "$bin" -m venv "$real_path" || return
   else
-    "$bin" -m venv "$tmp" || return
+    local -r real_path="$tmp"
   fi
+
+  "$bin" -m venv "$real_path" || return
 
   # Sanity check: on some environments (such as Cygwin) creation of the virtual
   # environment may succeed but place the environment in an unexpected location.
@@ -138,10 +139,11 @@ is_virtualenv_capable() (
 
   if [[ "$OSTYPE" == cygwin ]]; then
     local -r real_path="$(cygpath -aw "$tmp")" || return
-    "$bin" -m virtualenv -p "$bin" "$real_path" || return
   else
-    "$bin" -m virtualenv -p "$bin" "$tmp" || return
+    local -r real_path="$tmp"
   fi
+
+  "$bin" -m virtualenv -p "$bin" "$real_path" || return
 
   # Sanity check: on some environments (such as Cygwin) creation of the virtual
   # environment may succeed but place the environment in an unexpected location.

--- a/.evergreen/find-python3.sh
+++ b/.evergreen/find-python3.sh
@@ -138,7 +138,7 @@ is_virtualenv_capable() (
 
   # -p: some old versions of virtualenv (e.g. installed on Debian 10) are buggy.
   # Without -p, the created virtual environment may use the wrong Python binary
-  # (such as a Python 2 binary) even if it was created by a Python 3 binary.
+  # (e.g. using a Python 2 binary even if it was created by a Python 3 binary).
   "$bin" -m virtualenv -p "$bin" "$real_path" || return
 
   if [[ -f "$tmp/bin/activate" ]]; then

--- a/.evergreen/find-python3.sh
+++ b/.evergreen/find-python3.sh
@@ -88,14 +88,23 @@ is_venv_capable() (
     "$bin" -m venv "$tmp" || return
   fi
 
+  # Sanity check: on some environments (such as Cygwin) creation of the virtual
+  # environment may succeed but place the environment in an unexpected location.
+  if [[ -n "$(find "$tmp" -maxdepth 0 -type d -empty 2>/dev/null)" ]]; then
+    echo "$tmp is empty despite successful creation of virtual environment!"
+    return 1
+  fi
 
   if [[ -f "$tmp/bin/activate" ]]; then
     # shellcheck source=/dev/null
     . "$tmp/bin/activate"
-  else
+  elif [[ -f "$tmp/Scripts/activate" ]]; then
     dos2unix "$tmp/Scripts/activate" || return
     # shellcheck source=/dev/null
     . "$tmp/Scripts/activate"
+  else
+    echo "Could not find an activation script in $tmp!"
+    return 1
   fi
 ) 1>&2
 
@@ -134,14 +143,23 @@ is_virtualenv_capable() (
     "$bin" -m virtualenv -p "$bin" "$tmp" || return
   fi
 
+  # Sanity check: on some environments (such as Cygwin) creation of the virtual
+  # environment may succeed but place the environment in an unexpected location.
+  if [[ -n "$(find "$tmp" -maxdepth 0 -type d -empty 2>/dev/null)" ]]; then
+    echo "$tmp is empty despite successful creation of virtual environment!"
+    return 1
+  fi
 
   if [[ -f "$tmp/bin/activate" ]]; then
     # shellcheck source=/dev/null
     . "$tmp/bin/activate"
-  else
+  elif [[ -f "$tmp/Scripts/activate" ]]; then
     dos2unix "$tmp/Scripts/activate" || return
     # shellcheck source=/dev/null
     . "$tmp/Scripts/activate"
+  else
+    echo "Could not find an activation script in $tmp!"
+    return 1
   fi
 ) 1>&2
 

--- a/.evergreen/venv-utils.sh
+++ b/.evergreen/venv-utils.sh
@@ -49,11 +49,11 @@ venvcreate() {
 
     case "$mod" in
     venv)
-      "$bin" -m "$mod" "$real_path" || continue
+      "$bin" -m "$mod" --system-site-packages "$real_path" || continue
       ;;
     virtualenv)
       # -p: ensure correct Python binary is used by virtual environment.
-      "$bin" -m "$mod" -p "$bin" "$real_path" || continue
+      "$bin" -m "$mod" -p "$bin" --system-site-packages "$real_path" || continue
       ;;
     *)
       echo "Unexpected virtual environment module $mod!"

--- a/.evergreen/venv-utils.sh
+++ b/.evergreen/venv-utils.sh
@@ -52,7 +52,10 @@ venvcreate() {
       "$bin" -m "$mod" --system-site-packages "$real_path" || continue
       ;;
     virtualenv)
-      # -p: ensure correct Python binary is used by virtual environment.
+      # -p: some old versions of virtualenv (e.g. installed on Debian 10) are
+      # buggy. Without -p, the created virtual environment may use the wrong
+      # Python binary (such as a Python 2 binary) even if it was created by a
+      # Python 3 binary.
       "$bin" -m "$mod" -p "$bin" --system-site-packages "$real_path" || continue
       ;;
     *)

--- a/.evergreen/venv-utils.sh
+++ b/.evergreen/venv-utils.sh
@@ -50,9 +50,7 @@ venvcreate() {
       fi
 
       if venvactivate "$path"; then
-        # Use --no-cache-dir to ensure ensure the *actual* latest pip is
-        # correctly installed.
-        if python -m pip install --no-cache-dir --upgrade pip; then
+        if python -m pip install --upgrade pip; then
           # Only consider success if activation + pip upgrade was successful.
           return
         fi

--- a/.evergreen/venv-utils.sh
+++ b/.evergreen/venv-utils.sh
@@ -54,8 +54,8 @@ venvcreate() {
     virtualenv)
       # -p: some old versions of virtualenv (e.g. installed on Debian 10) are
       # buggy. Without -p, the created virtual environment may use the wrong
-      # Python binary (such as a Python 2 binary) even if it was created by a
-      # Python 3 binary.
+      # Python binary (e.g. using a Python 2 binary even if it was created by a
+      # Python 3 binary).
       "$bin" -m "$mod" -p "$bin" --system-site-packages "$real_path" || continue
       ;;
     *)

--- a/.evergreen/venv-utils.sh
+++ b/.evergreen/venv-utils.sh
@@ -30,12 +30,19 @@ venvcreate() {
   local -r bin="${1:?'venvcreate requires a Python binary to use for the virtual environment'}"
   local -r path="${2:?'venvcreate requires a path to the virtual environment to create'}"
 
+  if [[ "$OSTYPE" == cygwin ]]; then
+    local -r real_path="$(cygpath -aw "$path")" || return
+  else
+    local -r real_path="$path" || return
+  fi
+
   # Prefer venv, but fallback to virtualenv if venv fails.
   for mod in "venv" "virtualenv"; do
-    # Ensure a clean directory before attempting to create a virtual environment.
+    # Ensure a clean directory before attempting to create a virtual
+    # environment.
     rm -rf "$path"
 
-    if "$bin" -m "$mod" "$path"; then
+    if "$bin" -m "$mod" "$real_path"; then
       # Workaround https://bugs.python.org/issue32451:
       # mongovenv/Scripts/activate: line 3: $'\r': command not found
       if [[ -f "$path/Scripts/activate" ]]; then


### PR DESCRIPTION
## Description

This PR is a followup to https://github.com/mongodb-labs/drivers-evergreen-tools/pull/236 and applies a critical patch to [DRIVERS-2497](https://jira.mongodb.org/browse/DRIVERS-2497) required by Windows distros.

This PR is verified by [this patch](https://spruce.mongodb.com/version/636d66b17742ae6eb49bfedf/tasks).

## Paths on Cygwin

The [tests](https://spruce.mongodb.com/version/63485ef132f417225c2244fb) used to validate behavior in https://github.com/mongodb-labs/drivers-evergreen-tools/pull/236 did not account for the presence of [pre commands](https://github.com/mongodb-labs/drivers-evergreen-tools/blob/f5d1c049948718218b006c0732990e1c642cbb13/.evergreen/config.yml#L424) which modifies the environment such that it does not accurately reflect the environment used by Drivers, such as [modifying the `$PATH` variable](https://github.com/mongodb-labs/drivers-evergreen-tools/blob/f5d1c049948718218b006c0732990e1c642cbb13/.evergreen/config.yml#L80) to prefer binaries provided by `$MONGODB_BINARIES` such as `mktemp`. This [hid Cygwin path conversions requirements](https://evergreen.mongodb.com/lobster/evergreen/task/drivers_tools_test_kmstlsvenv_windows_64_2019_test_kmstlsvenv_patch_f5d1c049948718218b006c0732990e1c642cbb13_636a8f8e306615468cab5d20_22_11_08_17_19_11/0/task#bookmarks=0%2C574&l=1&shareLine=302) by Python binaries on Windows when creating the virtual environment, demonstrated below on a windows-64-vs2017-large distro (`virtualenv` is used to obtain informative output; `venv` demonstrates similar behavior but without any output):

```bash
$ pwd
/home/Administrator

$ # As found by find_python3.
$ PYTHON="C:/python/Python310/python.exe"

$ # Command behaves as expected given a relative path.
$ # Note `dest=C:\cygwin\home\Administrator\venv` in output.
$ "$PYTHON" -m virtualenv -p "$PYTHON" venv
created virtual environment CPython3.10.2.final.0-64 in 5641ms
  creator CPython3Windows(dest=C:\cygwin\home\Administrator\venv, clear=False, no_vcs_ignore=False, global=False)
  seeder FromAppData(download=False, pip=bundle, setuptools=bundle, wheel=bundle, via=copy, app_data_dir=C:\Users\Administrator\AppData\Local\pypa\virtualenv)
    added seed packages: pip==22.2.2, setuptools==65.4.1, wheel==0.37.1
  activators BashActivator,BatchActivator,FishActivator,NushellActivator,PowerShellActivator,PythonActivator

$ find venv -mindepth 1 -maxdepth 1
venv/.gitignore
venv/Lib
venv/pyvenv.cfg
venv/Scripts

$ # As done by is_venv_capable and is_virtualenv_capable.
$ # /tmp/tmp.RukOr5qrGb
$ VENV="$(mktemp -d)"

$ # Command succeeds but places virtual environment in an unxpected location.
$ # Note `dest=C:\tmp\tmp.RukOr5qrGb` in output.
$ "$PYTHON" -m virtualenv -p "$PYTHON" "$VENV"
created virtual environment CPython3.10.2.final.0-64 in 1047ms
  creator CPython3Windows(dest=C:\tmp\tmp.RukOr5qrGb, clear=False, no_vcs_ignore=False, global=False)
  seeder FromAppData(download=False, pip=bundle, setuptools=bundle, wheel=bundle, via=copy, app_data_dir=C:\Users\Administrator\AppData\Local\pypa\virtualenv)
    added seed packages: pip==22.2.2, setuptools==65.4.1, wheel==0.37.1
  activators BashActivator,BatchActivator,FishActivator,NushellActivator,PowerShellActivator,PythonActivator

$ # Intended directory is unexpectedly empty despite successful command.
$ find "$VENV" -maxdepth 0 -empty
/tmp/tmp.RukOr5qrGb
```

A sanity check was added to the `is_venv_capable` and `is_virtualenv_capable` functions to ensure correct behavior, as well as an explicit check for the presence of an activation script to provide more informative error messages if one still cannot be found.

## Seed Packages

In addition to ensuring `venvcreate` handles paths correctly on Cygwin, the `venvcreate` function was updated to ensure all three "seed" packages `pip`, `setuptools`, and `wheel` are consistently installed in the virtual environment, as default behavior is inconsistent depending on `venv` vs. `virtualenv` and their respective versions.

A drive-by fix to correctly pass `-p "$bin"` when using the `virtualenv` module was also applied.

The `--no-cache-dir` argument was removed due to lack of necessity.

The `--system-site-packages` argument was added to improve script performance.

Error handling of the `venvcreate` function was improved to ensure the virtual environment is only activated on success. `deactivate` is only possible/necessary if `venvcreate` was successful.

## kmstlsvenv Packages

As a result of ensuring up-to-date `pip`, `setuptools`, and `wheel` packages in the virtual environment, some distros began to encounter issues with installing required packages for the kmstlsvenv virtual environment. I took this opportunity to strictly narrow down the scope and conditions when default behavior does not suffice for successful installation.

The actual packages required by kmstlsvenv scripts, `boto3` and `pykmip`, are still pinned to `~=1.19.0` and `~=0.10.0` respectively. All additional, conditionally pinned packages are dependencies required by these two packages.

The `greenlet` package is conditionally pinned to `<2.0` to avoid build failures on macos-1012.

The `setuptools` package is conditionally pinned to `<65.0` to avoid build failures on windows-64-2016 (see [BUILD-16233](https://jira.mongodb.org/browse/BUILD-16233)).

The `cryptography` package is conditionally pinned to `<3.4` to avoid dependency on the presence of a Rust compiler when a cryptography wheel is not available. The associated conditions were narrowed down as much as possible to allow/encourage use of up-to-date packages whenever possible.

As with `venvcreate`, error handling of the `activate_kmstlsvenv` function was improved to ensure the virtual environment is only activated on success. `deactivate` is only possible/necessary if `activate_kmstlsvenv` was successful.