### PR TITLE
Added activate files for aws and ocsp in the same way as activate-kmstlsvenv

### DIFF
--- a/.evergreen/auth_aws/activate-authawsvenv.sh
+++ b/.evergreen/auth_aws/activate-authawsvenv.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# activate-authawsvenv.sh
+#
+# Usage:
+#   . ./activate-authawsvenv.sh
+#
+# This file creates and/or activates the authawsvenv virtual environment in the
+# current working directory. This file must be invoked from within the
+# .evergreen/csfle directory in the Drivers Evergreen Tools repository.
+#
+# If a authawsvenv virtual environment already exists, it will be activated and
+# no further action will be taken. If a authawsvenv virtual environment must be
+# created, required packages will also be installed.
+
+# If an error occurs during creation, activation, or installation of packages,
+# the authawsvenv virtual environment will be deactivated and activate_authawsvenv
+# will return a non-zero value.
+
+# Automatically invoked by activate-authawsvenv.sh.
+activate_authawsvenv() {
+  # shellcheck source=.evergreen/venv-utils.sh
+  . ../venv-utils.sh || return
+
+  if [[ -d authawsvenv ]]; then
+    venvactivate authawsvenv || return
+  else
+    # shellcheck source=.evergreen/find-python3.sh
+    . ../find-python3.sh || return
+
+    venvcreate "$(find_python3)" authawsvenv || return
+
+    local packages=(
+      "boto3~=1.19.0"
+      "pyop~=3.4.0"
+    )
+
+    if [[ "$OSTYPE" == cygwin && "$HOSTTYPE" == x86_64 ]]; then
+      local -r windows_os_name="$(systeminfo.exe /FO LIST | perl -lne 'print $1 if m/^OS Name:\s+(.*)$/' || true)"
+
+      if [[ "$windows_os_name" =~ 2016 ]]; then
+        # Avoid `RuntimeError: Could not determine home directory.` on
+        # windows-64-2016. See BUILD-16233.
+        python -m pip install -U "setuptools<65.0" || {
+          local -r ret="$?"
+          deactivate || return 1 # Deactivation should never fail!
+          return "$ret"
+        }
+      fi
+    fi
+
+    python -m pip install -U "${packages[@]}" || {
+      local -r ret="$?"
+      deactivate || return 1 # Deactivation should never fail!
+      return "$ret"
+    }
+  fi
+}
+
+activate_authawsvenv

--- a/.evergreen/ocsp/activate-ocspvenv.sh
+++ b/.evergreen/ocsp/activate-ocspvenv.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# activate-ocspvenv.sh
+#
+# Usage:
+#   . ./activate-ocspvenv.sh
+#
+# This file creates and/or activates the ocspvenv virtual environment in the
+# current working directory. This file must be invoked from within the
+# .evergreen/csfle directory in the Drivers Evergreen Tools repository.
+#
+# If a ocspvenv virtual environment already exists, it will be activated and
+# no further action will be taken. If a ocspvenv virtual environment must be
+# created, required packages will also be installed.
+
+# If an error occurs during creation, activation, or installation of packages,
+# the ocspvenv virtual environment will be deactivated and activate_ocspvenv
+# will return a non-zero value.
+
+# Automatically invoked by activate-ocspvenv.sh.
+activate_ocspvenv() {
+  # shellcheck source=.evergreen/venv-utils.sh
+  . ../venv-utils.sh || return
+
+  if [[ -d ocspvenv ]]; then
+    venvactivate ocspvenv || return
+  else
+    # shellcheck source=.evergreen/find-python3.sh
+    . ../find-python3.sh || return
+
+    venvcreate "$(find_python3)" ocspvenv || return
+
+    if [[ "$OSTYPE" == cygwin && "$HOSTTYPE" == x86_64 ]]; then
+      local -r windows_os_name="$(systeminfo.exe /FO LIST | perl -lne 'print $1 if m/^OS Name:\s+(.*)$/' || true)"
+
+      if [[ "$windows_os_name" =~ 2016 ]]; then
+        # Avoid `RuntimeError: Could not determine home directory.` on
+        # windows-64-2016. See BUILD-16233.
+        python -m pip install -U "setuptools<65.0" || {
+          local -r ret="$?"
+          deactivate || return 1 # Deactivation should never fail!
+          return "$ret"
+        }
+      fi
+    fi
+
+    python -m pip install -r mock-ocsp-responder-requirements.txt || {
+      local -r ret="$?"
+      deactivate || return 1 # Deactivation should never fail!
+      return "$ret"
+    }
+  fi
+}
+
+activate_ocspvenv


### PR DESCRIPTION
This PR is a followup to #244 and #236 and adds hygienic alternatives to Python virtual environment scripts for auth_aws and ocsp.