### PR TITLE
DRIVERS-2465 Download latest Major release of `crypt_shared`

### DIFF
--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -572,12 +572,16 @@ download_and_extract ()
       # Download 5.0 package to get the legacy mongo shell as a workaround until DRIVERS-2328 is addressed.
       echo "Legacy 'mongo' shell not detected."
       echo "Download legacy shell from 5.0 ... begin"
-      get_mongodb_download_url_for "$DISTRO" "5.0"
+      # Use a subshell to avoid overwriting MONGODB_DOWNLOAD_URL and MONGO_CRYPT_SHARED_DOWNLOAD_URL.
+      MONGODB50_DOWNLOAD_URL=$(
+         get_mongodb_download_url_for "$DISTRO" "5.0" > /dev/null
+         echo $MONGODB_DOWNLOAD_URL
+      )
 
       SAVED_DRIVERS_TOOLS=$DRIVERS_TOOLS
       mkdir $DRIVERS_TOOLS/legacy-shell-download
       DRIVERS_TOOLS=$DRIVERS_TOOLS/legacy-shell-download
-      download_and_extract_package "$MONGODB_DOWNLOAD_URL" "$EXTRACT"
+      download_and_extract_package "$MONGODB50_DOWNLOAD_URL" "$EXTRACT"
       if [ -e $DRIVERS_TOOLS/mongodb/bin/mongo ]; then
          cp $DRIVERS_TOOLS/mongodb/bin/mongo $SAVED_DRIVERS_TOOLS/mongodb/bin
       elif [ -e $DRIVERS_TOOLS/mongodb/bin/mongo.exe ]; then

--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -528,6 +528,9 @@ get_mongodb_download_url_for ()
       rapid) MONGO_CRYPT_SHARED_DOWNLOAD_URL=$MONGODB_RAPID ;;
       v6.0-latest) MONGO_CRYPT_SHARED_DOWNLOAD_URL=$MONGODB_60_LATEST ;;
       6.0) MONGO_CRYPT_SHARED_DOWNLOAD_URL=$MONGODB_60 ;;
+      5.0 | 4.4 | 4.2 | 4.0 | 3.6 | 3.4 | 3.2 | 3.0 | 2.6 | 2.4)
+         echo "REQUESTED_CRYPT_SHARED_VERSION is set to '$REQUESTED_CRYPT_SHARED_VERSION'. crypt_shared is not available for this version. crypt_shared was introduced in the 6.0 release."
+         ;;
       *) echo "Unknown version '$REQUESTED_CRYPT_SHARED_VERSION' set for REQUESTED_CRYPT_SHARED_VERSION";
          exit 1;
          ;;

--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -529,7 +529,7 @@ get_mongodb_download_url_for ()
       v6.0-latest) MONGO_CRYPT_SHARED_DOWNLOAD_URL=$MONGODB_60_LATEST ;;
       6.0) MONGO_CRYPT_SHARED_DOWNLOAD_URL=$MONGODB_60 ;;
       5.0 | 4.4 | 4.2 | 4.0 | 3.6 | 3.4 | 3.2 | 3.0 | 2.6 | 2.4)
-         echo "REQUESTED_CRYPT_SHARED_VERSION is set to '$REQUESTED_CRYPT_SHARED_VERSION'. crypt_shared is not available for this version. crypt_shared was introduced in the 6.0 release."
+         # This is not an error. crypt_shared is not available for this version. crypt_shared was introduced in the 6.0 release.
          ;;
       *) echo "Unknown version '$REQUESTED_CRYPT_SHARED_VERSION' set for REQUESTED_CRYPT_SHARED_VERSION";
          exit 1;

--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -44,7 +44,6 @@ get_distro ()
 }
 
 # get_mongodb_download_url_for "linux-distro-version-architecture" "latest|44|42|40|36|34|32|30|28|26|24"
-# Set the environment variable FORCE_CRYPT_SHARED=YES to always download the crypt_shared library. If crypt_shared is unavailable for the requested server version, the latest major version of crypt_shared is downloaded.
 # Sets EXTRACT to appropriate extract command
 # Sets MONGODB_DOWNLOAD_URL to the appropriate download url
 # Sets MONGO_CRYPT_SHARED_DOWNLOAD_URL to the corresponding URL to a crypt_shared library archive
@@ -518,13 +517,9 @@ get_mongodb_download_url_for ()
    if [ "$VERSION_INCLUDES_CRYPT_SHARED" = "YES" ]; then
       # Use the same version as the server.
       REQUESTED_CRYPT_SHARED_VERSION="$_VERSION"
-   elif [ "${FORCE_CRYPT_SHARED:-NO}" = "YES" ]; then
-      # If configuring CRYPT_SHARED library was forcibly requested,
-      # update to the latest Major release. Major releases are expected yearly.
-      REQUESTED_CRYPT_SHARED_VERSION="6.0"
    else
-      # Server version does not include crypt_shared, and caller did not request forcing.
-      REQUESTED_CRYPT_SHARED_VERSION="NONE"
+      # Default to using the latest Major release. Major releases are expected yearly.
+      REQUESTED_CRYPT_SHARED_VERSION="6.0"
    fi
 
    case "$REQUESTED_CRYPT_SHARED_VERSION" in

--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -44,6 +44,7 @@ get_distro ()
 }
 
 # get_mongodb_download_url_for "linux-distro-version-architecture" "latest|44|42|40|36|34|32|30|28|26|24"
+# Set the environment variable REQUESTED_CRYPT_SHARED_VERSION to specify a version of the crypt_shared library to download.
 # Sets EXTRACT to appropriate extract command
 # Sets MONGODB_DOWNLOAD_URL to the appropriate download url
 # Sets MONGO_CRYPT_SHARED_DOWNLOAD_URL to the corresponding URL to a crypt_shared library archive
@@ -487,36 +488,21 @@ get_mongodb_download_url_for ()
    esac
 
    # The crypt_shared package is available on server 6.0 and newer.
-   VERSION_INCLUDES_CRYPT_SHARED=YES
    case "$_VERSION" in
-      latest) MONGODB_DOWNLOAD_URL=$MONGODB_LATEST
-         # If latest is not at least 6.0 on this OS, the crypt_shared package will not be available.
-         if [ -z $MONGODB_60 ]; then
-           VERSION_INCLUDES_CRYPT_SHARED=NO
-         fi ;;
+      latest) MONGODB_DOWNLOAD_URL=$MONGODB_LATEST ;;
       rapid) MONGODB_DOWNLOAD_URL=$MONGODB_RAPID ;;
       v6.0-latest) MONGODB_DOWNLOAD_URL=$MONGODB_60_LATEST ;;
       6.0) MONGODB_DOWNLOAD_URL=$MONGODB_60 ;;
-      5.0) MONGODB_DOWNLOAD_URL=$MONGODB_50
-         VERSION_INCLUDES_CRYPT_SHARED=NO ;;
-      4.4) MONGODB_DOWNLOAD_URL=$MONGODB_44
-         VERSION_INCLUDES_CRYPT_SHARED=NO ;;
-      4.2) MONGODB_DOWNLOAD_URL=$MONGODB_42
-         VERSION_INCLUDES_CRYPT_SHARED=NO ;;
-      4.0) MONGODB_DOWNLOAD_URL=$MONGODB_40
-         VERSION_INCLUDES_CRYPT_SHARED=NO ;;
-      3.6) MONGODB_DOWNLOAD_URL=$MONGODB_36
-         VERSION_INCLUDES_CRYPT_SHARED=NO ;;
-      3.4) MONGODB_DOWNLOAD_URL=$MONGODB_34
-         VERSION_INCLUDES_CRYPT_SHARED=NO ;;
-      3.2) MONGODB_DOWNLOAD_URL=$MONGODB_32
-         VERSION_INCLUDES_CRYPT_SHARED=NO ;;
-      3.0) MONGODB_DOWNLOAD_URL=$MONGODB_30
-         VERSION_INCLUDES_CRYPT_SHARED=NO ;;
-      2.6) MONGODB_DOWNLOAD_URL=$MONGODB_26
-         VERSION_INCLUDES_CRYPT_SHARED=NO ;;
-      2.4) MONGODB_DOWNLOAD_URL=$MONGODB_24
-         VERSION_INCLUDES_CRYPT_SHARED=NO ;;
+      5.0) MONGODB_DOWNLOAD_URL=$MONGODB_50 ;;
+      4.4) MONGODB_DOWNLOAD_URL=$MONGODB_44 ;;
+      4.2) MONGODB_DOWNLOAD_URL=$MONGODB_42 ;;
+      4.0) MONGODB_DOWNLOAD_URL=$MONGODB_40 ;;
+      3.6) MONGODB_DOWNLOAD_URL=$MONGODB_36 ;;
+      3.4) MONGODB_DOWNLOAD_URL=$MONGODB_34 ;;
+      3.2) MONGODB_DOWNLOAD_URL=$MONGODB_32 ;;
+      3.0) MONGODB_DOWNLOAD_URL=$MONGODB_30 ;;
+      2.6) MONGODB_DOWNLOAD_URL=$MONGODB_26 ;;
+      2.4) MONGODB_DOWNLOAD_URL=$MONGODB_24 ;;
    esac
 
    if [ -z "$MONGODB_DOWNLOAD_URL" ]; then
@@ -524,10 +510,27 @@ get_mongodb_download_url_for ()
      exit 1
    fi
 
-   if [ "$VERSION_INCLUDES_CRYPT_SHARED" = "YES" ]; then
+   if [ -z "$REQUESTED_CRYPT_SHARED_VERSION" ]; then
+      # If no version of the crypt shared library was requested,
+      # use the same version as the server.
+      REQUESTED_CRYPT_SHARED_VERSION="$_VERSION"
+   fi
+
+   case "$REQUESTED_CRYPT_SHARED_VERSION" in
+      latest)
+         # If latest is not at least 6.0 on this OS, the crypt_shared package will not be available.
+         if [ -n "$MONGODB_60" ]; then
+           MONGO_CRYPT_SHARED_DOWNLOAD_URL=$MONGODB_LATEST
+         fi ;;
+      rapid) MONGO_CRYPT_SHARED_DOWNLOAD_URL=$MONGODB_RAPID ;;
+      v6.0-latest) MONGO_CRYPT_SHARED_DOWNLOAD_URL=$MONGODB_60_LATEST ;;
+      6.0) MONGO_CRYPT_SHARED_DOWNLOAD_URL=$MONGODB_60 ;;
+   esac
+
+   if [ -n "$MONGO_CRYPT_SHARED_DOWNLOAD_URL" ]; then
       # The crypt_shared package is simply the same file URL with the "mongodb-"
       # prefix replaced with "mongo_crypt_shared_v1-"
-      MONGO_CRYPT_SHARED_DOWNLOAD_URL="$(printf '%s' "$MONGODB_DOWNLOAD_URL" | sed 's|/mongodb-|/mongo_crypt_shared_v1-|')"
+      MONGO_CRYPT_SHARED_DOWNLOAD_URL="$(printf '%s' "$MONGO_CRYPT_SHARED_DOWNLOAD_URL" | sed 's|/mongodb-|/mongo_crypt_shared_v1-|')"
    fi
    echo $MONGODB_DOWNLOAD_URL
 }

--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -486,17 +486,11 @@ get_mongodb_download_url_for ()
       ;;
    esac
 
-   # The crypt_shared package is available on server 6.0 and newer.
-   VERSION_INCLUDES_CRYPT_SHARED=NO
    case "$_VERSION" in
-      latest) MONGODB_DOWNLOAD_URL=$MONGODB_LATEST
-         VERSION_INCLUDES_CRYPT_SHARED=YES ;;
-      rapid) MONGODB_DOWNLOAD_URL=$MONGODB_RAPID 
-         VERSION_INCLUDES_CRYPT_SHARED=YES ;;
-      v6.0-latest) MONGODB_DOWNLOAD_URL=$MONGODB_60_LATEST
-         VERSION_INCLUDES_CRYPT_SHARED=YES ;;
-      6.0) MONGODB_DOWNLOAD_URL=$MONGODB_60
-         VERSION_INCLUDES_CRYPT_SHARED=YES ;;
+      latest) MONGODB_DOWNLOAD_URL=$MONGODB_LATEST ;;
+      rapid) MONGODB_DOWNLOAD_URL=$MONGODB_RAPID ;;
+      v6.0-latest) MONGODB_DOWNLOAD_URL=$MONGODB_60_LATEST ;;
+      6.0) MONGODB_DOWNLOAD_URL=$MONGODB_60 ;;
       5.0) MONGODB_DOWNLOAD_URL=$MONGODB_50 ;;
       4.4) MONGODB_DOWNLOAD_URL=$MONGODB_44 ;;
       4.2) MONGODB_DOWNLOAD_URL=$MONGODB_42 ;;
@@ -514,15 +508,11 @@ get_mongodb_download_url_for ()
      exit 1
    fi
 
-   if [ "$VERSION_INCLUDES_CRYPT_SHARED" = "YES" ]; then
-      # Use the same version as the server.
-      REQUESTED_CRYPT_SHARED_VERSION="$_VERSION"
-   else
-      # Default to using the latest Major release. Major releases are expected yearly.
-      REQUESTED_CRYPT_SHARED_VERSION="6.0"
-   fi
-
-   case "$REQUESTED_CRYPT_SHARED_VERSION" in
+   # Get the download URL for crypt_shared.
+   # The crypt_shared package is available on server 6.0 and newer.
+   # Try to download a version of crypt_shared matching the server version.
+   # If no matching version is available, try to download the latest Major release of crypt_shared.
+   case "$_VERSION" in
       latest)
          # If latest is not at least 6.0 on this OS, the crypt_shared package will not be available.
          if [ -n "$MONGODB_60" ]; then
@@ -531,10 +521,12 @@ get_mongodb_download_url_for ()
       rapid) MONGO_CRYPT_SHARED_DOWNLOAD_URL=$MONGODB_RAPID ;;
       v6.0-latest) MONGO_CRYPT_SHARED_DOWNLOAD_URL=$MONGODB_60_LATEST ;;
       6.0) MONGO_CRYPT_SHARED_DOWNLOAD_URL=$MONGODB_60 ;;
-      5.0 | 4.4 | 4.2 | 4.0 | 3.6 | 3.4 | 3.2 | 3.0 | 2.6 | 2.4 | NONE)
-         # This is not an error. crypt_shared is not available for this version. crypt_shared was introduced in the 6.0 release.
+      5.0 | 4.4 | 4.2 | 4.0 | 3.6 | 3.4 | 3.2 | 3.0 | 2.6 | 2.4)
+         # Default to using the latest Major release. Major releases are expected yearly.
+         # MONGODB_60 may be empty if there is no 6.0 download available for this platform.
+         MONGO_CRYPT_SHARED_DOWNLOAD_URL="$MONGODB_60"
          ;;
-      *) echo "Unknown version '$REQUESTED_CRYPT_SHARED_VERSION' set for REQUESTED_CRYPT_SHARED_VERSION";
+      *) echo "Unknown version '$_VERSION'";
          exit 1;
          ;;
    esac

--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -514,6 +514,9 @@ get_mongodb_download_url_for ()
       # If no version of the crypt shared library was requested,
       # use the same version as the server.
       REQUESTED_CRYPT_SHARED_VERSION="$_VERSION"
+   elif [ "$REQUESTED_CRYPT_SHARED_VERSION" = "latest-major" ]; then
+      # Update to the latest Major release. Major releases are expected yearly.
+      REQUESTED_CRYPT_SHARED_VERSION="6.0"
    fi
 
    case "$REQUESTED_CRYPT_SHARED_VERSION" in
@@ -525,6 +528,9 @@ get_mongodb_download_url_for ()
       rapid) MONGO_CRYPT_SHARED_DOWNLOAD_URL=$MONGODB_RAPID ;;
       v6.0-latest) MONGO_CRYPT_SHARED_DOWNLOAD_URL=$MONGODB_60_LATEST ;;
       6.0) MONGO_CRYPT_SHARED_DOWNLOAD_URL=$MONGODB_60 ;;
+      *) echo "Unknown version '$REQUESTED_CRYPT_SHARED_VERSION' set for REQUESTED_CRYPT_SHARED_VERSION";
+         exit 1;
+         ;;
    esac
 
    if [ -n "$MONGO_CRYPT_SHARED_DOWNLOAD_URL" ]; then


### PR DESCRIPTION
# Summary

- Download latest Major release of `crypt_shared` if a version matching the server is unavailable.

After this change, downloading server versions < 6.0 is expected to try to download `crypt_shared` 6.0.

# Background & Motivation

The term Major comes from [MongoDB Software Lifecycle Schedules](https://www.mongodb.com/support-policy/lifecycles).

This is a request from product. Drivers only test the `crypt_shared` library with the same version of the server per DRIVERS-2355. MongoDB does not document support for using `crypt_shared` an older server version. Functionally, new versions of `crypt_shared` are expected to work with older server versions. Testing will validate that expectation and enable documenting support of new `crypt_shared` with old server versions.

Tested with [Go driver](https://spruce.mongodb.com/version/63a097815623430fa4eaf49e/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).
