### PR TITLE
Migrate deprecated set-output command to use $GITHUB_OUTPUT

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -51,5 +51,5 @@ runs:
       shell: sh
     - id: "get-cluster-uri"
       name: "Expose Cluster URI"
-      run: echo "::set-output name=cluster-uri::$(cat ${{ github.action_path }}/uri.txt)"
+      run: echo "cluster-uri=$(cat ${{ github.action_path }}/uri.txt)" >> $GITHUB_OUTPUT
       shell: bash


### PR DESCRIPTION
See: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

This eliminates deprecation notices in our workflow runs. Related to another PR I opened in https://github.com/cmb69/setup-php-sdk/pull/21, although that was for Windows.