### PR TITLE
DRIVERS-2377 remove SSH keys on task completion

### DIFF
--- a/.evergreen/csfle/gcpkms/create-and-setup-instance.sh
+++ b/.evergreen/csfle/gcpkms/create-and-setup-instance.sh
@@ -32,8 +32,9 @@ echo "create-instance.sh ... end"
 # Otherwise SSH may fail. See https://cloud.google.com/compute/docs/troubleshooting/troubleshooting-ssh.
 wait_for_server () {
     for i in $(seq 300); do
-        # Specify the non-root username "gcpkms". The instance may be configured to not permit root login.
-        if SSHOUTPUT=$($GCPKMS_GCLOUD compute ssh "gcpkms@$GCPKMS_INSTANCENAME" --zone $GCPKMS_ZONE --project $GCPKMS_PROJECT --command "echo 'ping' --ssh-flag='-o ConnectTimeout=10'" 2>&1); then
+        # The first `gcloud compute ssh` creates an SSH key pair and stores the public key in the Google Account.
+        # The public key is deleted from the Google Account in delete-instance.sh.
+        if SSHOUTPUT=$($GCPKMS_GCLOUD compute ssh "$GCPKMS_INSTANCENAME" --zone $GCPKMS_ZONE --project $GCPKMS_PROJECT --command "echo 'ping' --ssh-flag='-o ConnectTimeout=10'" 2>&1); then
             echo "ssh succeeded"
             return 0
         else

--- a/.evergreen/csfle/gcpkms/create-and-setup-instance.sh
+++ b/.evergreen/csfle/gcpkms/create-and-setup-instance.sh
@@ -33,7 +33,7 @@ echo "create-instance.sh ... end"
 wait_for_server () {
     for i in $(seq 300); do
         # Specify the non-root username "gcpkms". The instance may be configured to not permit root login.
-        if SSHOUTPUT=$($GCPKMS_GCLOUD compute ssh "gcpkms@$GCPKMS_INSTANCENAME" --zone $GCPKMS_ZONE --project $GCPKMS_PROJECT --command "echo 'ping'" 2>&1); then
+        if SSHOUTPUT=$($GCPKMS_GCLOUD compute ssh "gcpkms@$GCPKMS_INSTANCENAME" --zone $GCPKMS_ZONE --project $GCPKMS_PROJECT --command "echo 'ping' --ssh-flag='-o ConnectTimeout=10'" 2>&1); then
             echo "ssh succeeded"
             return 0
         else

--- a/.evergreen/csfle/gcpkms/create-instance.sh
+++ b/.evergreen/csfle/gcpkms/create-instance.sh
@@ -26,6 +26,7 @@ echo "Creating GCE instance ($GCPKMS_INSTANCENAME) ... begin"
 echo "Using service account: $GCPKMS_SERVICEACCOUNT"
 # Add cloudkms scope for making KMS requests.
 # Add compute scope so instance can self-delete.
+# enable-oslogin enables SSH keys to be managed from the Google account. SSH keys are deleted in delete-instance.sh. Without enable-oslogin, SSH keys are added to Project Metadata and may hit resource limits.
 $GCPKMS_GCLOUD compute instances create $GCPKMS_INSTANCENAME \
     --zone $GCPKMS_ZONE \
     --project $GCPKMS_PROJECT \
@@ -34,5 +35,6 @@ $GCPKMS_GCLOUD compute instances create $GCPKMS_INSTANCENAME \
     --image-project $GCPKMS_IMAGEPROJECT \
     --image-family $GCPKMS_IMAGEFAMILY \
     --metadata-from-file=startup-script=$GCPKMS_DRIVERS_TOOLS/.evergreen/csfle/gcpkms/remote-scripts/startup.sh \
-    --scopes https://www.googleapis.com/auth/cloudkms,https://www.googleapis.com/auth/compute
+    --scopes https://www.googleapis.com/auth/cloudkms,https://www.googleapis.com/auth/compute \
+    --metadata enable-oslogin=TRUE
 echo "Creating GCE instance ($GCPKMS_INSTANCENAME) ... end"

--- a/.evergreen/csfle/gcpkms/delete-instance.sh
+++ b/.evergreen/csfle/gcpkms/delete-instance.sh
@@ -14,3 +14,7 @@ $GCPKMS_GCLOUD --quiet compute instances delete $GCPKMS_INSTANCENAME \
     --zone $GCPKMS_ZONE \
     --project $GCPKMS_PROJECT
 echo "Deleting GCE instance ($GCPKMS_INSTANCENAME) ... end"
+
+echo "Removing SSH key ... begin"
+$GCPKMS_GCLOUD compute os-login ssh-keys remove --key-file ~/.ssh/google_compute_engine.pub
+echo "Removing SSH key ... end"


### PR DESCRIPTION
# Summary
- Delete SSH keys at task completion for GCP.
- Add ConnectTimeout=10 to ssh command.

# Background & Motivation

The `testgcpkms-task` task was failing with the error `The zone 'projects/devprod-drivers/zones/us-east1-b' does not have enough resources available to fulfill the request.  Try a different zone, or try again later.`. ([Example](https://spruce.mongodb.com/task/mongo_go_driver_testgcpkms_variant_testgcpkms_task_0e5ae89f1baf3d6edca093467ffd1f870b441add_22_11_28_21_11_31/logs?execution=0)).

The cause of the error was a resource limit for SSH keys created in the [GCP Project Metadata](https://cloud.google.com/compute/docs/metadata/setting-custom-metadata):

> SSH keys are stored as custom metadata under the ssh-keys key. If your metadata content or value for this key exceeds the 256 KB limit, you won't be able to add more SSH keys. If you run into this limit, consider removing unused keys to free up metadata space for new keys.

The SSH keys have been manually removed to fix test failures. To prevent this error in the future, SSH keys created during the task should be removed automatically.

By default `gcloud compute ssh` creates an SSH key and stores it in [Project Metadata](https://cloud.google.com/compute/docs/instances/ssh#gcloud):
> Your public SSH key is stored in project metadata

Removing SSH keys from [Project Metadata](https://cloud.google.com/compute/docs/connect/restrict-ssh-keys#remove-metadata-key) is more challenging to automate.

This PR creates the GCP instance with [OS Login](https://cloud.google.com/compute/docs/instances/access-overview). OS Login [stores the SSH key in the Google Account](https://cloud.google.com/compute/docs/instances/ssh#gcloud). This makes it easy to remove the SSH key. Using OS Login is also recommended access method for Linux VM.

This PR has been tested with the Go driver [in this patch](https://spruce.mongodb.com/version/6388ccfee3c331457812a1c7/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).