### PR TITLE
Remove outdated bottle version cap

### DIFF
--- a/.evergreen/start-orchestration.sh
+++ b/.evergreen/start-orchestration.sh
@@ -43,7 +43,7 @@ elif $PYTHON -m virtualenv --system-site-packages --never-download venv || $PYTH
 fi
 
 # Install from github to get the latest mongo-orchestration.
-pip install --upgrade 'https://github.com/ShaneHarvey/mongo-orchestration/archive/replace-cherrypy.tar.gz'
+pip install --upgrade 'https://github.com/mongodb/mongo-orchestration/archive/master.tar.gz'
 pip list
 cd -
 

--- a/.evergreen/start-orchestration.sh
+++ b/.evergreen/start-orchestration.sh
@@ -43,7 +43,7 @@ elif $PYTHON -m virtualenv --system-site-packages --never-download venv || $PYTH
 fi
 
 # Install from github to get the latest mongo-orchestration.
-pip install --upgrade 'https://github.com/mongodb/mongo-orchestration/archive/master.tar.gz' 'bottle<0.12.20'
+pip install --upgrade 'https://github.com/ShaneHarvey/mongo-orchestration/archive/replace-cherrypy.tar.gz'
 pip list
 cd -
 


### PR DESCRIPTION
Testing for https://github.com/10gen/mongo-orchestration/pull/293 and removes the now outdated workaround added in https://github.com/mongodb-labs/drivers-evergreen-tools/pull/202