### PR TITLE
Add bash check and use BASH_SOURCE instead of DRIVERS_TOOLS

### DIFF
--- a/.evergreen/auth_aws/activate-authawsvenv.sh
+++ b/.evergreen/auth_aws/activate-authawsvenv.sh
@@ -17,6 +17,11 @@
 # the authawsvenv virtual environment will be deactivated and activate_authawsvenv
 # will return a non-zero value.
 
+if [ -z "$BASHPID" ]; then
+  echo "activate-authawsvenv.sh must be run in a Bash shell!" 1>&2
+  return 1
+fi
+
 # Automatically invoked by activate-authawsvenv.sh.
 activate_authawsvenv() {
   # shellcheck source=.evergreen/venv-utils.sh

--- a/.evergreen/csfle/activate-kmstlsvenv.sh
+++ b/.evergreen/csfle/activate-kmstlsvenv.sh
@@ -17,6 +17,11 @@
 # the kmstlsvenv virtual environment will be deactivated and activate_kmstlsvenv
 # will return a non-zero value.
 
+if [ -z "$BASHPID" ]; then
+  echo "activate-kmstlsvenv.sh must be run in a Bash shell!" 1>&2
+  return 1
+fi
+
 # Automatically invoked by activate-kmstlsvenv.sh.
 activate_kmstlsvenv() {
   # shellcheck source=.evergreen/venv-utils.sh

--- a/.evergreen/find-python3.sh
+++ b/.evergreen/find-python3.sh
@@ -12,6 +12,11 @@
 #   - find_python3
 # These functions may be invoked from any working directory.
 
+if [ -z "$BASHPID" ]; then
+  echo "find-python3.sh must be run in a Bash shell!" 1>&2
+  return 1
+fi
+
 # is_python3
 #
 # Usage:

--- a/.evergreen/ocsp/activate-ocspvenv.sh
+++ b/.evergreen/ocsp/activate-ocspvenv.sh
@@ -17,6 +17,11 @@
 # the ocspvenv virtual environment will be deactivated and activate_ocspvenv
 # will return a non-zero value.
 
+if [ -z "$BASHPID" ]; then
+  echo "activate-kmstlsvenv.sh must be run in a Bash shell!" 1>&2
+  return 1
+fi
+
 # Automatically invoked by activate-ocspvenv.sh.
 activate_ocspvenv() {
   # shellcheck source=.evergreen/venv-utils.sh

--- a/.evergreen/start-orchestration.sh
+++ b/.evergreen/start-orchestration.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if [ -z "$BASH_SOURCE" ]; then
+if [ -z "$BASHPID" ]; then
   echo "start-orchestration.sh must be run in a Bash shell!" 1>&2
   exit 1
 fi

--- a/.evergreen/start-orchestration.sh
+++ b/.evergreen/start-orchestration.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [ -z "$BASH_SOURCE" ]; then
+  echo "start-orchestration.sh must be run in a Bash shell!" 1>&2
+  exit 1
+fi
+
 if [ "$#" -ne 1 ]; then
   echo "$0 requires one argument: <MONGO_ORCHESTRATION_HOME>"
   echo "For example: $0 /tmp/mongo-orchestration-home"
@@ -15,8 +20,10 @@ echo From shell `date` > $MONGO_ORCHESTRATION_HOME/server.log
 
 cd "$MONGO_ORCHESTRATION_HOME"
 
-. "$DRIVERS_TOOLS/.evergreen/find-python3.sh"
-. "$DRIVERS_TOOLS/.evergreen/venv-utils.sh"
+declare det_evergreen_dir
+det_evergreen_dir="$(dirname "${BASH_SOURCE[0]}")"
+. "$det_evergreen_dir/find-python3.sh"
+. "$det_evergreen_dir/venv-utils.sh"
 
 PYTHON="$(find_python3)"
 

--- a/.evergreen/venv-utils.sh
+++ b/.evergreen/venv-utils.sh
@@ -10,6 +10,11 @@
 #   - venvactivate
 # These functions may be invoked from any working directory.
 
+if [ -z "$BASHPID" ]; then
+  echo "venv-utils.sh must be run in a Bash shell!" 1>&2
+  return 1
+fi
+
 # venvcreate
 #
 # Usage:


### PR DESCRIPTION
This PR is a followup to https://github.com/mongodb-labs/drivers-evergreen-tools/pull/255 which assumed `DRIVERS_TOOLS` is defined when the script is invoked (as per `run-orchestration.sh`), which was not true (https://github.com/10gen/mongosync/pull/1180). This PR reverts to _not_ requiring `DRIVERS_TOOLS` in `start-orchestration.sh` by using `"$(dirname "${BASH_SOURCE[0]}")"` instead, taking advantage of the Bash shell requirement.

Furthermore, due to repeated instances of confusion regarding the Bash shell requirement and methods of invoking the script on Evergreen, this PR also introduces "Bash checks" to improve the quality of error messages that are encountered if a script is incorrectly invoked using i.e. `sh -c script.sh`, which does not respect the script shebangs ([sh is not bash!](https://mywiki.wooledge.org/BashGuide/CommandsAndArguments#Scripts)).