### PR TITLE
Use $BASH instead of $BASHPID for old Bash compatibility

### DIFF
--- a/.evergreen/auth_aws/activate-authawsvenv.sh
+++ b/.evergreen/auth_aws/activate-authawsvenv.sh
@@ -17,7 +17,7 @@
 # the authawsvenv virtual environment will be deactivated and activate_authawsvenv
 # will return a non-zero value.
 
-if [ -z "$BASHPID" ]; then
+if [ -z "$BASH" ]; then
   echo "activate-authawsvenv.sh must be run in a Bash shell!" 1>&2
   return 1
 fi

--- a/.evergreen/csfle/activate-kmstlsvenv.sh
+++ b/.evergreen/csfle/activate-kmstlsvenv.sh
@@ -17,7 +17,7 @@
 # the kmstlsvenv virtual environment will be deactivated and activate_kmstlsvenv
 # will return a non-zero value.
 
-if [ -z "$BASHPID" ]; then
+if [ -z "$BASH" ]; then
   echo "activate-kmstlsvenv.sh must be run in a Bash shell!" 1>&2
   return 1
 fi

--- a/.evergreen/find-python3.sh
+++ b/.evergreen/find-python3.sh
@@ -12,7 +12,7 @@
 #   - find_python3
 # These functions may be invoked from any working directory.
 
-if [ -z "$BASHPID" ]; then
+if [ -z "$BASH" ]; then
   echo "find-python3.sh must be run in a Bash shell!" 1>&2
   return 1
 fi

--- a/.evergreen/ocsp/activate-ocspvenv.sh
+++ b/.evergreen/ocsp/activate-ocspvenv.sh
@@ -17,7 +17,7 @@
 # the ocspvenv virtual environment will be deactivated and activate_ocspvenv
 # will return a non-zero value.
 
-if [ -z "$BASHPID" ]; then
+if [ -z "$BASH" ]; then
   echo "activate-kmstlsvenv.sh must be run in a Bash shell!" 1>&2
   return 1
 fi

--- a/.evergreen/serverless/create-instance.sh
+++ b/.evergreen/serverless/create-instance.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if [ -z "$BASHPID" ]; then
+if [ -z "$BASH" ]; then
   echo "create-instance.sh must be run in a Bash shell!" 1>&2
   exit 1
 fi

--- a/.evergreen/start-orchestration.sh
+++ b/.evergreen/start-orchestration.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if [ -z "$BASHPID" ]; then
+if [ -z "$BASH" ]; then
   echo "start-orchestration.sh must be run in a Bash shell!" 1>&2
   exit 1
 fi

--- a/.evergreen/venv-utils.sh
+++ b/.evergreen/venv-utils.sh
@@ -10,7 +10,7 @@
 #   - venvactivate
 # These functions may be invoked from any working directory.
 
-if [ -z "$BASHPID" ]; then
+if [ -z "$BASH" ]; then
   echo "venv-utils.sh must be run in a Bash shell!" 1>&2
   return 1
 fi


### PR DESCRIPTION
(Comprehensively) verified by [this patch](https://spruce.mongodb.com/version/63b5ad1630661566a4c540aa/tasks).

Followup to https://github.com/mongodb-labs/drivers-evergreen-tools/pull/257, where `$BASHPID` was selected due to (pessimistic) concern of being less likely to be user-defined (overwritten) than `$BASH`. However, lack of version information in the [Bash reference manual](https://www.gnu.org/software/bash/manual/bash.html) and failure to comprehensive test the PR missed [certain platforms](https://spruce.mongodb.com/task/mongo_node_driver_next_macos_1100_test_rapid_server_patch_fe65746a80715a42e221fdfa53b7976c6ec75446_63b5a4933e8e864403b41737_23_01_04_16_08_51/logs?execution=0) that do not support `$BASHPID`, which happens to be a Bash 4.0 or newer feature. This PR replaces all instances of `$BASHPID` introduced in https://github.com/mongodb-labs/drivers-evergreen-tools/pull/257 with `$BASH` instead.