### PR TITLE
Source DET scripts before changing directory in start-orchestration.sh

### DIFF
--- a/.evergreen/start-orchestration.sh
+++ b/.evergreen/start-orchestration.sh
@@ -18,12 +18,12 @@ MONGO_ORCHESTRATION_HOME="$1"
 
 echo From shell `date` > $MONGO_ORCHESTRATION_HOME/server.log
 
-cd "$MONGO_ORCHESTRATION_HOME"
-
 declare det_evergreen_dir
 det_evergreen_dir="$(dirname "${BASH_SOURCE[0]}")"
 . "$det_evergreen_dir/find-python3.sh"
 . "$det_evergreen_dir/venv-utils.sh"
+
+cd "$MONGO_ORCHESTRATION_HOME"
 
 PYTHON="$(find_python3)"
 


### PR DESCRIPTION
This PR is a followup to https://github.com/mongodb-labs/drivers-evergreen-tools/pull/257 which failed to account for a `cd` prior to setting `det_evergreen_dir`, as `${BASH_SOURCE[0]}` produces a path relative to `start-orchestration.sh` _on invocation_, not an absolute path. This resulted in the subsequent sourcing of `find-python3.sh` and `venv-utils.sh` using paths relative to the new `$MONGO_ORCHESTRATION_HOME` directory rather than the working directory on invocation of `start-orchestration.sh`.