### PR TITLE
DRIVERS-2377 add GCPKMS_DISKSIZE option with default 20GB

### DIFF
--- a/.evergreen/csfle/gcpkms/create-and-setup-instance.sh
+++ b/.evergreen/csfle/gcpkms/create-and-setup-instance.sh
@@ -15,6 +15,7 @@ export GCPKMS_ZONE=${GCPKMS_ZONE:-"us-east1-b"}
 export GCPKMS_IMAGEPROJECT=${GCPKMS_IMAGEPROJECT:-"debian-cloud"}
 export GCPKMS_IMAGEFAMILY=${GCPKMS_IMAGEFAMILY:-"debian-11"}
 export GCPKMS_MACHINETYPE=${GCPKMS_MACHINETYPE:-"e2-micro"}
+export GCPKMS_DISKSIZE=${GCPKMS_DISKSIZE:-"20gb"}
 
 # download-gcloud.sh sets GCPKMS_GCLOUD.
 echo "download-gcloud.sh ... begin"

--- a/.evergreen/csfle/gcpkms/create-instance.sh
+++ b/.evergreen/csfle/gcpkms/create-instance.sh
@@ -7,7 +7,8 @@ if [ -z "$GCPKMS_DRIVERS_TOOLS" -o \
      -z "$GCPKMS_SERVICEACCOUNT" -o \
      -z "$GCPKMS_IMAGEPROJECT" -o \
      -z "$GCPKMS_IMAGEFAMILY" -o \
-     -z "$GCPKMS_MACHINETYPE" ]; then
+     -z "$GCPKMS_MACHINETYPE" -o \
+     -z "$GCPKMS_DISKSIZE" ]; then
     echo "Please set the following required environment variables"
     echo " GCPKMS_DRIVERS_TOOLS to the path of the drivers-evergreen-tools directory"
     echo " GCPKMS_GCLOUD to the path of the gcloud binary"
@@ -17,6 +18,7 @@ if [ -z "$GCPKMS_DRIVERS_TOOLS" -o \
     echo " GCPKMS_IMAGEPROJECT to the GCE image project (e.g. debian-cloud)"
     echo " GCPKMS_IMAGEFAMILY to the GCE image family (e.g. debian-11)"
     echo " GCPKMS_MACHINETYPE to the GCE machine type (e.g. e2-micro)"
+    echo " GCPKMS_DISKSIZE to the GCE disk size (e.g. 20gb)"
     exit 1
 fi
 GCPKMS_INSTANCENAME="instancename-$RANDOM"
@@ -36,5 +38,6 @@ $GCPKMS_GCLOUD compute instances create $GCPKMS_INSTANCENAME \
     --image-family $GCPKMS_IMAGEFAMILY \
     --metadata-from-file=startup-script=$GCPKMS_DRIVERS_TOOLS/.evergreen/csfle/gcpkms/remote-scripts/startup.sh \
     --scopes https://www.googleapis.com/auth/cloudkms,https://www.googleapis.com/auth/compute \
-    --metadata enable-oslogin=TRUE
+    --metadata enable-oslogin=TRUE \
+    --boot-disk-size $GCPKMS_DISKSIZE
 echo "Creating GCE instance ($GCPKMS_INSTANCENAME) ... end"


### PR DESCRIPTION
# Summary
- Increase boot disk size from 10GB to 20GB.
- Add `GCPKMS_DISKSIZE` option to permit configuration of boot disk size.

# Background & Motivation

This is intended to address the `No space left on device` error on the C# task for the [prose test case for GCP with KMS](https://github.com/mongodb/specifications/blob/c94fefe3e14d163bedcab75a761bc14a77ec689f/source/client-side-encryption/tests/README.rst#case-2-success-1).

With this change, the `create-and-setup-instance.sh` script produces two new warnings:

```
WARNING: You have selected a disk size of under [200GB]. This may result in poor I/O performance. For more information, see: https://developers.google.com/compute/docs/disks#performance.
Created [https://www.googleapis.com/compute/v1/projects/devprod-drivers/zones/us-east1-b/instances/instancename-16692].
WARNING: Some requests generated warnings:
 - Disk size: '20 GB' is larger than image size: '10 GB'. You might need to resize the root repartition manually if the operating system does not support automatic resizing. See https://cloud.google.com/compute/docs/disks/add-persistent-disk#resize_pd for details.
```

Both warnings seem OK to ignore. The default boot disk size for the debian-11 image is 10 GB, so 20 GB is enough. Debian does not require additional steps to use the larger disk.

Before this change, creating a 11GB file on the created GCE instance fails:
```
$ fallocate -l 11GB test.txt
fallocate: fallocate failed: No space left on device
```

After this change, creating a 11GB file on the created GCE instance succeeds:
```
$ fallocate -l 11GB test.txt
$ ls -lh
total 11G
-rwxr--r-- 1 sa_113233652026321183788 sa_113233652026321183788  46 Jan 23 18:00 sample-test.sh
-rw-r--r-- 1 sa_113233652026321183788 sa_113233652026321183788 11G Jan 23 18:00 test.txt
```

Tested with this [Go driver patch build](https://spruce.mongodb.com/version/63ceccbad6d80a77254b0851/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).