### PR TITLE
update mongohouse config

### DIFF
--- a/.evergreen/atlas_data_lake/config.yml
+++ b/.evergreen/atlas_data_lake/config.yml
@@ -1,5 +1,9 @@
 environment: local
-
+# hostProvider is the cloud provider in which this machine is running.
+hostProvider: local
+# Disable billing to silence a "no billing configured" warning.
+billing:
+  enabled: false
 showInternalErrors: true
 
 frontend:


### PR DESCRIPTION
# Summary

- Update mongohouse config to add `hostProvider` and disable `billing`

# Background & Motivation

The `run-mongohouse-local.sh` script is failing to start mongohoused and [reports this error](https://spruce.mongodb.com/task/mongo_go_driver_atlas_data_lake_test_test_atlas_data_lake_b1e7aa5b82b06ebfc32b035757cef43ac03e8869_23_01_24_18_38_30/logs?execution=1&sortBy=STATUS&sortDir=ASC):

```
$ sh .evergreen/atlas_data_lake/run-mongohouse-local.sh
*internal.Config: hostProvider not configured and <warning *internal.Config.Billing: no billing configured>
```

This appears to be caused by changes made in MHOUSE-6118. See https://mongodb.slack.com/archives/CKNS6CS72/p1674779015703769

This branch was tested with the Go driver in [this patch](https://spruce.mongodb.com/task/mongo_go_driver_atlas_data_lake_test_test_atlas_data_lake_patch_e1bf8858dd9ba111e880f8e5a8b7e7b7da64cb54_63d3f606c9ec440e8b7856b8_23_01_27_16_04_23/logs?execution=0). 