### PR TITLE
DRIVERS-2377 Define expansions for GCP earlier

### DIFF
--- a/.evergreen/csfle/gcpkms/create-and-setup-instance.sh
+++ b/.evergreen/csfle/gcpkms/create-and-setup-instance.sh
@@ -29,6 +29,12 @@ echo "create-instance.sh ... begin"
 . $GCPKMS_DRIVERS_TOOLS/.evergreen/csfle/gcpkms/create-instance.sh
 echo "create-instance.sh ... end"
 
+# Echo expansions required for delete-instance.sh. If the remaining setup fails, delete-instance.sh can still clean up resources.
+echo "GCPKMS_GCLOUD: $GCPKMS_GCLOUD" > testgcpkms-expansions.yml
+echo "GCPKMS_INSTANCENAME: $GCPKMS_INSTANCENAME" >> testgcpkms-expansions.yml
+echo "GCPKMS_PROJECT: $GCPKMS_PROJECT" >> testgcpkms-expansions.yml
+echo "GCPKMS_ZONE: $GCPKMS_ZONE" >> testgcpkms-expansions.yml
+
 # Wait for a maximum of five minutes for VM to finish booting.
 # Otherwise SSH may fail. See https://cloud.google.com/compute/docs/troubleshooting/troubleshooting-ssh.
 wait_for_server () {
@@ -53,7 +59,3 @@ echo "setup-instance.sh ... begin"
 . $GCPKMS_DRIVERS_TOOLS/.evergreen/csfle/gcpkms/setup-instance.sh
 echo "setup-instance.sh ... end"
 
-echo "GCPKMS_GCLOUD: $GCPKMS_GCLOUD" > testgcpkms-expansions.yml
-echo "GCPKMS_INSTANCENAME: $GCPKMS_INSTANCENAME" >> testgcpkms-expansions.yml
-echo "GCPKMS_PROJECT: $GCPKMS_PROJECT" >> testgcpkms-expansions.yml
-echo "GCPKMS_ZONE: $GCPKMS_ZONE" >> testgcpkms-expansions.yml

--- a/.evergreen/csfle/gcpkms/create-and-setup-instance.sh
+++ b/.evergreen/csfle/gcpkms/create-and-setup-instance.sh
@@ -55,6 +55,11 @@ echo "waiting for server to start ... begin"
 wait_for_server
 echo "waiting for server to start ... end"
 
+# Add expiration to the SSH key created. This is a fallback to identify old keys in case the SSH key is unable to be deleted in delete-instance.sh.
+echo "Adding expiration time to SSH key ... begin"
+$GCPKMS_GCLOUD compute os-login ssh-keys update --key-file ~/.ssh/google_compute_engine.pub --ttl 7200s
+echo "Adding expiration time to SSH key ... end"
+
 echo "setup-instance.sh ... begin"
 . $GCPKMS_DRIVERS_TOOLS/.evergreen/csfle/gcpkms/setup-instance.sh
 echo "setup-instance.sh ... end"


### PR DESCRIPTION
# Summary
- Define expansions for GCP earlier.
- Add 7200s expiration to SSH keys for GCP instances.

Changes verified with the [C driver](https://spruce.mongodb.com/version/63ed3c3757e85ad57ad2127b/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).

# Background & Motivation
The test-gcpkms task is [failing in drivers](https://spruce.mongodb.com/task/mongo_java_driver_testgcpkms_variant_testgcpkms_task_a7489266d5eced73ce129357ec1782accccf0a5a_23_02_13_19_44_46/logs?execution=0) with the message:

```
failed to ssh into 'instancename-14683'. Output of last attempt: ERROR: (gcloud.compute.ssh) INVALID_ARGUMENT: Login profile size exceeds 32 KiB. Delete profile values to make additional space.
```

Keys have been manually deleted using this [suggested solution](https://github.com/kyma-project/test-infra/issues/93#issuecomment-457263589):

```
for i in $(gcloud compute os-login ssh-keys list | grep -v FINGERPRINT); do echo $i; gcloud compute os-login ssh-keys remove --key $i; done
```

This PR intends to prevent this error in the future.

The SSH key created for the GCP test instances is intended to be deleted in [delete-instance.sh](https://github.com/mongodb-labs/drivers-evergreen-tools/blob/6ac2fdd5eadc0a9deb960c661c3f9ecca1b0cca9/.evergreen/csfle/gcpkms/delete-instance.sh). I suspect `delete-instance.sh` may not run in cases where `create-and-setup-instance.sh` fails before writing required expansions. That may result in a leftover SSH key.

This PR adds an expiration time for the SSH key is added as 7200s. This matches the [expiration time of the instance](https://github.com/mongodb-labs/drivers-evergreen-tools/blob/6ac2fdd5eadc0a9deb960c661c3f9ecca1b0cca9/.evergreen/csfle/gcpkms/remote-scripts/startup.sh#L5). The expiration does not appear to delete the SSH key ([asked here to confirm](https://www.googlecloudcommunity.com/gc/Infrastructure-Compute-Storage/Do-expired-SSH-keys-get-deleted/m-p/522601#M2455)), but will at least help identify old keys. `gcloud compute os-login ssh-keys list` does not identify the time the key was created, but includes the expiration time.