### PR TITLE
Remove nounset and avoid masking exit status of command substitutions

### DIFF
--- a/.evergreen/find-python3.sh
+++ b/.evergreen/find-python3.sh
@@ -33,7 +33,6 @@ fi
 # to silence these messages.
 is_python3() (
   set -o errexit
-  set -o nounset
   set -o pipefail
 
   # Binary to use, e.g. "python".
@@ -77,7 +76,6 @@ is_python3() (
 # to silence these messages.
 is_venv_capable() (
   set -o errexit
-  set -o nounset
   set -o pipefail
 
   local -r bin="${1:?'is_venv_capable requires a name or path of a python binary to test'}"
@@ -126,7 +124,6 @@ is_venv_capable() (
 # to silence these messages.
 is_virtualenv_capable() (
   set -o errexit
-  set -o nounset
   set -o pipefail
 
   local -r bin="${1:?'is_virtualenv_capable requires a name or path of a python binary to test'}"
@@ -189,7 +186,6 @@ is_virtualenv_capable() (
 #   fi
 find_python3() (
   set -o errexit
-  set -o nounset
   set -o pipefail
 
   local -a bins=()

--- a/.evergreen/find-python3.sh
+++ b/.evergreen/find-python3.sh
@@ -129,13 +129,15 @@ is_virtualenv_capable() (
   local -r bin="${1:?'is_virtualenv_capable requires a name or path of a python binary to test'}"
 
   # Use a temporary directory to avoid polluting the caller's environment.
-  local -r tmp="$(mktemp -d)"
+  local tmp
+  tmp="$(mktemp -d)"
   trap 'rm -rf "$tmp"' EXIT
 
+  local real_path
   if [[ "$OSTYPE" == cygwin ]]; then
-    local -r real_path="$(cygpath -aw "$tmp")" || return
+    real_path="$(cygpath -aw "$tmp")" || return
   else
-    local -r real_path="$tmp"
+    real_path="$tmp"
   fi
 
   # -p: some old versions of virtualenv (e.g. installed on Debian 10) are buggy.

--- a/.evergreen/venv-utils.sh
+++ b/.evergreen/venv-utils.sh
@@ -40,10 +40,11 @@ venvcreate() {
   local -r bin="${1:?'venvcreate requires a Python binary to use for the virtual environment'}"
   local -r path="${2:?'venvcreate requires a path to the virtual environment to create'}"
 
+  local real_path
   if [[ "$OSTYPE" == cygwin ]]; then
-    local -r real_path="$(cygpath -aw "$path")" || return
+    real_path="$(cygpath -aw "$path")" || return
   else
-    local -r real_path="$path" || return
+    real_path="$path"
   fi
 
   # Prefer venv, but fallback to virtualenv if venv fails.


### PR DESCRIPTION
Examination of Evergreen logs in recent tests revealed the use of `nounset` within some subshell functions were excluding potentially viable Python binary candidates due to the generated activation scripts not satisfying the `nounset` condition (specifically due to the `PS1` environment variable being unset). This PR removes `nounset` to improve the selection of viable Python binaries.

Recent Bash experience also revealed that declaring a variable and immediately assigning it with value of a potentially-failing command substitution can [mask the exit status of the command substitution](http://mywiki.wooledge.org/BashPitfalls#local_var.3D.24.28cmd.29). Adjusted such instances accordingly so that command substitution failures are properly detected and handled.