### PR TITLE
Silence and ignore potential dos2unix conversion failures

### DIFF
--- a/.evergreen/find-python3.sh
+++ b/.evergreen/find-python3.sh
@@ -98,7 +98,9 @@ is_venv_capable() (
     # shellcheck source=/dev/null
     . "$tmp/bin/activate"
   elif [[ -f "$tmp/Scripts/activate" ]]; then
-    dos2unix "$tmp/Scripts/activate" || return
+    # Workaround https://bugs.python.org/issue32451:
+    # mongovenv/Scripts/activate: line 3: $'\r': command not found
+    dos2unix -q "$tmp/Scripts/activate" || true
     # shellcheck source=/dev/null
     . "$tmp/Scripts/activate"
   else
@@ -150,7 +152,9 @@ is_virtualenv_capable() (
     # shellcheck source=/dev/null
     . "$tmp/bin/activate"
   elif [[ -f "$tmp/Scripts/activate" ]]; then
-    dos2unix "$tmp/Scripts/activate" || return
+    # Workaround https://bugs.python.org/issue32451:
+    # mongovenv/Scripts/activate: line 3: $'\r': command not found
+    dos2unix -q "$tmp/Scripts/activate" || true
     # shellcheck source=/dev/null
     . "$tmp/Scripts/activate"
   else

--- a/.evergreen/venv-utils.sh
+++ b/.evergreen/venv-utils.sh
@@ -72,7 +72,7 @@ venvcreate() {
     # Workaround https://bugs.python.org/issue32451:
     # mongovenv/Scripts/activate: line 3: $'\r': command not found
     if [[ -f "$path/Scripts/activate" ]]; then
-      dos2unix "$path/Scripts/activate" || continue
+      dos2unix -q "$path/Scripts/activate" || true
     fi
 
     venvactivate "$path" || continue


### PR DESCRIPTION
Motivated by https://github.com/mongodb-labs/drivers-evergreen-tools/pull/260#discussion_r1114756250.

The invocation of `dos2unix` is intended to workaround the [as-of-yet unresolved issue with activation scripts generated by venv](https://bugs.python.org/issue32451) in Cygwin environments. Use of `dos2unix` as a simple workaround improves the viability of using recent Python binaries and the venv module over virtualenv.

Error handling was added to its invocation as part of https://github.com/mongodb-labs/drivers-evergreen-tools/pull/236. However, given this was observed to cause some friction during local development on Windows, this PR suggests silencing and ignoring potential `dos2unix` failures (as it had been done previously) in favor of allowing failure detection and handling in later stages of virtual environment use should they occur. This change is not expected to affect the scripts' behavior in Evergreen environments.

As a minor improvement, copied over rationale for the workaround from venv-utils.sh into all instances of invoking `dos2unix` for visibility.