### PR TITLE
DRIVERS-2411 Do not skip install of `azure-cli` if `az` is detected

### DIFF
--- a/.evergreen/csfle/azurekms/install-az.sh
+++ b/.evergreen/csfle/azurekms/install-az.sh
@@ -6,10 +6,12 @@ set -o nounset
 # Install az CLI for Debian/Ubuntu.
 # https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt#option-2-step-by-step-installation-instructions
 echo "Install az ... begin"
-if command -v az &> /dev/null; then
-    echo "az is already installed"
-    exit 0
-fi
+# Always install the latest `az`. The debian11 distros may have an older version of `az` installed that do not support required options.
+# Once BUILD-16836 is resolved, uncomment the following to skip an unnecessary install attempt.
+# if command -v az &> /dev/null; then
+#     echo "az is already installed"
+#     exit 0
+# fi
 sudo apt-get update
 sudo apt-get install -y ca-certificates curl apt-transport-https lsb-release gnupg
 curl -sL https://packages.microsoft.com/keys/microsoft.asc |

--- a/.evergreen/csfle/azurekms/install-az.sh
+++ b/.evergreen/csfle/azurekms/install-az.sh
@@ -22,4 +22,5 @@ echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO 
     sudo tee /etc/apt/sources.list.d/azure-cli.list
 sudo apt-get update
 sudo apt-get install -y azure-cli
+az --version
 echo "Install az ... end"

--- a/.evergreen/csfle/azurekms/install-az.sh
+++ b/.evergreen/csfle/azurekms/install-az.sh
@@ -6,12 +6,7 @@ set -o nounset
 # Install az CLI for Debian/Ubuntu.
 # https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt#option-2-step-by-step-installation-instructions
 echo "Install az ... begin"
-# Always install the latest `az`. The debian11 distros may have an older version of `az` installed that do not support required options.
-# Once BUILD-16836 is resolved, uncomment the following to skip an unnecessary install attempt.
-# if command -v az &> /dev/null; then
-#     echo "az is already installed"
-#     exit 0
-# fi
+# Once a sufficient version of `az` is installed on all tested distros, remove the install-az.sh script. BUILD-16836 requests installation of the latest `az` on supported distros.
 sudo apt-get update
 sudo apt-get install -y ca-certificates curl apt-transport-https lsb-release gnupg
 curl -sL https://packages.microsoft.com/keys/microsoft.asc |


### PR DESCRIPTION
# Summary

- Do not skip install of `azure-cli` if `az` is detected.
- Print `az --version`

# Background & Motivation

Drivers tests [using Azure scripts are failing](https://parsley.mongodb.com/evergreen/mongo_java_driver_testazurekms_variant_testazurekms_task_a7489266d5eced73ce129357ec1782accccf0a5a_23_02_13_19_44_46/0/task?bookmarks=0,330&shareLine=298) with this message:

```
ERROR: UnrecognizedArgumentError: unrecognized arguments: --nic-delete-option Delete --data-disk-delete-option Delete --os-disk-delete-option Delete
```

The tests fail on Debian11 hosts, but not Debian10 hosts. The cause appears to be an older version of `azure-cli` being installed on `debian10`.

The script is invoking `azure vm create` with the delete options (`--nic-delete-option`, `--data-disk-delete-option`, and `--os-disk-delete-option`).

The delete options were added in Azure CLI 2.25.0:
https://learn.microsoft.com/en-us/cli/azure/release-notes-azure-cli#june-15-2021

> `az vm create`: Support delete option for NICs and Disks for VMs in Azure CLI

The version of azure-cli packaged on Debian 11 (Bullseye) [is 2.18.0](https://packages.debian.org/search?keywords=azure-cli&searchon=names&suite=bullseye&section=all). BUILD-16836 requests a newer version of `azure-cli` on `debian11`.

Tested [with the Java driver](https://spruce.mongodb.com/version/63f6703f7742ae619b17fa80/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC), and verified [with this patch](https://spruce.mongodb.com/version/63f7989b32f41743079443f3/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) the `install-az.sh` script works on supported Ubuntu and Debian distros.