### PR TITLE
fix(DRIVERS-2415): bring back token endpoint

### DIFF
--- a/.evergreen/auth_oidc/oidc_write_orchestration.py
+++ b/.evergreen/auth_oidc/oidc_write_orchestration.py
@@ -58,9 +58,7 @@ def main():
     provider1_info['matchPattern'] = "test_user1"
     provider2_info = {
         "deviceAuthorizationEndpoint": MOCK_ENDPOINT,
-        # TODO: this should be uncommented before merging, once
-        # https://jira.mongodb.org/browse/SERVER-70958 is merged.
-        #"tokenEndpoint": MOCK_ENDPOINT,
+        "tokenEndpoint": MOCK_ENDPOINT,
         "JWKSUri": secrets['oidc_jwks_uri'],
         "authNamePrefix": "test2",
         "issuer": secrets['oidc_issuer_2_uri'],


### PR DESCRIPTION
SERVER-70958 merged so need the `tokenEndpoint` field back in the config, otherwise:

_"BadValue: Bad value for parameter "oidcIdentityProviders": BSON field 'IDPConfiguration.tokenEndpoint' is missing but a required field"_