### PR TITLE
DRIVERS-2377 run apt-get update in setup-gce-instance.sh

### DIFF
--- a/.evergreen/csfle/gcpkms/remote-scripts/setup-gce-instance.sh
+++ b/.evergreen/csfle/gcpkms/remote-scripts/setup-gce-instance.sh
@@ -3,6 +3,7 @@
 set -o errexit # Exit on first command error.
 
 echo "Installing dependencies ... begin"
+sudo apt-get update
 # Dependencies for mongod: https://www.mongodb.com/docs/manual/tutorial/install-mongodb-enterprise-on-debian-tarball/
 sudo apt-get -y install libcurl4 libgssapi-krb5-2 libldap-2.4-2 libwrap0 libsasl2-2 libsasl2-modules libsasl2-modules-gssapi-mit snmp openssl liblzma5
 # Dependencies for run-orchestration.sh


### PR DESCRIPTION
# Summary
- run `apt-get update` in setup-gce-instance.sh

# Background & Motivation
Fixes failures observed in the `test_gcpkms` task for the C driver:

```
[2023/02/28 16:31:19.508] E: Failed to fetch http://security.debian.org/debian-security/pool/updates/main/t/tiff/libtiff5_4.2.0-1%2bdeb11u3_amd64.deb  404  Not Found [IP: 146.75.34.132 80]
[2023/02/28 16:31:19.510] E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

Fix has been verified tested with the C driver in this [patch build](https://spruce.mongodb.com/version/63ff93b25623435ea1e7befe/).