### PR TITLE
Fix Failing EG Builds

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -147,7 +147,6 @@ functions:
         aws_secret: ${aws_secret}
         remote_file: ${UPLOAD_BUCKET}/${build_variant}/${revision}/${branch_name}/${BUILD_NAME}/build.tar.gz
         bucket: mciuploads
-        local_file: build.tar.gz
         extract_to: ${PROJECT_DIRECTORY}
 
   "exec compile script" :

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -148,11 +148,7 @@ functions:
         remote_file: ${UPLOAD_BUCKET}/${build_variant}/${revision}/${branch_name}/${BUILD_NAME}/build.tar.gz
         bucket: mciuploads
         local_file: build.tar.gz
-    - command: shell.exec
-      params:
-        continue_on_err: true
-        # EVG-1105: Use s3.get extract_to: ./
-        script: "cd .. && rm -rf ${PROJECT_DIRECTORY} && mkdir ${PROJECT_DIRECTORY}/ && tar xf build.tar.gz -C ${PROJECT_DIRECTORY}/"
+        extract_to: ${PROJECT_DIRECTORY}
 
   "exec compile script" :
     - command: shell.exec

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -131,7 +131,7 @@ functions:
         aws_secret: ${aws_secret}
         local_file: ${build_id}.tar.gz
         # Example: /mciuploads/${UPLOAD_BUCKET}/gcc49/9dfb7d741efbca16faa7859b9349d7a942273e43/debug-compile-nosasl-nossl/mongo_c_driver_releng_9dfb7d741efbca16faa7859b9349d7a942273e43_16_11_08_19_29_52.tar.gz
-        remote_file: ${UPLOAD_BUCKET}/${build_variant}/${revision}/${task_name}/${build_id}.tar.gz
+        remote_file: ${UPLOAD_BUCKET}/${build_variant}/${revision}/${branch_name}/${task_name}/build.tar.gz
         bucket: mciuploads
         permissions: public-read
         content_type: ${content_type|application/x-gzip}
@@ -145,7 +145,7 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        remote_file: ${UPLOAD_BUCKET}/${build_variant}/${revision}/${BUILD_NAME}/${build_id}.tar.gz
+        remote_file: ${UPLOAD_BUCKET}/${build_variant}/${revision}/${branch_name}/${BUILD_NAME}/build.tar.gz
         bucket: mciuploads
         local_file: build.tar.gz
     - command: shell.exec

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -496,6 +496,8 @@ tasks:
       commands:
         # Fetch the make-release-archive generated archive, rather then the git clone
         - func: "fetch build"
+          vars:
+            BUILD_NAME: "make-release-archive"
         - func: "exec script"
           vars:
             file: ".evergreen/compile.sh"
@@ -509,6 +511,8 @@ tasks:
       commands:
         # Fetch the make-release-archive generated archive, rather then the git clone
         - func: "fetch build"
+          vars:
+            BUILD_NAME: "make-release-archive"
         - func: "exec compile script"
           vars:
             file: ".evergreen/compile.sh"
@@ -792,9 +796,9 @@ axes:
         display_name: "Debian 8.1"
         run_on: debian81-test
 
-      - id: rhel72-zseries-test
-        display_name: "RHEL 7.2 (zSeries)"
-        run_on: rhel72-zseries-test
+      - id: rhel70-small
+        display_name: "RHEL 7.0"
+        run_on: rhel70-small
 
   # OSes that support versions of MongoDB>=4.2 with SSL.
   - id: os-requires-42
@@ -805,7 +809,7 @@ axes:
         run_on: debian92-test
 
       - id: ubuntu-18.04
-        display_name: "Ubuntu 18.04 (Requires 4.2)"
+        display_name: "Ubuntu 18.0ß4 (Requires 4.2)"
         run_on: ubuntu1804-test
 
       - id: ubuntu1804-arm64-small

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -804,7 +804,7 @@ axes:
         run_on: debian92-test
 
       - id: ubuntu-18.04
-        display_name: "Ubuntu 18.0ß4 (Requires 4.2)"
+        display_name: "Ubuntu 18.04 (Requires 4.2)"
         run_on: ubuntu1804-test
 
       - id: ubuntu1804-arm64-small


### PR DESCRIPTION
- Servers were failing to [start](https://spruce.mongodb.com/task/drivers_tools_tests_os_requires_36__os_requires_36~rhel72_zseries_test_auth~auth_ssl~nossl_test_3.6_sharded_cluster_6362b957e40af2ef8f4438efc719abf37b368479_23_03_17_17_44_27/tests?execution=0&sortBy=STATUS&sortDir=ASC) on Rhel 7.2 (ZSeries), move to Rhel 7.0 Small
- The build upload/fetch was [failing](https://spruce.mongodb.com/task/drivers_tools_releng_release_archive_creator_release_compile_6362b957e40af2ef8f4438efc719abf37b368479_23_03_17_17_44_27/logs?execution=0) on the Release tasks