### PR TITLE
Add DPkg::Lock::Timeout to apt-get install commands

### DIFF
--- a/.evergreen/auth_oidc/Dockerfile
+++ b/.evergreen/auth_oidc/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-RUN apt-get update -qq && apt-get install -qqy --no-install-recommends \
+RUN apt-get -qq update && apt-get -qqy -o DPkg::Lock::Timeout=-1 install --no-install-recommends \
   git \
   ca-certificates \
   curl \

--- a/.evergreen/csfle/azurekms/install-az.sh
+++ b/.evergreen/csfle/azurekms/install-az.sh
@@ -8,7 +8,7 @@ set -o nounset
 echo "Install az ... begin"
 # Once a sufficient version of `az` is installed on all tested distros, remove the install-az.sh script. BUILD-16836 requests installation of the latest `az` on supported distros.
 sudo apt-get update
-sudo apt-get install -y ca-certificates curl apt-transport-https lsb-release gnupg
+sudo apt-get -y -o DPkg::Lock::Timeout=-1 install ca-certificates curl apt-transport-https lsb-release gnupg
 curl -sL https://packages.microsoft.com/keys/microsoft.asc |
     gpg --dearmor |
     sudo tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null
@@ -16,6 +16,6 @@ AZ_REPO=$(lsb_release -cs)
 echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" |
     sudo tee /etc/apt/sources.list.d/azure-cli.list
 sudo apt-get update
-sudo apt-get install -y azure-cli
+sudo apt-get -y -o DPkg::Lock::Timeout=-1 install -y azure-cli
 az --version
 echo "Install az ... end"

--- a/.evergreen/csfle/azurekms/remote-scripts/setup-azure-vm.sh
+++ b/.evergreen/csfle/azurekms/remote-scripts/setup-azure-vm.sh
@@ -4,17 +4,17 @@ set -o pipefail
 # Do not error on unset variables. run-orchestration.sh accesses unset variables.
 
 echo "Install jq ... begin"
-sudo apt-get install jq -y
+sudo apt-get -y -o DPkg::Lock::Timeout=-1 install jq
 echo "Install jq ... end"
 
 echo "Installing MongoDB dependencies ... begin"
 # Dependencies for mongod: https://www.mongodb.com/docs/manual/tutorial/install-mongodb-enterprise-on-debian-tarball/
-sudo apt-get -y install libcurl4 libgssapi-krb5-2 libldap-2.4-2 libwrap0 libsasl2-2 libsasl2-modules libsasl2-modules-gssapi-mit snmp openssl liblzma5
+sudo apt-get -y -o DPkg::Lock::Timeout=-1 install libcurl4 libgssapi-krb5-2 libldap-2.4-2 libwrap0 libsasl2-2 libsasl2-modules libsasl2-modules-gssapi-mit snmp openssl liblzma5
 # Dependencies for run-orchestration.sh
-sudo apt-get -y install virtualenv
-sudo apt-get -y install python3-pip
+sudo apt-get -y -o DPkg::Lock::Timeout=-1 install virtualenv
+sudo apt-get -y -o DPkg::Lock::Timeout=-1 install python3-pip
 # Install git.
-sudo apt-get -y install git
+sudo apt-get -y -o DPkg::Lock::Timeout=-1 install git
 echo "Installing MongoDB dependencies ... end"
 
 echo "Starting MongoDB server ... begin"

--- a/.evergreen/csfle/gcpkms/remote-scripts/setup-gce-instance.sh
+++ b/.evergreen/csfle/gcpkms/remote-scripts/setup-gce-instance.sh
@@ -5,12 +5,12 @@ set -o errexit # Exit on first command error.
 echo "Installing dependencies ... begin"
 sudo apt-get update
 # Dependencies for mongod: https://www.mongodb.com/docs/manual/tutorial/install-mongodb-enterprise-on-debian-tarball/
-sudo apt-get -y install libcurl4 libgssapi-krb5-2 libldap-2.4-2 libwrap0 libsasl2-2 libsasl2-modules libsasl2-modules-gssapi-mit snmp openssl liblzma5
+sudo apt-get -y -o DPkg::Lock::Timeout=-1 install libcurl4 libgssapi-krb5-2 libldap-2.4-2 libwrap0 libsasl2-2 libsasl2-modules libsasl2-modules-gssapi-mit snmp openssl liblzma5
 # Dependencies for run-orchestration.sh
-sudo apt-get -y install virtualenv
-sudo apt-get -y install python3-pip
+sudo apt-get -y -o DPkg::Lock::Timeout=-1 install virtualenv
+sudo apt-get -y -o DPkg::Lock::Timeout=-1 install python3-pip
 # Install git.
-sudo apt-get -y install git
+sudo apt-get -y -o DPkg::Lock::Timeout=-1 install git
 echo "Installing dependencies ... end"
 
 echo "Starting MongoDB server ... begin"

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -25,7 +25,7 @@ case "$DISTRO" in
    linux-ubuntu*)
       echo "Install Ubuntu dependencies"
       sudo apt-get update || true
-      sudo apt-get install -y awscli || true
+      sudo apt-get -y -o DPkg::Lock::Timeout=-1 install awscli || true
       ;;
 
    sunos*)
@@ -37,4 +37,3 @@ case "$DISTRO" in
       echo "All other platforms..."
       ;;
 esac
-


### PR DESCRIPTION
This PR is motivated by the occasional observation of the following error (by multiple Drivers teams) when running Azure KMS tests:

```
E: Could not get lock /var/lib/dpkg/lock-frontend - open (11: Resource temporarily unavailable)
E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it?
```

This PR proposes adding the [undocumented(?)](https://manpages.ubuntu.com/manpages/jammy/man5/apt.conf.5.html) `DPkg::Lock::Timeout` option when invoking `apt-get install` to use its built-in support for [waiting on the dpkg lock](https://salsa.debian.org/apt-team/apt/-/merge_requests/109/diffs?commit_id=93e1565796b61eb44bec39f50e09a34cbe090178) instead of triggering an immediate error. This is probably preferable to [bypassing the lock](https://manpages.ubuntu.com/manpages/jammy/en/man1/dpkg.1.html) via `DPKG_FRONTEND_LOCKED`.

In `apt-get` versions [prior to 1.9.11](https://salsa.debian.org/apt-team/apt/-/commit/de9762d5443b8a957fae781bbdc4a740cc6c4e6f), the option will simply be ignored by the command. This applies to the ubuntu1404, ubuntu1604, ubuntu1804, debian81, and debian91 distros.

Note this option only applies to the `apt-get install` program. There is the possibility that `apt-get update` may also fail when attempting to acquire it's own apt lock (separate from the dpkg lock). This can be addressed by setting the `Debug::NoLocking=true` option if deemed necessary.

Also note that the timeout is currently set to `-1` to wait indefinitely for the dpkg lock to be released. If we do not want to wait indefinitely, we can set an explicit value (in seconds) instead.