### PR TITLE
Bump rapid version to 6.2.1

### DIFF
--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -53,7 +53,7 @@ get_mongodb_download_url_for ()
    _VERSION=$2
 
    # Set VERSION_RAPID to the latest rapid release each quarter.
-   VERSION_RAPID="6.1.1"
+   VERSION_RAPID="6.2.1"
    VERSION_MONGOSH="1.6.2"
    VERSION_60_LATEST="v6.0-latest"
    VERSION_60="6.0.5"


### PR DESCRIPTION
6.2 was released in February, so this PR updates our rapid version to 6.2.1.