### PR TITLE
DRIVERS-2435 add option to enable `featureFlagFLE2ProtocolVersion2` 

### DIFF
--- a/.evergreen/orchestration/setfle2parameter.py
+++ b/.evergreen/orchestration/setfle2parameter.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""
+setfle2parameter.py modifies and prints an orchestration config file to add the `--setParameter featureFlagFLE2ProtocolVersion2=1` option to mongod and mongos.
+Usage: setfle2parameter.py <orchestration config file path>
+This file is a temporary workaround until featureFlagFLE2ProtocolVersion2 is enabled by default in SERVER-69563. Once latest server builds have SERVER-69563, this file may be removed.
+"""
+
+import json
+import sys
+import unittest
+import os
+
+
+def do_rewrite(config):
+    did_rewrite = False
+
+    def rewrite_server(server):
+        nonlocal did_rewrite
+        if "procParams" in server:
+            if "setParameter" in server["procParams"]:
+                server["procParams"]["setParameter"]["featureFlagFLE2ProtocolVersion2"] = "1"
+            else:
+                server["procParams"]["setParameter"] = {
+                    "featureFlagFLE2ProtocolVersion2": "1"
+                }
+            did_rewrite = True
+
+    # Rewrite for a server.
+    rewrite_server(config)
+    # Rewrite for each member in a replica set.
+    if "members" in config:
+        for server in config["members"]:
+            rewrite_server(server)
+    # Rewrite each shard.
+    if "shards" in config:
+        for shard in config["shards"]:
+            if "shardParams" in shard:
+                if "members" in shard["shardParams"]:
+                    for server in shard["shardParams"]["members"]:
+                        rewrite_server (server)
+    # Rewrite each router.
+    if "routers" in config:
+        for router in config["routers"]:
+            # routers do not use `procParams`. Use setParameter directly.
+            if "setParameter" in router:
+                router["setParameter"]["featureFlagFLE2ProtocolVersion2"] = "1"
+            else:
+                router["setParameter"] = {
+                    "featureFlagFLE2ProtocolVersion2": "1"
+                }
+            did_rewrite = True
+
+
+    if not did_rewrite:
+        raise Exception(
+            "Did not add setParameter. Does the orchestration config have `procParams`?"
+        )
+    pass
+
+
+class TestRewrite(unittest.TestCase):
+    def test_rewrite(self):
+        # Test that setParameter is added for a server.
+        input = {
+            "procParams": {}
+        }
+        do_rewrite (input)
+        self.assertEqual (input, {
+            "procParams": {
+                "setParameter": {
+                    "featureFlagFLE2ProtocolVersion2": "1"
+                }
+            }
+        })
+
+        # Test that other setParameter values are kept for a server.
+        input = {
+            "procParams": {
+                "setParameter": {
+                    "foo": "bar"
+                }
+            }
+        }
+        do_rewrite (input)
+        self.assertEqual (input, {
+            "procParams": {
+                "setParameter": {
+                    "foo": "bar",
+                    "featureFlagFLE2ProtocolVersion2": "1"
+                }
+            }
+        })
+
+        # Test that setParameter is added for a replica_set.
+        input = {
+            "members": [
+                {"procParams": {}},
+                {"procParams": {}},
+            ]
+        }
+        do_rewrite(input)
+        self.assertEqual(
+            input,
+            {
+                "members": [
+                    {
+                        "procParams": {
+                            "setParameter": {"featureFlagFLE2ProtocolVersion2": "1"}
+                        }
+                    },
+                    {
+                        "procParams": {
+                            "setParameter": {"featureFlagFLE2ProtocolVersion2": "1"}
+                        }
+                    },
+                ]
+            },
+        )
+
+        # Test that setParameter is added for shards and routers.
+        input = {
+            "shards": [
+                {"shardParams": {"members": [{"procParams": {}}, {"procParams": {}}]}}
+            ],
+            "routers": [{}, {}],
+        }
+
+        do_rewrite(input)
+        self.assertEqual(
+            input,
+            {
+                "shards": [
+                    {
+                        "shardParams": {
+                            "members": [
+                                {
+                                    "procParams": {
+                                        "setParameter": {
+                                            "featureFlagFLE2ProtocolVersion2": "1"
+                                        }
+                                    }
+                                },
+                                {
+                                    "procParams": {
+                                        "setParameter": {
+                                            "featureFlagFLE2ProtocolVersion2": "1"
+                                        }
+                                    }
+                                },
+                            ]
+                        }
+                    }
+                ],
+                "routers": [
+                    {"setParameter": {"featureFlagFLE2ProtocolVersion2": "1"}},
+                    {"setParameter": {"featureFlagFLE2ProtocolVersion2": "1"}},
+                ],
+            },
+        )
+
+
+if __name__ == "__main__":
+    if os.environ.get("SELFTEST", "OFF") == "ON":
+        print("Doing self test")
+        unittest.main()
+        sys.exit(0)
+
+    if len(sys.argv) != 2:
+        print(
+            "Error: expected path to orchestration config file path as first argument"
+        )
+        print("Usage: setfle2parameter.py <orchestration config file path>")
+        sys.exit(1)
+
+    path = sys.argv[1]
+    with open(path, "r") as file:
+        config = json.loads(file.read())
+    do_rewrite(config)
+    print (json.dumps(config, indent=4))
+

--- a/.evergreen/orchestration/setfle2parameter.py
+++ b/.evergreen/orchestration/setfle2parameter.py
@@ -15,7 +15,6 @@ def do_rewrite(config):
     did_rewrite = False
 
     def rewrite_server(server):
-        nonlocal did_rewrite
         if "procParams" in server:
             if "setParameter" in server["procParams"]:
                 server["procParams"]["setParameter"]["featureFlagFLE2ProtocolVersion2"] = "1"
@@ -23,21 +22,25 @@ def do_rewrite(config):
                 server["procParams"]["setParameter"] = {
                     "featureFlagFLE2ProtocolVersion2": "1"
                 }
-            did_rewrite = True
+            return True
+        return False
 
     # Rewrite for a server.
-    rewrite_server(config)
+    if rewrite_server(config):
+        did_rewrite = True
     # Rewrite for each member in a replica set.
     if "members" in config:
         for server in config["members"]:
-            rewrite_server(server)
+            if rewrite_server(server):
+                did_rewrite = True
     # Rewrite each shard.
     if "shards" in config:
         for shard in config["shards"]:
             if "shardParams" in shard:
                 if "members" in shard["shardParams"]:
                     for server in shard["shardParams"]["members"]:
-                        rewrite_server (server)
+                        if rewrite_server (server):
+                            did_rewrite = True
     # Rewrite each router.
     if "routers" in config:
         for router in config["routers"]:

--- a/.evergreen/orchestration/setfle2parameter.py
+++ b/.evergreen/orchestration/setfle2parameter.py
@@ -3,6 +3,7 @@
 setfle2parameter.py modifies and prints an orchestration config file to add the `--setParameter featureFlagFLE2ProtocolVersion2=1` option to mongod and mongos.
 Usage: setfle2parameter.py <orchestration config file path>
 This file is a temporary workaround until featureFlagFLE2ProtocolVersion2 is enabled by default in SERVER-69563. Once latest server builds have SERVER-69563, this file may be removed.
+DRIVERS-2590 tracks removal of this file.
 """
 
 import json

--- a/.evergreen/run-orchestration.sh
+++ b/.evergreen/run-orchestration.sh
@@ -86,10 +86,10 @@ perl -p -i -e "s|ABSOLUTE_PATH_REPLACEMENT_TOKEN|${DRIVERS_TOOLS}|g" $ORCHESTRAT
 if [ "$ENABLE_featureFlagFLE2ProtocolVersion2" = "ON" -a "$MONGODB_VERSION" = "latest" ]; then
   # This is a temporary workaround until featureFlagFLE2ProtocolVersion2 is enabled by default in SERVER-69563. Once latest server builds have SERVER-69563, this if block may be removed.
   # DRIVERS-2590 tracks removal of this workaround.
-  echo "rewrite orchestration config to add setParameter featureFlagFLE2ProtocolVersion2=1 ... begin"
+  echo "SERVER-69563: rewrite orchestration config to add setParameter featureFlagFLE2ProtocolVersion2=1 ... begin"
   python $DIR/orchestration/setfle2parameter.py $ORCHESTRATION_FILE > $ORCHESTRATION_FILE.modified
   mv $ORCHESTRATION_FILE.modified $ORCHESTRATION_FILE
-  echo "rewrite orchestration config to add setParameter featureFlagFLE2ProtocolVersion2=1 ... end"
+  echo "SERVER-69563: rewrite orchestration config to add setParameter featureFlagFLE2ProtocolVersion2=1 ... end"
 fi
 
 export ORCHESTRATION_URL="http://localhost:8889/v1/${TOPOLOGY}s"

--- a/.evergreen/run-orchestration.sh
+++ b/.evergreen/run-orchestration.sh
@@ -83,7 +83,7 @@ fi
 
 perl -p -i -e "s|ABSOLUTE_PATH_REPLACEMENT_TOKEN|${DRIVERS_TOOLS}|g" $ORCHESTRATION_FILE
 
-if [ "$ENABLE_featureFlagFLE2ProtocolVersion2" = "ON" ]; then
+if [ "$ENABLE_featureFlagFLE2ProtocolVersion2" = "ON" -a "$MONGODB_VERSION" = "latest" ]; then
   # This is a temporary workaround until featureFlagFLE2ProtocolVersion2 is enabled by default in SERVER-69563. Once latest server builds have SERVER-69563, this if block may be removed.
   echo "rewrite orchestration config to add setParameter featureFlagFLE2ProtocolVersion2=1 ... begin"
   . "$DIR/find-python3.sh"

--- a/.evergreen/run-orchestration.sh
+++ b/.evergreen/run-orchestration.sh
@@ -97,7 +97,7 @@ if ! curl --silent --show-error --data @"$ORCHESTRATION_FILE" "$ORCHESTRATION_UR
   exit 1
 fi
 cat tmp.json
-URI=$(python -c 'import sys, json; j=json.load(open("tmp.json")); print(j["mongodb_auth_uri" if "mongodb_auth_uri" in j else "mongodb_uri"])' | tr -d '\r')
+URI=$(python -c 'import json; j=json.load(open("tmp.json")); print(j["mongodb_auth_uri" if "mongodb_auth_uri" in j else "mongodb_uri"])' | tr -d '\r')
 echo 'MONGODB_URI: "'$URI'"' > mo-expansion.yml
 echo $URI > $DRIVERS_TOOLS/uri.txt
 echo "Cluster URI: $URI"

--- a/.evergreen/run-orchestration.sh
+++ b/.evergreen/run-orchestration.sh
@@ -85,6 +85,7 @@ perl -p -i -e "s|ABSOLUTE_PATH_REPLACEMENT_TOKEN|${DRIVERS_TOOLS}|g" $ORCHESTRAT
 
 if [ "$ENABLE_featureFlagFLE2ProtocolVersion2" = "ON" -a "$MONGODB_VERSION" = "latest" ]; then
   # This is a temporary workaround until featureFlagFLE2ProtocolVersion2 is enabled by default in SERVER-69563. Once latest server builds have SERVER-69563, this if block may be removed.
+  # DRIVERS-2590 tracks removal of this workaround.
   echo "rewrite orchestration config to add setParameter featureFlagFLE2ProtocolVersion2=1 ... begin"
   python $DIR/orchestration/setfle2parameter.py $ORCHESTRATION_FILE > $ORCHESTRATION_FILE.modified
   mv $ORCHESTRATION_FILE.modified $ORCHESTRATION_FILE

--- a/.evergreen/run-orchestration.sh
+++ b/.evergreen/run-orchestration.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 set -o errexit  # Exit the script with error if any of the commands fail
 
 # Supported environment variables:
@@ -86,9 +86,7 @@ perl -p -i -e "s|ABSOLUTE_PATH_REPLACEMENT_TOKEN|${DRIVERS_TOOLS}|g" $ORCHESTRAT
 if [ "$ENABLE_featureFlagFLE2ProtocolVersion2" = "ON" -a "$MONGODB_VERSION" = "latest" ]; then
   # This is a temporary workaround until featureFlagFLE2ProtocolVersion2 is enabled by default in SERVER-69563. Once latest server builds have SERVER-69563, this if block may be removed.
   echo "rewrite orchestration config to add setParameter featureFlagFLE2ProtocolVersion2=1 ... begin"
-  . "$DIR/find-python3.sh"
-  PYTHON="$(find_python3)"
-  $PYTHON $DIR/orchestration/setfle2parameter.py $ORCHESTRATION_FILE > $ORCHESTRATION_FILE.modified
+  python $DIR/orchestration/setfle2parameter.py $ORCHESTRATION_FILE > $ORCHESTRATION_FILE.modified
   mv $ORCHESTRATION_FILE.modified $ORCHESTRATION_FILE
   echo "rewrite orchestration config to add setParameter featureFlagFLE2ProtocolVersion2=1 ... end"
 fi

--- a/.evergreen/run-orchestration.sh
+++ b/.evergreen/run-orchestration.sh
@@ -91,7 +91,7 @@ if [ "$ENABLE_featureFlagFLE2ProtocolVersion2" = "ON" -a "$MONGODB_VERSION" = "l
   ACTUAL_MONGODB_VERSION=$($DRIVERS_TOOLS/mongodb/bin/mongod --version | head -1 | awk '{print $3}')
   case $ACTUAL_MONGODB_VERSION in
   v7*)
-   python $DIR/setfle2parameter.py $ORCHESTRATION_FILE > $ORCHESTRATION_FILE.modified
+   python $DIR/orchestration/setfle2parameter.py $ORCHESTRATION_FILE > $ORCHESTRATION_FILE.modified
    mv $ORCHESTRATION_FILE.modified $ORCHESTRATION_FILE
    ;;
   *)

--- a/.evergreen/run-orchestration.sh
+++ b/.evergreen/run-orchestration.sh
@@ -87,8 +87,17 @@ if [ "$ENABLE_featureFlagFLE2ProtocolVersion2" = "ON" -a "$MONGODB_VERSION" = "l
   # This is a temporary workaround until featureFlagFLE2ProtocolVersion2 is enabled by default in SERVER-69563. Once latest server builds have SERVER-69563, this if block may be removed.
   # DRIVERS-2590 tracks removal of this workaround.
   echo "SERVER-69563: rewrite orchestration config to add setParameter featureFlagFLE2ProtocolVersion2=1 ... begin"
-  python $DIR/orchestration/setfle2parameter.py $ORCHESTRATION_FILE > $ORCHESTRATION_FILE.modified
-  mv $ORCHESTRATION_FILE.modified $ORCHESTRATION_FILE
+  # Only attempt to enable the feature flag if the server is 7.0.0. The 'latest' builds may not be updated to 7.0 yet.
+  ACTUAL_MONGODB_VERSION=$(./mongodb/bin/mongod --version | head -1 | awk '{print $3}')
+  case $ACTUAL_MONGODB_VERSION in
+  v7*)
+   python $DIR/setfle2parameter.py $ORCHESTRATION_FILE > $ORCHESTRATION_FILE.modified
+   mv $ORCHESTRATION_FILE.modified $ORCHESTRATION_FILE
+   ;;
+  *)
+   echo "mongod version $ACTUAL_MONGODB_VERSION is not v7. Not enabling featureFlagFLE2ProtocolVersion2"
+   ;;
+  esac
   echo "SERVER-69563: rewrite orchestration config to add setParameter featureFlagFLE2ProtocolVersion2=1 ... end"
 fi
 

--- a/.evergreen/run-orchestration.sh
+++ b/.evergreen/run-orchestration.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -o errexit  # Exit the script with error if any of the commands fail
 
 # Supported environment variables:

--- a/.evergreen/run-orchestration.sh
+++ b/.evergreen/run-orchestration.sh
@@ -88,7 +88,7 @@ if [ "$ENABLE_featureFlagFLE2ProtocolVersion2" = "ON" -a "$MONGODB_VERSION" = "l
   # DRIVERS-2590 tracks removal of this workaround.
   echo "SERVER-69563: rewrite orchestration config to add setParameter featureFlagFLE2ProtocolVersion2=1 ... begin"
   # Only attempt to enable the feature flag if the server is 7.0.0. The 'latest' builds may not be updated to 7.0 yet.
-  ACTUAL_MONGODB_VERSION=$(./mongodb/bin/mongod --version | head -1 | awk '{print $3}')
+  ACTUAL_MONGODB_VERSION=$($DRIVERS_TOOLS/mongodb/bin/mongod --version | head -1 | awk '{print $3}')
   case $ACTUAL_MONGODB_VERSION in
   v7*)
    python $DIR/setfle2parameter.py $ORCHESTRATION_FILE > $ORCHESTRATION_FILE.modified

--- a/.evergreen/run-orchestration.sh
+++ b/.evergreen/run-orchestration.sh
@@ -83,6 +83,16 @@ fi
 
 perl -p -i -e "s|ABSOLUTE_PATH_REPLACEMENT_TOKEN|${DRIVERS_TOOLS}|g" $ORCHESTRATION_FILE
 
+if [ "$ENABLE_featureFlagFLE2ProtocolVersion2" = "ON" ]; then
+  # This is a temporary workaround until featureFlagFLE2ProtocolVersion2 is enabled by default in SERVER-69563. Once latest server builds have SERVER-69563, this if block may be removed.
+  echo "rewrite orchestration config to add setParameter featureFlagFLE2ProtocolVersion2=1 ... begin"
+  . "$DIR/find-python3.sh"
+  PYTHON="$(find_python3)"
+  $PYTHON $DIR/orchestration/setfle2parameter.py $ORCHESTRATION_FILE > $ORCHESTRATION_FILE.modified
+  mv $ORCHESTRATION_FILE.modified $ORCHESTRATION_FILE
+  echo "rewrite orchestration config to add setParameter featureFlagFLE2ProtocolVersion2=1 ... end"
+fi
+
 export ORCHESTRATION_URL="http://localhost:8889/v1/${TOPOLOGY}s"
 
 # Start mongo-orchestration


### PR DESCRIPTION
# Summary

- Enable `featureFlagFLE2ProtocolVersion2` if environment variable `ENABLE_featureFlagFLE2ProtocolVersion2=ON` is set in `run-orchestration.sh`

Updated scripts were tested in Go driver tests: https://github.com/mongodb/mongo-go-driver/pull/1213

# Background & Motivation

Enabling `featureFlagFLE2ProtocolVersion2` is required to enable the Queryable Encryption v2 protocol. [SERVER-69563](https://jira.mongodb.org/browse/SERVER-69563) plans to enable the feature flag by default. Once the feature flag is enabled by default, the `setfle2parameter.py` script and check for `ENABLE_featureFlagFLE2ProtocolVersion2` can be removed. 
