### PR TITLE
DRIVERS-2328: Allow disabling usage of legacy shell

### DIFF
--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -54,7 +54,7 @@ get_mongodb_download_url_for ()
 
    # Set VERSION_RAPID to the latest rapid release each quarter.
    VERSION_RAPID="6.2.1"
-   VERSION_MONGOSH="1.6.2"
+   VERSION_MONGOSH="1.8.1"
    VERSION_60_LATEST="v6.0-latest"
    VERSION_60="6.0.5"
    VERSION_50="5.0.15"

--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -645,7 +645,7 @@ download_and_extract ()
    fi
 
    # Deprecated: this will be removed once drivers have updated to mongosh
-   if [ ! -e $DRIVERS_TOOLS/mongodb/bin/mongo -a ! -e $DRIVERS_TOOLS/mongodb/bin/mongo.exe ]; then
+   if [ -z "${SKIP_LEGACY_SHELL:-}" -a ! -e $DRIVERS_TOOLS/mongodb/bin/mongo -a ! -e $DRIVERS_TOOLS/mongodb/bin/mongo.exe ]; then
       # The legacy mongo shell is not included in server downloads of 6.0.0-rc6 or later. Refer: SERVER-64352.
       # Some test scripts use the mongo shell for setup.
       # Download 5.0 package to get the legacy mongo shell as a workaround until DRIVERS-2328 is addressed.

--- a/.evergreen/run-orchestration.sh
+++ b/.evergreen/run-orchestration.sh
@@ -145,5 +145,5 @@ EOT
 
 # Set the requireApiVersion parameter
 if [ ! -z "$REQUIRE_API_VERSION" ]; then
-  mongo $URI $MONGO_ORCHESTRATION_HOME/require-api-version.js
+  mongosh $URI $MONGO_ORCHESTRATION_HOME/require-api-version.js
 fi


### PR DESCRIPTION
This PR adds a new `SKIP_LEGACY_SHELL` variable to skip installing the legacy shell. This is necessary on platforms that don't have 5.0 builds which we use to download the legacy shell. It also changes the script to set `requireApiVersion` on the server to use mongosh instead of the legacy shell. While there are some platforms where mongosh is not available, I believe that we don't test the stable API on those platforms. If any drivers run into issues with this, please let me know.

The only usage of the legacy shell that is left are the AWS auth tests. These tests will be updated separately, as I'm currently not convinced they can run on mongosh at all, so they might have to be rewritten.

To test these changes in your driver before the PR is merged, apply the patch below. This should apply cleanly in any standard evergreen/config.yml.

```diff
diff --git a/evergreen/evergreen.yml b/evergreen/evergreen.yml
index 85223c09a3..4f75d0f345 100644
--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -114,7 +114,7 @@ functions:
             # If this was a patch build, doing a fresh clone would not actually test the patch
             cp -R ${PROJECT_DIRECTORY}/ $DRIVERS_TOOLS
           else
-            git clone https://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
+            git clone https://github.com/alcaeus/drivers-evergreen-tools.git --branch=drivers-2328-for-perf-testing --depth 1 $DRIVERS_TOOLS
           fi
           echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" > $MONGO_ORCHESTRATION_HOME/orchestration.config
```

To skip installing the legacy shell, set the `SKIP_LEGACY_SHELL` environment variable in the "bootstrap mongo-orchestration" build step (i.e. when calling `run-orchestration.sh`).