### PR TITLE
DRIVERS-2415 Add ECR Support

### DIFF
--- a/.evergreen/auth_oidc/Dockerfile
+++ b/.evergreen/auth_oidc/Dockerfile
@@ -1,19 +1,47 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
-RUN apt-get -qq update && apt-get -qqy -o DPkg::Lock::Timeout=-1 install --no-install-recommends \
+ENV DEBIAN_FRONTEND noninteractive
+
+# Set up mongodb-enterprise repo.
+RUN apt-get -qq update && apt-get -qqy install gnupg curl sudo && \
+curl -fsSL https://pgp.mongodb.com/server-6.0.asc | \
+ sudo gpg -o /usr/share/keyrings/mongodb-server-6.0.gpg \
+ --dearmor && \
+echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-6.0.gpg ] https://repo.mongodb.com/apt/ubuntu jammy/mongodb-enterprise/6.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-enterprise-6.0.list
+
+# Install deps.
+RUN apt-get -qq update && apt-get -qqy install --no-install-recommends \
   git \
-  ca-certificates \
-  curl \
   wget \
-  sudo \
-  gnupg \
-  python \
   python3 \
   python3-virtualenv \
   lsof \
-  libsnmp35 \
-  net-tools \
- && rm -rf /var/lib/apt/lists/*
+  mongodb-enterprise \
+&& rm -rf /var/lib/apt/lists/*
+
+ARG AWS_SECRET_ACCESS_KEY=""
+ARG AWS_ACCESS_KEY_ID=""
+ARG AWS_ROLE_ARN=""
+
+# Install drivers-evergreen-tools and write orchestration file.
+SHELL ["/bin/bash", "-c"]
+RUN export DRIVERS_TOOLS=/home/root/drivers-evergreen-tools && \
+git clone --branch https://github.com/blink1073/drivers-evergreen-tools.git $DRIVERS_TOOLS && \
+# Download mongodb and mongosh.
+export MONGODB_VERSION=latest && \
+cd $DRIVERS_TOOLS/.evergreen && \
+. ./download-mongodb.sh && \
+get_distro && \
+get_mongodb_download_url_for "$DISTRO" "$MONGODB_VERSION" && \
+get_mongodb_download_url_for "$DISTRO" && \
+download_and_extract "$MONGODB_DOWNLOAD_URL" "$EXTRACT" "$MONGOSH_DOWNLOAD_URL" "$EXTRACT_MONGOSH" && \
+# Write orchestration file.
+cd ./auth_oidc && \
+. ./activate-authoidcvenv.sh && \
+export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} && \
+export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} && \
+export AWS_ROLE_ARN=${AWS_ROLE_ARN} && \
+python oidc_write_orchestration.py
 
 COPY ./docker_entry.sh /home/root/docker_entry.sh
 

--- a/.evergreen/auth_oidc/Dockerfile
+++ b/.evergreen/auth_oidc/Dockerfile
@@ -1,7 +1,8 @@
 FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND noninteractive
-ENV DRIVERS_TOOLS /home/root/drivers-evergreen-tools
+ENV HOME /home/root
+ENV DRIVERS_TOOLS $HOME/drivers-evergreen-tools
 
 ARG AWS_SECRET_ACCESS_KEY=""
 ARG AWS_ACCESS_KEY_ID=""
@@ -47,6 +48,6 @@ export AWS_ROLE_ARN=${AWS_ROLE_ARN} && \
 export NO_IPV6=${NO_IPV6} && \
 python oidc_write_orchestration.py
 
-COPY ./.evergreen/auth_oidc/docker_entry.sh /home/root/docker_entry.sh
+COPY ./.evergreen/auth_oidc/docker_entry.sh $HOME/docker_entry.sh
 
 ENTRYPOINT ["/bin/bash", "/home/root/docker_entry.sh"]

--- a/.evergreen/auth_oidc/Dockerfile
+++ b/.evergreen/auth_oidc/Dockerfile
@@ -1,6 +1,12 @@
 FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND noninteractive
+ENV DRIVERS_TOOLS /home/root/drivers-evergreen-tools
+
+ARG AWS_SECRET_ACCESS_KEY=""
+ARG AWS_ACCESS_KEY_ID=""
+ARG AWS_ROLE_ARN=""
+ARG NO_IPV6=""
 
 # Set up mongodb-enterprise repo.
 RUN apt-get -qq update && apt-get -qqy install gnupg curl sudo && \
@@ -19,29 +25,28 @@ RUN apt-get -qq update && apt-get -qqy install --no-install-recommends \
   mongodb-enterprise \
 && rm -rf /var/lib/apt/lists/*
 
-ARG AWS_SECRET_ACCESS_KEY=""
-ARG AWS_ACCESS_KEY_ID=""
-ARG AWS_ROLE_ARN=""
+COPY . $DRIVERS_TOOLS
 
-# Install drivers-evergreen-tools and binaries, and write orchestration file.
-SHELL ["/bin/bash", "-c"]
-RUN export DRIVERS_TOOLS=/home/root/drivers-evergreen-tools && \
-git clone --branch DRIVERS-2415-8 https://github.com/blink1073/drivers-evergreen-tools.git $DRIVERS_TOOLS && \
-# Download mongodb and mongosh.
+# Install drivers-evergreen-tools and binaries.
+RUN cd $DRIVERS_TOOLS && \
+git clean -dffx && \
 export MONGODB_VERSION=latest && \
-cd $DRIVERS_TOOLS/.evergreen && \
-. ./download-mongodb.sh && \
+export SKIP_LEGACY_SHELL=1 && \
+. $DRIVERS_TOOLS/.evergreen/download-mongodb.sh && \
 get_distro && \
 get_mongodb_download_url_for "$DISTRO" "$MONGODB_VERSION" && \
-download_and_extract "$MONGODB_DOWNLOAD_URL" "$EXTRACT" "$MONGOSH_DOWNLOAD_URL" "$EXTRACT_MONGOSH" && \
-# Write orchestration file.
-cd ./auth_oidc && \
+download_and_extract "$MONGODB_DOWNLOAD_URL" "$EXTRACT" "$MONGOSH_DOWNLOAD_URL" "$EXTRACT_MONGOSH"
+
+# Write the orchestration file.
+SHELL ["/bin/bash", "-c"]
+RUN cd $DRIVERS_TOOLS/.evergreen/auth_oidc && \
 . ./activate-authoidcvenv.sh && \
 export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} && \
 export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} && \
 export AWS_ROLE_ARN=${AWS_ROLE_ARN} && \
+export NO_IPV6=${NO_IPV6} && \
 python oidc_write_orchestration.py
 
-COPY ./docker_entry.sh /home/root/docker_entry.sh
+COPY ./.evergreen/auth_oidc/docker_entry.sh /home/root/docker_entry.sh
 
 ENTRYPOINT ["/bin/bash", "/home/root/docker_entry.sh"]

--- a/.evergreen/auth_oidc/Dockerfile
+++ b/.evergreen/auth_oidc/Dockerfile
@@ -23,17 +23,16 @@ ARG AWS_SECRET_ACCESS_KEY=""
 ARG AWS_ACCESS_KEY_ID=""
 ARG AWS_ROLE_ARN=""
 
-# Install drivers-evergreen-tools and write orchestration file.
+# Install drivers-evergreen-tools and binaries, and write orchestration file.
 SHELL ["/bin/bash", "-c"]
 RUN export DRIVERS_TOOLS=/home/root/drivers-evergreen-tools && \
-git clone --branch https://github.com/blink1073/drivers-evergreen-tools.git $DRIVERS_TOOLS && \
+git clone --branch DRIVERS-2415-8 https://github.com/blink1073/drivers-evergreen-tools.git $DRIVERS_TOOLS && \
 # Download mongodb and mongosh.
 export MONGODB_VERSION=latest && \
 cd $DRIVERS_TOOLS/.evergreen && \
 . ./download-mongodb.sh && \
 get_distro && \
 get_mongodb_download_url_for "$DISTRO" "$MONGODB_VERSION" && \
-get_mongodb_download_url_for "$DISTRO" && \
 download_and_extract "$MONGODB_DOWNLOAD_URL" "$EXTRACT" "$MONGOSH_DOWNLOAD_URL" "$EXTRACT_MONGOSH" && \
 # Write orchestration file.
 cd ./auth_oidc && \

--- a/.evergreen/auth_oidc/README.md
+++ b/.evergreen/auth_oidc/README.md
@@ -39,3 +39,13 @@ To set up the server auth roles, run `mongosh setup_oidc.js`.
 Then, tests can be run against the server.  Set `AWS_WEB_IDENTITY_TOKEN_FILE` to either `/tmp/tokens/test_user1` or `/tmp/tokens/test_user2` as desired.
 
 The token in `/tmp/tokens/test_user1_expires` can be used to test expired credentials.
+
+
+## ECR
+
+Set the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` variables.
+
+Run `bash ./ecr_push.sh` to build and push the latest.
+
+Run `docker run -p 27017:27017 -p 27018:27018  857654397073.dkr.ecr.us-east-1.amazonaws.com/drivers-oidc:latest` to run
+the image locally.

--- a/.evergreen/auth_oidc/README.md
+++ b/.evergreen/auth_oidc/README.md
@@ -47,5 +47,4 @@ Set the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` variables.
 
 Run `bash ./ecr_push.sh` to build and push the latest.
 
-Run `docker run -p 27017:27017 -p 27018:27018  857654397073.dkr.ecr.us-east-1.amazonaws.com/drivers-oidc:latest` to run
-the image locally.
+To run locally, run `bash ./ecr_run.sh`.

--- a/.evergreen/auth_oidc/docker_entry.sh
+++ b/.evergreen/auth_oidc/docker_entry.sh
@@ -9,15 +9,9 @@ export ORCHESTRATION_FILE=auth-oidc.json
 export DRIVERS_TOOLS=$HOME/drivers-evergreen-tools
 export PROJECT_ORCHESTRATION_HOME=$DRIVERS_TOOLS/.evergreen/orchestration
 export MONGO_ORCHESTRATION_HOME=$HOME
-export NO_IPV6=${NO_IPV6:-""}
-
-if [ ! -d $DRIVERS_TOOLS ]; then
-    git clone --branch DRIVERS-2415 https://github.com/blink1073/drivers-evergreen-tools.git $DRIVERS_TOOLS
-fi
-
-cd $DRIVERS_TOOLS/.evergreen/auth_oidc
-. ./activate-authoidcvenv.sh
-python oidc_write_orchestration.py
+export SKIP_LEGACY_SHELL=1
+export SKIP_CRYPT_SHARED=1
+export SKIP_MONGODB_DOWNLOAD=1
 
 bash $DRIVERS_TOOLS/.evergreen/run-orchestration.sh
 $DRIVERS_TOOLS/mongodb/bin/mongosh $DRIVERS_TOOLS/.evergreen/auth_oidc/setup_oidc.js

--- a/.evergreen/auth_oidc/docker_entry.sh
+++ b/.evergreen/auth_oidc/docker_entry.sh
@@ -11,7 +11,7 @@ export PROJECT_ORCHESTRATION_HOME=$DRIVERS_TOOLS/.evergreen/orchestration
 export MONGO_ORCHESTRATION_HOME=$HOME
 export SKIP_LEGACY_SHELL=1
 export SKIP_CRYPT_SHARED=1
-export SKIP_MONGODB_DOWNLOAD=1
+export MONGODB_SKIP_DOWNLOAD=1
 
 bash $DRIVERS_TOOLS/.evergreen/run-orchestration.sh
 $DRIVERS_TOOLS/mongodb/bin/mongosh $DRIVERS_TOOLS/.evergreen/auth_oidc/setup_oidc.js

--- a/.evergreen/auth_oidc/docker_entry.sh
+++ b/.evergreen/auth_oidc/docker_entry.sh
@@ -9,10 +9,10 @@ export ORCHESTRATION_FILE=auth-oidc.json
 export DRIVERS_TOOLS=$HOME/drivers-evergreen-tools
 export PROJECT_ORCHESTRATION_HOME=$DRIVERS_TOOLS/.evergreen/orchestration
 export MONGO_ORCHESTRATION_HOME=$HOME
-export SKIP_LEGACY_SHELL=1
-export SKIP_CRYPT_SHARED=1
 export MONGODB_SKIP_DOWNLOAD=1
+export SKIP_CRYPT_SHARED=1
 
 bash $DRIVERS_TOOLS/.evergreen/run-orchestration.sh
+echo "here I am"
 $DRIVERS_TOOLS/mongodb/bin/mongosh $DRIVERS_TOOLS/.evergreen/auth_oidc/setup_oidc.js
 tail -f $MONGO_ORCHESTRATION_HOME/server.log

--- a/.evergreen/auth_oidc/docker_entry.sh
+++ b/.evergreen/auth_oidc/docker_entry.sh
@@ -3,6 +3,7 @@
 # Entry point for Dockerfile for launching an oidc-enabled server.
 #
 set -eux
+export HOME=/home/root
 export MONGODB_VERSION=latest
 export TOPOLOGY=replica_set
 export ORCHESTRATION_FILE=auth-oidc.json

--- a/.evergreen/auth_oidc/docker_entry.sh
+++ b/.evergreen/auth_oidc/docker_entry.sh
@@ -14,6 +14,5 @@ export MONGODB_SKIP_DOWNLOAD=1
 export SKIP_CRYPT_SHARED=1
 
 bash $DRIVERS_TOOLS/.evergreen/run-orchestration.sh
-echo "here I am"
 $DRIVERS_TOOLS/mongodb/bin/mongosh $DRIVERS_TOOLS/.evergreen/auth_oidc/setup_oidc.js
 tail -f $MONGO_ORCHESTRATION_HOME/server.log

--- a/.evergreen/auth_oidc/ecr_push.sh
+++ b/.evergreen/auth_oidc/ecr_push.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+export ACCT=857654397073
+export REPO=drivers-oidc
+
+aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $ACCT.dkr.ecr.us-east-1.amazonaws.com
+
+cd ../..
+docker build -t $REPO --build-arg AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" --build-arg AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" --build-arg AWS_ROLE_ARN=$AWS_ROLE_ARN --build-arg NO_IPV6=true -f .evergreen/auth_oidc/Dockerfile .
+
+docker tag oidc-test:latest $ACCT.dkr.ecr.us-east-1.amazonaws.com/$REPO
+
+docker push $ACCT.dkr.ecr.us-east-1.amazonaws.com/$REPO

--- a/.evergreen/auth_oidc/ecr_run.sh
+++ b/.evergreen/auth_oidc/ecr_run.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+export ACCT=857654397073
+export REPO=drivers-oidc
+
+aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $ACCT.dkr.ecr.us-east-1.amazonaws.com
+
+docker run -p 27017:27017 -p 27018:27018  $ACCT.dkr.ecr.us-east-1.amazonaws.com/$REPO:latest

--- a/.evergreen/auth_oidc/oidc_get_tokens.py
+++ b/.evergreen/auth_oidc/oidc_get_tokens.py
@@ -21,10 +21,16 @@ def main():
         'token_file': os.path.join(token_dir, 'test_user1')
     }
     get_id_token(config)
+    for i in range(2):
+        config['token_file'] = os.path.join(token_dir, f'test_user1_{i+1}')
+        get_id_token(config)
     config['issuer'] = secrets['oidc_issuer_2_uri']
     config['username'] = 'test_user2'
     config['token_file'] = os.path.join(token_dir, 'test_user2')
     get_id_token(config)
+    for i in range(2):
+        config['token_file'] = os.path.join(token_dir, f'test_user2_{i+1}')
+        get_id_token(config)
     config['issuer'] = secrets['oidc_issuer_1_uri']
     config['username'] = 'test_user1'
     config['token_file'] = os.path.join(token_dir, 'test_user1_expires')

--- a/.evergreen/auth_oidc/oidc_write_orchestration.py
+++ b/.evergreen/auth_oidc/oidc_write_orchestration.py
@@ -26,6 +26,7 @@ def main():
         "clientId": DEFAULT_CLIENT,
         "audience": DEFAULT_CLIENT,
         "authorizationClaim": "foo",
+        "requestScopes": ["fizz", "buzz"],
 
     }
     providers = json.dumps([provider1_info], separators=(',',':'))
@@ -59,6 +60,7 @@ def main():
         "audience": DEFAULT_CLIENT,
         "authorizationClaim": "bar",
         "matchPattern": "test_user2",
+        "requestScopes": ["foo", "bar"],
     }
     providers = [provider1_info, provider2_info]
     providers = json.dumps(providers, separators=(',',':'))

--- a/.evergreen/auth_oidc/start_local_server.sh
+++ b/.evergreen/auth_oidc/start_local_server.sh
@@ -11,5 +11,5 @@ if [[ -z "${AWS_ROLE_ARN}" ||  -z "${AWS_ACCESS_KEY_ID}" || -z "${AWS_SECRET_ACC
 fi
 
 cd ../..
-docker build -t oidc-test --build-arg AWS_ROLE_ARN=${AWS_ROLE_ARN} --build-arg AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} --build-arg AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} --build-arg NO_IPV6=true -f .evergreen/auth_oidc/Dockerfile .
-docker run -it -p 27017:27017 -p 27018:27018 -e HOME=/home/root oidc-test
+docker build -t drivers-oidc --build-arg AWS_ROLE_ARN=${AWS_ROLE_ARN} --build-arg AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} --build-arg AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} --build-arg NO_IPV6=true -f .evergreen/auth_oidc/Dockerfile .
+docker run -it -p 27017:27017 -p 27018:27018 drivers-oidc

--- a/.evergreen/auth_oidc/start_local_server.sh
+++ b/.evergreen/auth_oidc/start_local_server.sh
@@ -16,5 +16,5 @@ rm -rf $DRIVERS_TOOLS/.evergreen/auth_oidc/authoidcvenv
 rm -rf $DRIVERS_TOOLS/mongodb
 rm -rf $DRIVERS_TOOLS/legacy-shell-download
 rm -rf $DRIVERS_TOOLS/mongosh
-docker build -t oidc-test .
-docker run -it -v ${DRIVERS_TOOLS}:/home/root/drivers-evergreen-tools -p 27017:27017 -p 27018:27018 -e HOME=/home/root -e AWS_ROLE_ARN=${AWS_ROLE_ARN} -e AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} -e AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} -e NO_IPV6=true oidc-test
+docker build -t oidc-test --build-arg AWS_ROLE_ARN=${AWS_ROLE_ARN} --build-arg AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} --build-arg AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} --build-arg NO_IPV6=true .
+docker run -it -v ${DRIVERS_TOOLS}:/home/root/drivers-evergreen-tools -p 27017:27017 -p 27018:27018 -e HOME=/home/root oidc-test

--- a/.evergreen/auth_oidc/start_local_server.sh
+++ b/.evergreen/auth_oidc/start_local_server.sh
@@ -10,11 +10,6 @@ if [[ -z "${AWS_ROLE_ARN}" ||  -z "${AWS_ACCESS_KEY_ID}" || -z "${AWS_SECRET_ACC
     exit 1
 fi
 
-DRIVERS_TOOLS=${DRIVERS_TOOLS:-$(readlink -f ../..)}
-echo "Drivers tools: $DRIVERS_TOOLS"
-rm -rf $DRIVERS_TOOLS/.evergreen/auth_oidc/authoidcvenv
-rm -rf $DRIVERS_TOOLS/mongodb
-rm -rf $DRIVERS_TOOLS/legacy-shell-download
-rm -rf $DRIVERS_TOOLS/mongosh
-docker build -t oidc-test --build-arg AWS_ROLE_ARN=${AWS_ROLE_ARN} --build-arg AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} --build-arg AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} --build-arg NO_IPV6=true .
-docker run -it -v ${DRIVERS_TOOLS}:/home/root/drivers-evergreen-tools -p 27017:27017 -p 27018:27018 -e HOME=/home/root oidc-test
+cd ../..
+docker build -t oidc-test --build-arg AWS_ROLE_ARN=${AWS_ROLE_ARN} --build-arg AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} --build-arg AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} --build-arg NO_IPV6=true -f .evergreen/auth_oidc/Dockerfile .
+docker run -it -p 27017:27017 -p 27018:27018 -e HOME=/home/root oidc-test

--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -359,6 +359,7 @@ get_mongodb_download_url_for ()
          MONGODB_LATEST="http://downloads.10gen.com/linux/mongodb-linux-aarch64-enterprise-ubuntu2204-latest.tgz"
          MONGOSH="https://downloads.mongodb.com/compass/mongosh-${VERSION_MONGOSH}-linux-arm64.tgz"
              MONGODB_RAPID="http://downloads.10gen.com/linux/mongodb-linux-aarch64-enterprise-ubuntu2204-${VERSION_RAPID}.tgz"
+             MONGODB_70="http://downloads.10gen.com/linux/mongodb-linux-aarch64-enterprise-ubuntu2204-${VERSION_70}.tgz"
              MONGODB_60_LATEST="http://downloads.10gen.com/linux/mongodb-linux-aarch64-enterprise-ubuntu2204-${VERSION_60_LATEST}.tgz"
              MONGODB_60="http://downloads.10gen.com/linux/mongodb-linux-aarch64-enterprise-ubuntu2204-${VERSION_60}.tgz"
              MONGODB_50="http://downloads.10gen.com/linux/mongodb-linux-aarch64-enterprise-ubuntu2204-${VERSION_50}.tgz"
@@ -368,6 +369,7 @@ get_mongodb_download_url_for ()
          MONGODB_LATEST="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-ubuntu2204-latest.tgz"
          MONGOSH="https://downloads.mongodb.com/compass/mongosh-${VERSION_MONGOSH}-linux-x64.tgz"
              MONGODB_RAPID="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-ubuntu2204-${VERSION_RAPID}.tgz"
+             MONGODB_70="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-ubuntu2204-${VERSION_70}.tgz"
              MONGODB_60_LATEST="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-ubuntu2204-${VERSION_60_LATEST}.tgz"
              MONGODB_60="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-ubuntu2204-${VERSION_60}.tgz"
       ;;

--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -342,14 +342,28 @@ get_mongodb_download_url_for ()
              MONGODB_50="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-debian11-${VERSION_50}.tgz"
              # SERVER-62299 Added support for Debian 11 in 5.0.8 and 6.0.0-rc0
       ;;
+      linux-ubuntu-22.04-aarch64)
+         MONGODB_LATEST="http://downloads.10gen.com/linux/mongodb-linux-aarch64-enterprise-ubuntu2204-latest.tgz"
+         MONGOSH="https://downloads.mongodb.com/compass/mongosh-${VERSION_MONGOSH}-linux-arm64.tgz"
+             MONGODB_RAPID="http://downloads.10gen.com/linux/mongodb-linux-aarch64-enterprise-ubuntu2204-${VERSION_RAPID}.tgz"
+             MONGODB_60_LATEST="http://downloads.10gen.com/linux/mongodb-linux-aarch64-enterprise-ubuntu2204-${VERSION_60_LATEST}.tgz"
+             MONGODB_60="http://downloads.10gen.com/linux/mongodb-linux-aarch64-enterprise-ubuntu2204-${VERSION_60}.tgz"
+             MONGODB_50="http://downloads.10gen.com/linux/mongodb-linux-aarch64-enterprise-ubuntu2204-${VERSION_50}.tgz"
+             MONGODB_44="http://downloads.10gen.com/linux/mongodb-linux-aarch64-enterprise-ubuntu2204-${VERSION_44}.tgz"
+      ;;
+      linux-ubuntu-22.04*)
+         MONGODB_LATEST="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-ubuntu2204-latest.tgz"
+         MONGOSH="https://downloads.mongodb.com/compass/mongosh-${VERSION_MONGOSH}-linux-x64.tgz"
+             MONGODB_RAPID="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-ubuntu2204-${VERSION_RAPID}.tgz"
+             MONGODB_60_LATEST="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-ubuntu2204-${VERSION_60_LATEST}.tgz"
+             MONGODB_60="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-ubuntu2204-${VERSION_60}.tgz"
+      ;;
       linux-ubuntu-20.04-aarch64)
          MONGODB_LATEST="http://downloads.10gen.com/linux/mongodb-linux-aarch64-enterprise-ubuntu2004-latest.tgz"
          MONGOSH="https://downloads.mongodb.com/compass/mongosh-${VERSION_MONGOSH}-linux-arm64.tgz"
              MONGODB_RAPID="http://downloads.10gen.com/linux/mongodb-linux-aarch64-enterprise-ubuntu2004-${VERSION_RAPID}.tgz"
              MONGODB_60_LATEST="http://downloads.10gen.com/linux/mongodb-linux-aarch64-enterprise-ubuntu2004-${VERSION_60_LATEST}.tgz"
              MONGODB_60="http://downloads.10gen.com/linux/mongodb-linux-aarch64-enterprise-ubuntu2004-${VERSION_60}.tgz"
-             MONGODB_50="http://downloads.10gen.com/linux/mongodb-linux-aarch64-enterprise-ubuntu2004-${VERSION_50}.tgz"
-             MONGODB_44="http://downloads.10gen.com/linux/mongodb-linux-aarch64-enterprise-ubuntu2004-${VERSION_44}.tgz"
       ;;
       linux-ubuntu-20.04*)
          MONGODB_LATEST="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-ubuntu2004-latest.tgz"

--- a/.evergreen/run-orchestration.sh
+++ b/.evergreen/run-orchestration.sh
@@ -31,6 +31,7 @@ DIR=$(dirname $0)
 
 get_distro
 if [ -z "$MONGODB_SKIP_DOWNLOAD" ]; then
+  DL_START=$(date +%s)
   if [ -z "$MONGODB_DOWNLOAD_URL" ]; then
       get_mongodb_download_url_for "$DISTRO" "$MONGODB_VERSION"
   else
@@ -38,6 +39,9 @@ if [ -z "$MONGODB_SKIP_DOWNLOAD" ]; then
     get_mongodb_download_url_for "$DISTRO"
   fi
   download_and_extract "$MONGODB_DOWNLOAD_URL" "$EXTRACT" "$MONGOSH_DOWNLOAD_URL" "$EXTRACT_MONGOSH"
+else
+  # support DL_ELAPSED
+  sleep 1
 fi
 
 DL_END=$(date +%s)
@@ -100,9 +104,10 @@ if ! curl --silent --show-error --data @"$ORCHESTRATION_FILE" "$ORCHESTRATION_UR
 fi
 cat tmp.json
 URI=$(python3 -c 'import json; j=json.load(open("tmp.json")); print(j["mongodb_auth_uri" if "mongodb_auth_uri" in j else "mongodb_uri"])' | tr -d '\r')
-echo 'MONGODB_URI: "'$URI'"' > mo-expansion.yml
+echo '\nMONGODB_URI: "'$URI'"' > mo-expansion.yml
 echo $URI > $DRIVERS_TOOLS/uri.txt
-echo "Cluster URI: $URI"
+echo "\nCluster URI: $URI"
+
 # Define SKIP_CRYPT_SHARED=1 to skip downloading crypt_shared. This is useful for platforms that have a
 # server release but don't ship a corresponding crypt_shared release, like Amazon 2018.
 if [ -z "${SKIP_CRYPT_SHARED:-}" ]; then

--- a/.evergreen/run-orchestration.sh
+++ b/.evergreen/run-orchestration.sh
@@ -37,8 +37,7 @@ if [ -z "$MONGODB_SKIP_DOWNLOAD" ]; then
     # Even though we have the MONGODB_DOWNLOAD_URL, we still call this to get the proper EXTRACT variable
     get_mongodb_download_url_for "$DISTRO"
   fi
-    download_and_extract "$MONGODB_DOWNLOAD_URL" "$EXTRACT" "$MONGOSH_DOWNLOAD_URL" "$EXTRACT_MONGOSH"
-  fi
+  download_and_extract "$MONGODB_DOWNLOAD_URL" "$EXTRACT" "$MONGOSH_DOWNLOAD_URL" "$EXTRACT_MONGOSH"
 fi
 
 DL_END=$(date +%s)

--- a/.evergreen/run-orchestration.sh
+++ b/.evergreen/run-orchestration.sh
@@ -30,14 +30,15 @@ DIR=$(dirname $0)
 . $DIR/download-mongodb.sh
 
 get_distro
-if [ -z "$MONGODB_DOWNLOAD_URL" ]; then
-    get_mongodb_download_url_for "$DISTRO" "$MONGODB_VERSION"
-else
-  # Even though we have the MONGODB_DOWNLOAD_URL, we still call this to get the proper EXTRACT variable
-  get_mongodb_download_url_for "$DISTRO"
-fi
 if [ -z "$MONGODB_SKIP_DOWNLOAD" ]; then
-  download_and_extract "$MONGODB_DOWNLOAD_URL" "$EXTRACT" "$MONGOSH_DOWNLOAD_URL" "$EXTRACT_MONGOSH"
+  if [ -z "$MONGODB_DOWNLOAD_URL" ]; then
+      get_mongodb_download_url_for "$DISTRO" "$MONGODB_VERSION"
+  else
+    # Even though we have the MONGODB_DOWNLOAD_URL, we still call this to get the proper EXTRACT variable
+    get_mongodb_download_url_for "$DISTRO"
+  fi
+    download_and_extract "$MONGODB_DOWNLOAD_URL" "$EXTRACT" "$MONGOSH_DOWNLOAD_URL" "$EXTRACT_MONGOSH"
+  fi
 fi
 
 DL_END=$(date +%s)

--- a/.evergreen/run-orchestration.sh
+++ b/.evergreen/run-orchestration.sh
@@ -36,7 +36,9 @@ else
   # Even though we have the MONGODB_DOWNLOAD_URL, we still call this to get the proper EXTRACT variable
   get_mongodb_download_url_for "$DISTRO"
 fi
-download_and_extract "$MONGODB_DOWNLOAD_URL" "$EXTRACT" "$MONGOSH_DOWNLOAD_URL" "$EXTRACT_MONGOSH"
+if [ -z "$MONGODB_SKIP_DOWNLOAD" ]; then
+  download_and_extract "$MONGODB_DOWNLOAD_URL" "$EXTRACT" "$MONGOSH_DOWNLOAD_URL" "$EXTRACT_MONGOSH"
+fi
 
 DL_END=$(date +%s)
 MO_START=$(date +%s)
@@ -97,7 +99,7 @@ if ! curl --silent --show-error --data @"$ORCHESTRATION_FILE" "$ORCHESTRATION_UR
   exit 1
 fi
 cat tmp.json
-URI=$(python -c 'import json; j=json.load(open("tmp.json")); print(j["mongodb_auth_uri" if "mongodb_auth_uri" in j else "mongodb_uri"])' | tr -d '\r')
+URI=$(python3 -c 'import json; j=json.load(open("tmp.json")); print(j["mongodb_auth_uri" if "mongodb_auth_uri" in j else "mongodb_uri"])' | tr -d '\r')
 echo 'MONGODB_URI: "'$URI'"' > mo-expansion.yml
 echo $URI > $DRIVERS_TOOLS/uri.txt
 echo "Cluster URI: $URI"


### PR DESCRIPTION
Supports https://jira.mongodb.org/browse/BUILD-16723.  

- Adds support for Ubuntu 22.
- Adds an `MONGODB_SKIP_DOWNLOAD` flag to enable separately downloading the binaries before running `run-orchestration`.
- Adds `"requestScopes"` IdP config for integration testing.
- Creates extra tokens for testing: `test_user1_1`, `test_user1_2`, `test_user2_1`, and `test_user2_2`