### PR TITLE
BUILD-17302 AWS EC2 credential retrieval 404s in Drivers CI

### DIFF
--- a/.evergreen/auth_aws/lib/aws_assign_instance_profile.py
+++ b/.evergreen/auth_aws/lib/aws_assign_instance_profile.py
@@ -17,9 +17,6 @@ import botocore
 LOGGER = logging.getLogger(__name__)
 HERE = os.path.abspath(os.path.dirname(__file__))
 
-# This varies based on hosting EC2 as the account id and role name can vary
-AWS_ACCOUNT_ARN = "arn:aws:sts::557821124784:role/evergreen_task_hosts_instance_role_production";
-
 
 def _get_local_instance_id():
     return urllib.request.urlopen('http://169.254.169.254/latest/meta-data/instance-id').read().decode()
@@ -93,8 +90,10 @@ def _handle_config():
 
         os.environ.setdefault('AWS_ACCESS_KEY_ID', CONFIG['iam_auth_ec2_instance_account'])
         os.environ.setdefault('AWS_SECRET_ACCESS_KEY', CONFIG['iam_auth_ec2_instance_secret_access_key'])
+        return CONFIG['iam_auth_ec2_instance_profile']
     except Exception as e:
         print(e)
+        return ''
 
 
 def main() -> None:
@@ -105,11 +104,12 @@ def main() -> None:
     parser.add_argument('-v', "--verbose", action='store_true', help="Enable verbose logging")
     parser.add_argument('-d', "--debug", action='store_true', help="Enable debug logging")
 
-    parser.add_argument('--instance_profile_arn', type=str, help="Name of instance profile", default=AWS_ACCOUNT_ARN)
+    default_arn = _handle_config()
+
+    parser.add_argument('--instance_profile_arn', type=str, help="Name of instance profile", default=default_arn)
 
     args = parser.parse_args()
 
-    _handle_config()
 
     if args.debug:
         logging.basicConfig(level=logging.DEBUG)

--- a/.evergreen/auth_aws/lib/aws_assign_instance_profile.py
+++ b/.evergreen/auth_aws/lib/aws_assign_instance_profile.py
@@ -18,7 +18,7 @@ LOGGER = logging.getLogger(__name__)
 HERE = os.path.abspath(os.path.dirname(__file__))
 
 # This varies based on hosting EC2 as the account id and role name can vary
-AWS_ACCOUNT_ARN = "arn:aws:sts::557821124784:assumed-role/evergreen_task_hosts_instance_role_production/*";
+AWS_ACCOUNT_ARN = "arn:aws:sts::557821124784:role/evergreen_task_hosts_instance_role_production";
 
 
 def _get_local_instance_id():

--- a/.evergreen/auth_aws/lib/aws_assign_instance_profile.py
+++ b/.evergreen/auth_aws/lib/aws_assign_instance_profile.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""
+Script for assign an instance policy to the current machine.
+"""
+
+import argparse
+import urllib.request
+import logging
+import json
+import os
+import sys
+import time
+
+import boto3
+import botocore
+
+LOGGER = logging.getLogger(__name__)
+HERE = os.path.abspath(os.path.dirname(__file__))
+
+# This varies based on hosting EC2 as the account id and role name can vary
+AWS_ACCOUNT_ARN = "arn:aws:sts::557821124784:assumed-role/evergreen_task_hosts_instance_role_production/*";
+
+
+def _get_local_instance_id():
+    return urllib.request.urlopen('http://169.254.169.254/latest/meta-data/instance-id').read().decode()
+
+def _has_instance_profile():
+    base_url = "http://169.254.169.254/latest/meta-data/iam/security-credentials/"
+    try:
+        print("Reading: " + base_url)
+        iam_role = urllib.request.urlopen(base_url).read().decode()
+    except urllib.error.HTTPError as e:
+        print(e)
+        if e.code == 404:
+            return False
+        raise e
+
+    try:
+        url = base_url + iam_role
+        print("Reading: " + url)
+        req = urllib.request.urlopen(url)
+    except urllib.error.HTTPError as e:
+        print(e)
+        if e.code == 404:
+            return False
+        raise e
+
+    return True
+
+def _wait_instance_profile():
+    retry = 60
+    while not _has_instance_profile() and retry:
+        time.sleep(5)
+        retry -= 1
+
+    if retry == 0:
+        raise ValueError("Timeout on waiting for instance profile")
+
+def _assign_instance_policy(iam_instance_arn):
+
+    if _has_instance_profile():
+        print("IMPORTANT: Found machine already has instance profile, skipping the assignment")
+        return
+
+    instance_id = _get_local_instance_id()
+
+    ec2_client = boto3.client("ec2", 'us-east-1')
+
+    #https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.associate_iam_instance_profile
+    try:
+        response = ec2_client.associate_iam_instance_profile(
+            IamInstanceProfile={
+                'Arn' : iam_instance_arn,
+            },
+            InstanceId = instance_id)
+
+        print(response)
+
+        # Wait for the instance profile to be assigned by polling the local instance metadata service
+        _wait_instance_profile()
+
+    except botocore.exceptions.ClientError as ce:
+        if ce.response["Error"]["Code"] == "RequestLimitExceeded":
+            print("WARNING: RequestLimitExceeded, exiting with error code 2")
+            sys.exit(2)
+        raise
+
+
+def _handle_config():
+    try:
+        with open(os.path.join(HERE, '..', 'aws_e2e_setup.json')) as fid:
+            CONFIG = json.load(fid)
+
+        os.environ.setdefault('AWS_ACCESS_KEY_ID', CONFIG['iam_auth_ec2_instance_account'])
+        os.environ.setdefault('AWS_SECRET_ACCESS_KEY', CONFIG['iam_auth_ec2_instance_secret_access_key'])
+    except Exception as e:
+        print(e)
+
+
+def main() -> None:
+    """Execute Main entry point."""
+
+    parser = argparse.ArgumentParser(description='IAM Assign Instance frontend.')
+
+    parser.add_argument('-v', "--verbose", action='store_true', help="Enable verbose logging")
+    parser.add_argument('-d', "--debug", action='store_true', help="Enable debug logging")
+
+    parser.add_argument('--instance_profile_arn', type=str, help="Name of instance profile", default=AWS_ACCOUNT_ARN)
+
+    args = parser.parse_args()
+
+    _handle_config()
+
+    if args.debug:
+        logging.basicConfig(level=logging.DEBUG)
+    elif args.verbose:
+        logging.basicConfig(level=logging.INFO)
+
+    _assign_instance_policy(args.instance_profile_arn)
+
+
+if __name__ == "__main__":
+    main()

--- a/.evergreen/auth_aws/lib/aws_assign_instance_profile.py
+++ b/.evergreen/auth_aws/lib/aws_assign_instance_profile.py
@@ -36,6 +36,7 @@ def _has_instance_profile():
         url = base_url + iam_role
         print("Reading: " + url)
         req = urllib.request.urlopen(url)
+        print("Assigned " + iam_role)
     except urllib.error.HTTPError as e:
         print(e)
         if e.code == 404:


### PR DESCRIPTION
- Reassign the instance profile during teardown
- Requires an update to the `iam_auth_ec2_instance_profile` project variable
- Required driver config changes in https://github.com/mongodb/mongo-python-driver/pull/1218
- Successful [reassignment](https://evergreen.mongodb.com/task_log_raw/mongo_python_driver_aws_auth_test__platform~ubuntu_20.04_python_version~3.7_aws_auth_test_latest_patch_bda9e3a0bb533b6d0c6c5141feeecb77c4d31709_646761f057e85a09b6954eaf_23_05_19_11_48_14/3?type=T#L2567)
- I will open a drivers ticket to track making the required changes