### PR TITLE
DRIVERS-2639 Fix handling of EC2 Instance Profile in EG Tests

### DIFF
--- a/.evergreen/auth_aws/aws_e2e_ec2.js
+++ b/.evergreen/auth_aws/aws_e2e_ec2.js
@@ -13,7 +13,7 @@ function assignInstanceProfile() {
     const python_command = getPython3Binary() +
         ` -u lib/aws_assign_instance_profile.py`;
 
-    const ret = runShellCmdWithEnv(python_command, env);
+    const ret = runShellCmdWithEnv(python_command, {});
     if (ret == 2) {
         print("WARNING: Request limit exceeded for AWS API");
         return false;

--- a/.evergreen/auth_aws/aws_e2e_ec2.js
+++ b/.evergreen/auth_aws/aws_e2e_ec2.js
@@ -9,6 +9,24 @@ load("lib/aws_e2e_lib.js");
 // This varies based on hosting EC2 as the account id and role name can vary
 const AWS_ACCOUNT_ARN = "arn:aws:sts::557821124784:assumed-role/evergreen_task_hosts_instance_role_production/*";
 
+function assignInstanceProfile() {
+    const python_command = getPython3Binary() +
+        ` -u lib/aws_assign_instance_profile.py`;
+
+    const ret = runShellCmdWithEnv(python_command, env);
+    if (ret == 2) {
+        print("WARNING: Request limit exceeded for AWS API");
+        return false;
+    }
+
+    assert.eq(ret, 0, "Failed to assign an instance profile to the current machine");
+    return true;
+}
+
+if (!assignInstanceProfile()) {
+    return;
+}
+
 const admin = Mongo().getDB("admin");
 const external = admin.getMongo().getDB("$external");
 

--- a/.evergreen/auth_aws/aws_tester.py
+++ b/.evergreen/auth_aws/aws_tester.py
@@ -16,7 +16,7 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 sys.path.insert(0, os.path.join(HERE, 'lib'))
 from aws_assume_role import _assume_role
 from aws_assume_web_role import _assume_role_with_web_identity
-
+from aws_assign_instance_profile import _assign_instance_policy
 
 ASSUMED_ROLE = "arn:aws:sts::557821124784:assumed-role/authtest_user_assume_role/*";
 ASSUMED_WEB_ROLE = "arn:aws:sts::857654397073:assumed-role/webIdentityTestRole/*"
@@ -66,6 +66,7 @@ def setup_assume_role():
 
 def setup_ec2():
     # Create the user.
+    _assign_instance_policy()
     create_user(AWS_ACCOUNT_ARN, dict())
 
 

--- a/.evergreen/auth_aws/aws_tester.py
+++ b/.evergreen/auth_aws/aws_tester.py
@@ -66,9 +66,9 @@ def setup_assume_role():
 
 def setup_ec2():
     # Create the user.
-    env = os.environ.copy()
     _assign_instance_policy()
-    os.environ.update(**env)
+    del os.environ['AWS_ACCESS_KEY_ID']
+    del os.environ['AWS_SECRET_ACCESS_KEY']
     create_user(AWS_ACCOUNT_ARN, dict())
 
 

--- a/.evergreen/auth_aws/aws_tester.py
+++ b/.evergreen/auth_aws/aws_tester.py
@@ -66,7 +66,9 @@ def setup_assume_role():
 
 def setup_ec2():
     # Create the user.
+    env = os.environ.copy()
     _assign_instance_policy()
+    os.environ.update(**env)
     create_user(AWS_ACCOUNT_ARN, dict())
 
 


### PR DESCRIPTION
Tested with both [`aws_tester`](https://spruce.mongodb.com/version/6477dfc71e2d1768666c4fbe/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) and [Legacy Shell](https://spruce.mongodb.com/version/6477e8131e2d1768666c6135/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

`IMPORTANT: Found machine already has instance profile, skipping the assignment`