### PR TITLE
Add dedicated perf version tag for server 6.x

### DIFF
--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -3,6 +3,7 @@
 #For future use the feed to get full list of distros : http://downloads.mongodb.org/full.json
 
 set -o errexit  # Exit the script with error if any of the commands fail
+set -o xtrace
 
 get_distro ()
 {

--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -3,7 +3,6 @@
 #For future use the feed to get full list of distros : http://downloads.mongodb.org/full.json
 
 set -o errexit  # Exit the script with error if any of the commands fail
-set -o xtrace
 
 get_distro ()
 {

--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -58,6 +58,7 @@ get_mongodb_download_url_for ()
    VERSION_70="7.0.0-rc0"
    VERSION_60_LATEST="v6.0-latest"
    VERSION_60="6.0.6"
+   VERSION_60_PERF="6.3.1"
    VERSION_50="5.0.17"
    VERSION_44="4.4.21"
    VERSION_42="4.2.24"
@@ -134,6 +135,7 @@ get_mongodb_download_url_for ()
              MONGODB_RAPID="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-rhel90-${VERSION_RAPID}.tgz"
              MONGODB_70="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-rhel90-${VERSION_70}.tgz"
              MONGODB_60_LATEST="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-rhel90-${VERSION_60_LATEST}.tgz"
+             MONGODB_60_PERF="http://downloads.10gen.com/linux/mongodb-linux-aarch64-enterprise-rhel90-${VERSION_60_PERF}.tgz"
              MONGODB_60="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-rhel90-${VERSION_60}.tgz"
       ;;
       linux-rhel-8.1-ppc64le)
@@ -579,6 +581,7 @@ get_mongodb_download_url_for ()
       rapid) MONGODB_DOWNLOAD_URL=$MONGODB_RAPID ;;
       7.0) MONGODB_DOWNLOAD_URL=$MONGODB_70 ;;
       v6.0-latest) MONGODB_DOWNLOAD_URL=$MONGODB_60_LATEST ;;
+      v6.0-perf) MONGODB_DOWNLOAD_URL=$MONGODB_60_PERF ;;
       6.0) MONGODB_DOWNLOAD_URL=$MONGODB_60 ;;
       5.0) MONGODB_DOWNLOAD_URL=$MONGODB_50 ;;
       4.4) MONGODB_DOWNLOAD_URL=$MONGODB_44 ;;

--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -136,7 +136,7 @@ get_mongodb_download_url_for ()
              MONGODB_RAPID="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-rhel90-${VERSION_RAPID}.tgz"
              MONGODB_70="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-rhel90-${VERSION_70}.tgz"
              MONGODB_60_LATEST="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-rhel90-${VERSION_60_LATEST}.tgz"
-             MONGODB_60_PERF="http://downloads.10gen.com/linux/mongodb-linux-aarch64-enterprise-rhel90-${VERSION_60_PERF}.tgz"
+             MONGODB_60_PERF="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-rhel90-${VERSION_60_PERF}.tgz"
              MONGODB_60="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-rhel90-${VERSION_60}.tgz"
       ;;
       linux-rhel-8.1-ppc64le)

--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -614,6 +614,7 @@ get_mongodb_download_url_for ()
       rapid) MONGO_CRYPT_SHARED_DOWNLOAD_URL=$MONGODB_RAPID ;;
       7.0) MONGO_CRYPT_SHARED_DOWNLOAD_URL=$MONGODB_70 ;;
       v6.0-latest) MONGO_CRYPT_SHARED_DOWNLOAD_URL=$MONGODB_60_LATEST ;;
+      v6.0-perf) MONGO_CRYPT_SHARED_DOWNLOAD_URL=$MONGODB_60_PERF ;;
       6.0) MONGO_CRYPT_SHARED_DOWNLOAD_URL=$MONGODB_60 ;;
       5.0 | 4.4 | 4.2 | 4.0 | 3.6 | 3.4 | 3.2 | 3.0 | 2.6 | 2.4)
          # Default to using the latest Major release. Major releases are expected yearly.


### PR DESCRIPTION
Adds a dedicated tag `v6.0-perf` pinned to 6.3.1 (same as current rapid).

Once 7.0 is GA, we'll want to add a similar 7.0 perf version that drivers can use to test against in addition to this version.

Node driver [test run](https://spruce.mongodb.com/task/mongo_node_driver_next_performance_tests_run_spec_benchmark_tests_patch_ed5e27b77dd3393ba845fcead5f0baefc10add56_647a44e8562343aa2beb0913_23_06_02_19_37_19/logs?execution=4)