### PR TITLE
PYTHON-3721 Make retry more robust

### DIFF
--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -635,14 +635,11 @@ get_mongodb_download_url_for ()
    echo $MONGODB_DOWNLOAD_URL
 }
 
-# curl_retry runs curl with the --retry-all-errors flag if supported.
+# curl_retry runs curl with up to three retries, retrying any error.
 curl_retry ()
 {
-  RETRY_ALL=""
-  if curl --help curl | grep -q "retry-all-errors" ; then
-    RETRY_ALL="--retry-all-errors"
-  fi
-  curl --retry 3 -sS --max-time 300 $RETRY_ALL "$@"
+  for i in 1 2 3; do curl --fail -sS --max-time 300 "$@" && break || sleep 5;
+  done
 }
 
 # download_and_extract_package downloads a MongoDB server package.


### PR DESCRIPTION
curl's --retry-all-errors is not available on versions older than 7.71.0, and the older --retry option does not retry non-transient server errors such as 4xx and 5xx. By using the --fail option and manually checking the status code of the completed curl command, this fix ensures that the `curl_retry` function retries all failures up to three times.