### PR TITLE
remove extra single quotes

### DIFF
--- a/.evergreen/csfle/azurekms/create-vm.sh
+++ b/.evergreen/csfle/azurekms/create-vm.sh
@@ -16,7 +16,7 @@ if [ -z "${AZUREKMS_VMNAME_PREFIX:-}" ] || \
     exit 1
 fi
 
-AZUREKMS_IDENTITY="${AZUREKMS_IDENTITY:-'[system]'}"
+AZUREKMS_IDENTITY="${AZUREKMS_IDENTITY:-[system]}"
 AZUREKMS_VMNAME="vmname-$AZUREKMS_VMNAME_PREFIX-$RANDOM"
 echo "Creating a Virtual Machine ($AZUREKMS_VMNAME) ... begin"
 # az vm create also creates a "nic" and "public IP" by default.


### PR DESCRIPTION
# Summary
Remove extra quotes on default value of `AZUREKMS_IDENTITY`

# Background & Motivation

This is a follow up to https://github.com/mongodb-labs/drivers-evergreen-tools/pull/294/files#diff-6996a1a9561c8d80fe15eac2063b2da6f999f3f4b01a93d15090045366693c05R19 to resolves observed task failures creating the virtual machine. [Example](https://spruce.mongodb.com/task/mongo_c_driver_testazurekms_variant_testazurekms_task_fff643a3144fcce08b3163cbd6437949fe466061_23_05_31_19_23_49/logs?execution=1). Here is the error message with values redacted:

```
The client '<redacted>' with object id '<redacted>' has permission to perform action 'Microsoft.Compute/virtualMachines/write' on scope '<redacted>'; however, it does not have permission to perform action 'Microsoft.ManagedIdentity/userAssignedIdentities/assign/action' on the linked scope(s) '/subscriptions/<redacted>/resourceGroups/<redacted>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/'[system]'' or the linked scope(s) are invalid.
```

Changes were verified with a patch of the C driver testazurekms-task here: https://spruce.mongodb.com/version/6483484cd1fe0782ac9138b4