### PR TITLE
Skip Prerelease Python versions

### DIFF
--- a/.evergreen/find-python3.sh
+++ b/.evergreen/find-python3.sh
@@ -54,7 +54,8 @@ is_python3() (
   # Evaluate result of this function.
   # Note: Python True (1) and False (0) is treated as fail (1) and success (0)
   # by Bash; therefore `is_python3` returns "true" when `v < 3` is false.
-  "$bin" -c "import sys; exit(sys.version_info[0] < 3)"
+  # Skip prerelease versions of python.
+  "$bin" -c "import sys; exit(sys.version_info[0] < 3 and sys.version_info.releaselevel == 'final')"
 ) 1>&2
 
 # is_venv_capable

--- a/.evergreen/find-python3.sh
+++ b/.evergreen/find-python3.sh
@@ -55,7 +55,7 @@ is_python3() (
   # Note: Python True (1) and False (0) is treated as fail (1) and success (0)
   # by Bash; therefore `is_python3` returns "true" when `v < 3` is false.
   # Skip prerelease versions of python.
-  "$bin" -c "import sys; exit(sys.version_info[0] < 3 and sys.version_info.releaselevel == 'final')"
+  "$bin" -c "import sys; exit(sys.version_info[0] < 3 or sys.version_info.releaselevel != 'final')"
 ) 1>&2
 
 # is_venv_capable


### PR DESCRIPTION
Addresses failure seen in https://spruce.mongodb.com/task/mongo_go_driver_atlas_data_lake_test_test_atlas_data_lake_patch_09631fa3b26267e1be80efbae7d849e9bfb8de74_64877e241e2d175824253079_23_06_12_20_20_53/logs?execution=0, where we tried to use Python 3.12b1 and then install `greenlet`, which is not yet compatible with Python 3.12.