### PR TITLE
Update 7.0 server download version to `7.0.0-rc3`

### DIFF
--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -55,7 +55,7 @@ get_mongodb_download_url_for ()
    VERSION_MONGOSH="1.8.1"
    # Set VERSION_RAPID to the latest rapid release each quarter.
    VERSION_RAPID="6.3.1"
-   VERSION_70="7.0.0-rc0"
+   VERSION_70="7.0.0-rc3"
    VERSION_60_LATEST="v6.0-latest"
    VERSION_60="6.0.6"
    # The perf version must always remain pinned to the same patch


### PR DESCRIPTION
# Summary
- Update 7.0 server download version to `7.0.0-rc3`

# Background & Motivation
7.0.0-rc3 appears to be latest release: https://jira.mongodb.org/browse/STAR-3966.

There appears to be no published download for 7.0.0-rc0 with RHEL 8.3 s390x. This caused task failures in the C driver attempting to test server 7.0. [STAR-3822](https://jira.mongodb.org/browse/STAR-3822) suggests that `Enterprise RHEL 8.3 s390x` and `Enterprise RHEL 7.2 s390x variants` were not published for 7.0.0-rc0.  There are published downloads for 7.0.0-rc1, 7.0.0-rc2, and 7.0.0-rc3:

https://downloads.mongodb.com/linux/mongodb-linux-s390x-enterprise-rhel83-7.0.0-rc0.tgz results in HTTP 403.
https://downloads.mongodb.com/linux/mongodb-linux-s390x-enterprise-rhel83-7.0.0-rc3.tgz results in successful download.