### PR TITLE
DRIVERS-2416 Force MONGODB-OIDC to be enabled

### DIFF
--- a/.evergreen/auth_oidc/azure/start-mongodb.sh
+++ b/.evergreen/auth_oidc/azure/start-mongodb.sh
@@ -15,7 +15,7 @@ export MONGO_ORCHESTRATION_HOME=$HOME
 export NO_IPV6=${NO_IPV6:-""}
 
 if [ ! -d $DRIVERS_TOOLS ]; then
-    git clone https://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
+    git clone --branch DRIVERS-2616-2 https://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
 fi
 
 cd $DRIVERS_TOOLS/.evergreen/auth_oidc

--- a/.evergreen/auth_oidc/azure/start-mongodb.sh
+++ b/.evergreen/auth_oidc/azure/start-mongodb.sh
@@ -15,7 +15,7 @@ export MONGO_ORCHESTRATION_HOME=$HOME
 export NO_IPV6=${NO_IPV6:-""}
 
 if [ ! -d $DRIVERS_TOOLS ]; then
-    git clone --branch DRIVERS-2616-2 https://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
+    git clone --branch DRIVERS-2616-2 https://github.com/blink1073/drivers-evergreen-tools.git $DRIVERS_TOOLS
 fi
 
 cd $DRIVERS_TOOLS/.evergreen/auth_oidc

--- a/.evergreen/auth_oidc/azure/start-mongodb.sh
+++ b/.evergreen/auth_oidc/azure/start-mongodb.sh
@@ -15,7 +15,7 @@ export MONGO_ORCHESTRATION_HOME=$HOME
 export NO_IPV6=${NO_IPV6:-""}
 
 if [ ! -d $DRIVERS_TOOLS ]; then
-    git clone --branch DRIVERS-2416-2 https://github.com/blink1073/drivers-evergreen-tools.git $DRIVERS_TOOLS
+    git clone https://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
 fi
 
 cd $DRIVERS_TOOLS/.evergreen/auth_oidc

--- a/.evergreen/auth_oidc/azure/start-mongodb.sh
+++ b/.evergreen/auth_oidc/azure/start-mongodb.sh
@@ -15,7 +15,7 @@ export MONGO_ORCHESTRATION_HOME=$HOME
 export NO_IPV6=${NO_IPV6:-""}
 
 if [ ! -d $DRIVERS_TOOLS ]; then
-    git clone https://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
+    git clone --branch DRIVERS-2416-2 https://github.com/blink1073/drivers-evergreen-tools.git $DRIVERS_TOOLS
 fi
 
 cd $DRIVERS_TOOLS/.evergreen/auth_oidc

--- a/.evergreen/auth_oidc/azure/start-mongodb.sh
+++ b/.evergreen/auth_oidc/azure/start-mongodb.sh
@@ -15,7 +15,7 @@ export MONGO_ORCHESTRATION_HOME=$HOME
 export NO_IPV6=${NO_IPV6:-""}
 
 if [ ! -d $DRIVERS_TOOLS ]; then
-    git clone --branch DRIVERS-2616-2 https://github.com/blink1073/drivers-evergreen-tools.git $DRIVERS_TOOLS
+    git clone --branch DRIVERS-2416-2 https://github.com/blink1073/drivers-evergreen-tools.git $DRIVERS_TOOLS
 fi
 
 cd $DRIVERS_TOOLS/.evergreen/auth_oidc

--- a/.evergreen/auth_oidc/azure/test.py
+++ b/.evergreen/auth_oidc/azure/test.py
@@ -2,7 +2,7 @@ from pymongo import MongoClient
 import os
 import json
 from urllib.request import urlopen, Request
-from pymongo.auth import _AUTH_MAP
+from pymongo.auth import _AUTH_MAP, _authenticate_oidc
 
 # Force MONGODB-OIDC to be enabled.
 _AUTH_MAP["MONGODB-OIDC"] = _authenticate_oidc

--- a/.evergreen/auth_oidc/azure/test.py
+++ b/.evergreen/auth_oidc/azure/test.py
@@ -2,6 +2,10 @@ from pymongo import MongoClient
 import os
 import json
 from urllib.request import urlopen, Request
+from pymongo.auth import _AUTH_MAP
+
+# Force MONGODB-OIDC to be enabled.
+_AUTH_MAP["MONGODB-OIDC"] = _authenticate_oidc
 
 app_id = os.environ['AZUREOIDC_CLIENTID']
 


### PR DESCRIPTION
Tested in a PyMongo patch build: https://spruce.mongodb.com/task/mongo_python_driver_testazureoidc_variant_oidc_auth_test_azure_latest_patch_1269c006da2ad9c35d812ff309ded7beebc50e81_648b1219e3c33133ea520ba3_23_06_15_13_28_59/logs?execution=0.