### PR TITLE
Improve the 'not found' error message printed by mongodl.py

### DIFF
--- a/.evergreen/mongodl.py
+++ b/.evergreen/mongodl.py
@@ -668,9 +668,9 @@ def _published_build_url(cache: Cache, version: str, target: str, arch: str,
     tup = next(iter(matching), None)
     if tup is None:
         raise ValueError(
-            'No download for "{}" was found for '
-            'the requested version+target+architecture+edition'.format(
-                component))
+            'No download was found for '
+            'version="{}" target="{}" arch="{}" edition="{}" component="{}" '.format(
+                version, target, arch, edition, component))
     data = json.loads(tup.data_json)
     return data['url']
 

--- a/.evergreen/mongodl.py
+++ b/.evergreen/mongodl.py
@@ -669,7 +669,7 @@ def _published_build_url(cache: Cache, version: str, target: str, arch: str,
     if tup is None:
         raise ValueError(
             'No download was found for '
-            'version="{}" target="{}" arch="{}" edition="{}" component="{}" '.format(
+            'version="{}" target="{}" arch="{}" edition="{}" component="{}"'.format(
                 version, target, arch, edition, component))
     data = json.loads(tup.data_json)
     return data['url']


### PR DESCRIPTION
The `mongodl.py` script currently prints an error message like:
```
ValueError: No download for "archive" was found for the requested version+target+architecture+edition
```
Make troubleshooting CI issues easier by printing the parameters used to try to find a download in the error message:
```
ValueError: No download was found for version="7.0.0-nope" target="ubuntu2204" arch="x86_64" edition="enterprise" component="archive"
```