### PR TITLE
Include rhel utilities in PID termination if/else branch

### DIFF
--- a/.evergreen/start-orchestration.sh
+++ b/.evergreen/start-orchestration.sh
@@ -50,17 +50,17 @@ fi
 if [ "Windows_NT" = "$OS" ]; then # Magic variable in cygwin
   OLD_MO_PID=$(netstat -ano | grep ':8889 .* LISTENING' | awk '{print $5}' | tr -d '[:space:]')
   if [ ! -z "$OLD_MO_PID" ]; then
-    taskkill /F /T /PID "$OLD_MO_PID"
+    taskkill /F /T /PID "$OLD_MO_PID" || true
   fi
 elif [ -x "$(command -v lsof)" ]; then
   OLD_MO_PID=$(lsof -t -i:8889 || true)
   if [ ! -z "$OLD_MO_PID" ]; then
-    kill -9 "$OLD_MO_PID"
+    kill -9 "$OLD_MO_PID" || true
   fi
 elif [ -x "$(command -v ss)" ]; then
   OLD_MO_PID=$(ss -tlnp 'sport = :8889' | awk 'NR>1 {split($7,a,","); print a[1]}' | tr -d '[:space:]')
   if [ ! -z "$OLD_MO_PID" ]; then
-    kill -9 "$OLD_MO_PID"
+    kill -9 "$OLD_MO_PID" || true
   fi
 else
   echo "Unable to identify the OS or find necessary utilities (lsof/ss) to kill the process."

--- a/.evergreen/start-orchestration.sh
+++ b/.evergreen/start-orchestration.sh
@@ -45,18 +45,26 @@ if [ "Windows_NT" = "$OS" ]; then # Magic variable in cygwin
   ORCHESTRATION_ARGUMENTS="$ORCHESTRATION_ARGUMENTS -s wsgiref"
 fi
 
-# Forcibly kill the process listening on port 8889, most likey a wild
+# Forcibly kill the process listening on port 8889, most likely a wild
 # mongo-orchestration left running from a previous task.
 if [ "Windows_NT" = "$OS" ]; then # Magic variable in cygwin
   OLD_MO_PID=$(netstat -ano | grep ':8889 .* LISTENING' | awk '{print $5}' | tr -d '[:space:]')
   if [ ! -z "$OLD_MO_PID" ]; then
-    taskkill /F /T /PID "$OLD_MO_PID" || true
+    taskkill /F /T /PID "$OLD_MO_PID"
   fi
-else
+elif [ -x "$(command -v lsof)" ]; then
   OLD_MO_PID=$(lsof -t -i:8889 || true)
   if [ ! -z "$OLD_MO_PID" ]; then
-    kill -9 "$OLD_MO_PID" || true
+    kill -9 "$OLD_MO_PID"
   fi
+elif [ -x "$(command -v ss)" ]; then
+  OLD_MO_PID=$(ss -tlnp 'sport = :8889' | awk 'NR>1 {split($7,a,","); print a[1]}' | tr -d '[:space:]')
+  if [ ! -z "$OLD_MO_PID" ]; then
+    kill -9 "$OLD_MO_PID"
+  fi
+else
+  echo "Unable to identify the OS or find necessary utilities (lsof/ss) to kill the process."
+  exit 1
 fi
 
 mongo-orchestration $ORCHESTRATION_ARGUMENTS start > $MONGO_ORCHESTRATION_HOME/out.log 2>&1 < /dev/null &


### PR DESCRIPTION
The existing if/else branch for terminating a zombie mongo-orchestration is missing a branch to account for Red Hat. This PR proposes that addition to the code.