### PR TITLE
DRIVERS-2411 delete Azure Virtual Network

### DIFF
--- a/.evergreen/csfle/azurekms/create-vm.sh
+++ b/.evergreen/csfle/azurekms/create-vm.sh
@@ -37,6 +37,6 @@ az vm create \
     --public-ip-address "$AZUREKMS_VMNAME-PUBLIC-IP" \
     --nsg "$AZUREKMS_VMNAME-NSG" \
     --assign-identity $AZUREKMS_IDENTITY \
-    --vnet-name "$AZUREKMS_VNAME-VNET" \
+    --vnet-name "$AZUREKMS_VMNAME-VNET" \
     >/dev/null
 echo "Creating a Virtual Machine ($AZUREKMS_VMNAME) ... end"

--- a/.evergreen/csfle/azurekms/create-vm.sh
+++ b/.evergreen/csfle/azurekms/create-vm.sh
@@ -37,5 +37,6 @@ az vm create \
     --public-ip-address "$AZUREKMS_VMNAME-PUBLIC-IP" \
     --nsg "$AZUREKMS_VMNAME-NSG" \
     --assign-identity $AZUREKMS_IDENTITY \
+    --vnet-name "$AZUREKMS_VNAME-VNET" \
     >/dev/null
 echo "Creating a Virtual Machine ($AZUREKMS_VMNAME) ... end"

--- a/.evergreen/csfle/azurekms/delete-vm.sh
+++ b/.evergreen/csfle/azurekms/delete-vm.sh
@@ -30,3 +30,9 @@ az network nsg delete \
     --resource-group "$AZUREKMS_RESOURCEGROUP" \
     -n "$AZUREKMS_VMNAME-NSG"
 echo "Delete Network Security Group $AZUREKMS_VMNAME-NSG ... end"
+
+echo "Delete Virtual Network $AZUREKMS_VMNAME-VNET ... begin"
+az network vnet delete \
+    --resource-group "$AZUREKMS_RESOURCEGROUP" \
+    -n "$AZUREKMS_VMNAME-VNET"
+echo "Delete Virtual Network $AZUREKMS_VMNAME-VNET ... end"


### PR DESCRIPTION
# Summary

- Add `az network vnet delete` to delete created Virtual Network.
- Add `--vnet-name` option to the `azure vm create` command.

Tested with C driver: https://spruce.mongodb.com/version/64e3a22ad1fe07741da84c88/tasks

# Background & Motivation
`azure vm create` creates a Virtual Network along with the Virtual Machine. The Virtual Network does not appear to be deleted with `azure vm delete`. After running `delete-vm.sh`, a Virtual Network was observed in the portal:

![Leftover Virtual Network](https://github.com/mongodb-labs/drivers-evergreen-tools/assets/992997/66b5e021-f1bc-4b0e-bf06-5134601d1a44)
