### PR TITLE
PYTHON-3935 Skip legacy shell on Ubuntu 22

### DIFF
--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -739,22 +739,19 @@ download_and_extract ()
          get_mongodb_download_url_for "$DISTRO" "5.0" > /dev/null
          echo $MONGODB_DOWNLOAD_URL
       )
-      if [ -z "$MONGODB50_DOWNLOAD_URL" ]; then
-         echo "Legacy shell not supported on this platform, skipping."
-      else
-         SAVED_DRIVERS_TOOLS=$DRIVERS_TOOLS
-         mkdir $DRIVERS_TOOLS/legacy-shell-download
-         DRIVERS_TOOLS=$DRIVERS_TOOLS/legacy-shell-download
-         download_and_extract_package "$MONGODB50_DOWNLOAD_URL" "$EXTRACT"
-         if [ -e $DRIVERS_TOOLS/mongodb/bin/mongo ]; then
-            cp $DRIVERS_TOOLS/mongodb/bin/mongo $SAVED_DRIVERS_TOOLS/mongodb/bin
-         elif [ -e $DRIVERS_TOOLS/mongodb/bin/mongo.exe ]; then
-            cp $DRIVERS_TOOLS/mongodb/bin/mongo.exe $SAVED_DRIVERS_TOOLS/mongodb/bin
-         fi
-         DRIVERS_TOOLS=$SAVED_DRIVERS_TOOLS
-         rm -rf $DRIVERS_TOOLS/legacy-shell-download
-         echo "Download legacy shell from 5.0 ... end"
+
+      SAVED_DRIVERS_TOOLS=$DRIVERS_TOOLS
+      mkdir $DRIVERS_TOOLS/legacy-shell-download
+      DRIVERS_TOOLS=$DRIVERS_TOOLS/legacy-shell-download
+      download_and_extract_package "$MONGODB50_DOWNLOAD_URL" "$EXTRACT"
+      if [ -e $DRIVERS_TOOLS/mongodb/bin/mongo ]; then
+         cp $DRIVERS_TOOLS/mongodb/bin/mongo $SAVED_DRIVERS_TOOLS/mongodb/bin
+      elif [ -e $DRIVERS_TOOLS/mongodb/bin/mongo.exe ]; then
+         cp $DRIVERS_TOOLS/mongodb/bin/mongo.exe $SAVED_DRIVERS_TOOLS/mongodb/bin
       fi
+      DRIVERS_TOOLS=$SAVED_DRIVERS_TOOLS
+      rm -rf $DRIVERS_TOOLS/legacy-shell-download
+      echo "Download legacy shell from 5.0 ... end"
    fi
 }
 

--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -72,8 +72,6 @@ get_mongodb_download_url_for ()
    VERSION_26="2.6.12"
    VERSION_24="2.4.14"
 
-   MONGODB_50=""
-
    EXTRACT="tar zxf"
    EXTRACT_MONGOSH=$EXTRACT
 
@@ -733,7 +731,7 @@ download_and_extract ()
       echo "Download legacy shell from 5.0 ... begin"
       # Use a subshell to avoid overwriting MONGODB_DOWNLOAD_URL and MONGO_CRYPT_SHARED_DOWNLOAD_URL.
       MONGODB50_DOWNLOAD_URL=$(
-         get_mongodb_download_url_for "$DISTRO" "5.0"
+         get_mongodb_download_url_for "$DISTRO" "5.0" > /dev/null | true
          echo $MONGODB_DOWNLOAD_URL
       )
       if [ -z "$MONGODB50_DOWNLOAD_URL" ]; then

--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -733,7 +733,7 @@ download_and_extract ()
       echo "Download legacy shell from 5.0 ... begin"
       # Use a subshell to avoid overwriting MONGODB_DOWNLOAD_URL and MONGO_CRYPT_SHARED_DOWNLOAD_URL.
       MONGODB50_DOWNLOAD_URL=$(
-         get_mongodb_download_url_for "$DISTRO" "5.0" > /dev/null
+         get_mongodb_download_url_for "$DISTRO" "5.0"
          echo $MONGODB_DOWNLOAD_URL
       )
       if [ -z "$MONGODB50_DOWNLOAD_URL" ]; then

--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -72,6 +72,8 @@ get_mongodb_download_url_for ()
    VERSION_26="2.6.12"
    VERSION_24="2.4.14"
 
+   MONGODB_50=""
+
    EXTRACT="tar zxf"
    EXTRACT_MONGOSH=$EXTRACT
 
@@ -734,19 +736,22 @@ download_and_extract ()
          get_mongodb_download_url_for "$DISTRO" "5.0" > /dev/null
          echo $MONGODB_DOWNLOAD_URL
       )
-
-      SAVED_DRIVERS_TOOLS=$DRIVERS_TOOLS
-      mkdir $DRIVERS_TOOLS/legacy-shell-download
-      DRIVERS_TOOLS=$DRIVERS_TOOLS/legacy-shell-download
-      download_and_extract_package "$MONGODB50_DOWNLOAD_URL" "$EXTRACT"
-      if [ -e $DRIVERS_TOOLS/mongodb/bin/mongo ]; then
-         cp $DRIVERS_TOOLS/mongodb/bin/mongo $SAVED_DRIVERS_TOOLS/mongodb/bin
-      elif [ -e $DRIVERS_TOOLS/mongodb/bin/mongo.exe ]; then
-         cp $DRIVERS_TOOLS/mongodb/bin/mongo.exe $SAVED_DRIVERS_TOOLS/mongodb/bin
+      if [ -z "$MONGODB50_DOWNLOAD_URL" ]; then
+         echo "Legacy shell not supported on this platform, skipping."
+      else
+         SAVED_DRIVERS_TOOLS=$DRIVERS_TOOLS
+         mkdir $DRIVERS_TOOLS/legacy-shell-download
+         DRIVERS_TOOLS=$DRIVERS_TOOLS/legacy-shell-download
+         download_and_extract_package "$MONGODB50_DOWNLOAD_URL" "$EXTRACT"
+         if [ -e $DRIVERS_TOOLS/mongodb/bin/mongo ]; then
+            cp $DRIVERS_TOOLS/mongodb/bin/mongo $SAVED_DRIVERS_TOOLS/mongodb/bin
+         elif [ -e $DRIVERS_TOOLS/mongodb/bin/mongo.exe ]; then
+            cp $DRIVERS_TOOLS/mongodb/bin/mongo.exe $SAVED_DRIVERS_TOOLS/mongodb/bin
+         fi
+         DRIVERS_TOOLS=$SAVED_DRIVERS_TOOLS
+         rm -rf $DRIVERS_TOOLS/legacy-shell-download
+         echo "Download legacy shell from 5.0 ... end"
       fi
-      DRIVERS_TOOLS=$SAVED_DRIVERS_TOOLS
-      rm -rf $DRIVERS_TOOLS/legacy-shell-download
-      echo "Download legacy shell from 5.0 ... end"
    fi
 }
 

--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -722,7 +722,12 @@ download_and_extract ()
       download_and_extract_mongosh "$MONGOSH_DOWNLOAD_URL" "$EXTRACT_MONGOSH"
    fi
 
-   # Deprecated: this will be removed once drivers have updated to mongosh
+   # Deprecated: this will be removed once drivers have updated to mongosh.
+   # Ubunutu 22 does not support the legacy shell.
+   case "$DISTRO" in
+      linux-ubuntu-22.04*) SKIP_LEGACY_SHELL=1
+      ;;
+   esac
    if [ -z "${SKIP_LEGACY_SHELL:-}" -a ! -e $DRIVERS_TOOLS/mongodb/bin/mongo -a ! -e $DRIVERS_TOOLS/mongodb/bin/mongo.exe ]; then
       # The legacy mongo shell is not included in server downloads of 6.0.0-rc6 or later. Refer: SERVER-64352.
       # Some test scripts use the mongo shell for setup.
@@ -731,7 +736,7 @@ download_and_extract ()
       echo "Download legacy shell from 5.0 ... begin"
       # Use a subshell to avoid overwriting MONGODB_DOWNLOAD_URL and MONGO_CRYPT_SHARED_DOWNLOAD_URL.
       MONGODB50_DOWNLOAD_URL=$(
-         get_mongodb_download_url_for "$DISTRO" "5.0" > /dev/null || true
+         get_mongodb_download_url_for "$DISTRO" "5.0" > /dev/null
          echo $MONGODB_DOWNLOAD_URL
       )
       if [ -z "$MONGODB50_DOWNLOAD_URL" ]; then

--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -731,7 +731,7 @@ download_and_extract ()
       echo "Download legacy shell from 5.0 ... begin"
       # Use a subshell to avoid overwriting MONGODB_DOWNLOAD_URL and MONGO_CRYPT_SHARED_DOWNLOAD_URL.
       MONGODB50_DOWNLOAD_URL=$(
-         get_mongodb_download_url_for "$DISTRO" "5.0" > /dev/null | true
+         get_mongodb_download_url_for "$DISTRO" "5.0" > /dev/null || true
          echo $MONGODB_DOWNLOAD_URL
       )
       if [ -z "$MONGODB50_DOWNLOAD_URL" ]; then


### PR DESCRIPTION
Ubuntu 22 does not support server versions 5.0 and earlier, so we can't install the legacy shell there.