### PR TITLE
Make EVG outputs quieter

### DIFF
--- a/.evergreen/auth_aws/activate-authawsvenv.sh
+++ b/.evergreen/auth_aws/activate-authawsvenv.sh
@@ -33,11 +33,12 @@ activate_authawsvenv() {
     # shellcheck source=.evergreen/find-python3.sh
     . ../find-python3.sh || return
 
-    echo "Creating virtual environment 'authawsvenv'..."
     echo "Finding Python3 binary..."
-    PYTHON="$(find_python3 2>/dev/null)"
+    PYTHON="$(find_python3 2>/dev/null)" || return
     echo "Finding Python3 binary... done."
-    venvcreate $PYTHON authawsvenv || return
+
+    echo "Creating virtual environment 'authawsvenv'..."
+    venvcreate "${PYTHON:?}" authawsvenv || return
 
     local packages=(
       "boto3~=1.26.0"

--- a/.evergreen/auth_aws/activate-authawsvenv.sh
+++ b/.evergreen/auth_aws/activate-authawsvenv.sh
@@ -48,6 +48,7 @@ activate_authawsvenv() {
       deactivate || return 1 # Deactivation should never fail!
       return "$ret"
     }
+    echo "Creating virtual environment 'authawsvenv'... done."
   fi
 }
 

--- a/.evergreen/auth_aws/activate-authawsvenv.sh
+++ b/.evergreen/auth_aws/activate-authawsvenv.sh
@@ -34,8 +34,10 @@ activate_authawsvenv() {
     . ../find-python3.sh || return
 
     echo "Creating virtual environment 'authawsvenv'..."
-
-    venvcreate "$(find_python3 2>/dev/null)" authawsvenv || return
+    echo "Finding Python3 binary..."
+    PYTHON="$(find_python3 2>/dev/null)"
+    echo "Finding Python3 binary... done."
+    venvcreate $PYTHON authawsvenv || return
 
     local packages=(
       "boto3~=1.26.0"

--- a/.evergreen/auth_aws/activate-authawsvenv.sh
+++ b/.evergreen/auth_aws/activate-authawsvenv.sh
@@ -33,7 +33,9 @@ activate_authawsvenv() {
     # shellcheck source=.evergreen/find-python3.sh
     . ../find-python3.sh || return
 
-    venvcreate "$(find_python3)" authawsvenv || return
+    echo "Creating virtual environment 'authawsvenv'..."
+
+    venvcreate "$(find_python3 2>/dev/null)" authawsvenv || return
 
     local packages=(
       "boto3~=1.26.0"
@@ -41,21 +43,7 @@ activate_authawsvenv() {
       "pymongo[aws]~=4.0"
     )
 
-    if [[ "$OSTYPE" == cygwin && "$HOSTTYPE" == x86_64 ]]; then
-      local -r windows_os_name="$(systeminfo.exe /FO LIST | perl -lne 'print $1 if m/^OS Name:\s+(.*)$/' || true)"
-
-      if [[ "$windows_os_name" =~ 2016 ]]; then
-        # Avoid `RuntimeError: Could not determine home directory.` on
-        # windows-64-2016. See BUILD-16233.
-        python -m pip install -U "setuptools<65.0" || {
-          local -r ret="$?"
-          deactivate || return 1 # Deactivation should never fail!
-          return "$ret"
-        }
-      fi
-    fi
-
-    python -m pip install -U "${packages[@]}" || {
+    python -m pip install -q -U "${packages[@]}" || {
       local -r ret="$?"
       deactivate || return 1 # Deactivation should never fail!
       return "$ret"

--- a/.evergreen/auth_oidc/activate-authoidcvenv.sh
+++ b/.evergreen/auth_oidc/activate-authoidcvenv.sh
@@ -33,11 +33,12 @@ activate_authoidcvenv() {
     # shellcheck source=.evergreen/find-python3.sh
     . ../find-python3.sh || return
 
-    echo "Creating virtual environment 'authoidcvenv'..."
     echo "Finding Python3 binary..."
-    PYTHON="$(find_python3 2>/dev/null)"
+    PYTHON="$(find_python3 2>/dev/null)" || return
     echo "Finding Python3 binary... done."
-    venvcreate $PYTHON authoidcvenv || return
+
+    echo "Creating virtual environment 'authoidcvenv'..."
+    venvcreate "${PYTHON:?}" authoidcvenv || return
 
     local packages=(
       "boto3~=1.19.0"

--- a/.evergreen/auth_oidc/activate-authoidcvenv.sh
+++ b/.evergreen/auth_oidc/activate-authoidcvenv.sh
@@ -34,8 +34,10 @@ activate_authoidcvenv() {
     . ../find-python3.sh || return
 
     echo "Creating virtual environment 'authoidcvenv'..."
-
-    venvcreate "$(find_python3 2>/dev/null)" authoidcvenv || return
+    echo "Finding Python3 binary..."
+    PYTHON="$(find_python3 2>/dev/null)"
+    echo "Finding Python3 binary... done."
+    venvcreate $PYTHON authoidcvenv || return
 
     local packages=(
       "boto3~=1.19.0"

--- a/.evergreen/auth_oidc/activate-authoidcvenv.sh
+++ b/.evergreen/auth_oidc/activate-authoidcvenv.sh
@@ -33,7 +33,9 @@ activate_authoidcvenv() {
     # shellcheck source=.evergreen/find-python3.sh
     . ../find-python3.sh || return
 
-    venvcreate "$(find_python3)" authoidcvenv || return
+    echo "Creating virtual environment 'authoidcvenv'..."
+
+    venvcreate "$(find_python3 2>/dev/null)" authoidcvenv || return
 
     local packages=(
       "boto3~=1.19.0"
@@ -41,23 +43,7 @@ activate_authoidcvenv() {
       "azure-identity"
       "azure-keyvault-secrets"
     )
-
-    if [[ "$OSTYPE" == cygwin && "$HOSTTYPE" == x86_64 ]]; then
-      local -r windows_os_name="$(systeminfo.exe /FO LIST | perl -lne 'print $1 if m/^OS Name:\s+(.*)$/' || true)"
-
-      if [[ "$windows_os_name" =~ 2016 ]]; then
-        # Avoid `RuntimeError: Could not determine home directory.` on
-        # windows-64-2016. See BUILD-16233.
-        python -m pip install -U "setuptools<65.0" || {
-          local -r ret="$?"
-          deactivate || return 1 # Deactivation should never fail!
-          return "$ret"
-        }
-      fi
-    fi
-
-    python -m pip install -U pip setuptools
-    python -m pip install -U "${packages[@]}" || {
+    python -m pip install -q -U "${packages[@]}" || {
       local -r ret="$?"
       deactivate || return 1 # Deactivation should never fail!
       return "$ret"

--- a/.evergreen/auth_oidc/activate-authoidcvenv.sh
+++ b/.evergreen/auth_oidc/activate-authoidcvenv.sh
@@ -48,6 +48,7 @@ activate_authoidcvenv() {
       deactivate || return 1 # Deactivation should never fail!
       return "$ret"
     }
+    echo "Creating virtual environment 'authoidcvenv'... done."
   fi
 }
 

--- a/.evergreen/auth_oidc/azure/run-test.sh
+++ b/.evergreen/auth_oidc/azure/run-test.sh
@@ -11,6 +11,6 @@ git clone https://github.com/mongodb/mongo-python-driver
 pushd mongo-python-driver
 python setup.py install --no_ext
 popd
-pip install requests
+pip install -q requests
 python azure/test.py
 popd

--- a/.evergreen/csfle/activate-kmstlsvenv.sh
+++ b/.evergreen/csfle/activate-kmstlsvenv.sh
@@ -33,7 +33,9 @@ activate_kmstlsvenv() {
     # shellcheck source=.evergreen/find-python3.sh
     . ../find-python3.sh || return
 
-    venvcreate "$(find_python3)" kmstlsvenv || return
+    echo "Creating virtual environment 'kmstlsvenv'..."
+
+    venvcreate "$(find_python3 2>/dev/null)" kmstlsvenv || return
 
     local packages=(
       "boto3~=1.19.0"
@@ -47,21 +49,7 @@ activate_kmstlsvenv() {
       packages+=("greenlet<2.0")
     fi
 
-    if [[ "$OSTYPE" == cygwin && "$HOSTTYPE" == x86_64 ]]; then
-      local -r windows_os_name="$(systeminfo.exe /FO LIST | perl -lne 'print $1 if m/^OS Name:\s+(.*)$/' || true)"
-
-      if [[ "$windows_os_name" =~ 2016 ]]; then
-        # Avoid `RuntimeError: Could not determine home directory.` on
-        # windows-64-2016. See BUILD-16233.
-        python -m pip install -U "setuptools<65.0" || {
-          local -r ret="$?"
-          deactivate || return 1 # Deactivation should never fail!
-          return "$ret"
-        }
-      fi
-    fi
-
-    if ! python -m pip install -U "${packages[@]}"; then
+    if ! python -m pip install -q -U "${packages[@]}"; then
       # Avoid `error: can't find Rust compiler`.
       # Assume install failure at this point is due to new versions of
       # cryptography require a Rust toolchain when a cryptography wheel is not
@@ -73,7 +61,7 @@ activate_kmstlsvenv() {
       #  - Ubuntu 18.04 on powerpc64le or s390x
       packages+=("cryptography<3.4")
 
-      python -m pip install -U "${packages[@]}" || {
+      python -m pip install -q -U "${packages[@]}" || {
         local -r ret="$?"
         deactivate || return 1 # Deactivation should never fail!
         return "$ret"

--- a/.evergreen/csfle/activate-kmstlsvenv.sh
+++ b/.evergreen/csfle/activate-kmstlsvenv.sh
@@ -67,6 +67,7 @@ activate_kmstlsvenv() {
         return "$ret"
       }
     fi
+    echo "Creating virtual environment 'kmstlsvenv'... done."
   fi
 }
 

--- a/.evergreen/csfle/activate-kmstlsvenv.sh
+++ b/.evergreen/csfle/activate-kmstlsvenv.sh
@@ -33,11 +33,11 @@ activate_kmstlsvenv() {
     # shellcheck source=.evergreen/find-python3.sh
     . ../find-python3.sh || return
 
-    echo "Creating virtual environment 'kmstlsvenv'..."
     echo "Finding Python3 binary..."
-    PYTHON="$(find_python3 2>/dev/null)"
+    PYTHON="$(find_python3 2>/dev/null)" || return
     echo "Finding Python3 binary... done."
-    venvcreate $PYTHON kmstlsvenv || return
+
+    venvcreate "${PYTHON:?}" kmstlsvenv || return
 
     local packages=(
       "boto3~=1.19.0"
@@ -69,7 +69,6 @@ activate_kmstlsvenv() {
         return "$ret"
       }
     fi
-    echo "Creating virtual environment 'kmstlsvenv'... done."
   fi
 }
 

--- a/.evergreen/csfle/activate-kmstlsvenv.sh
+++ b/.evergreen/csfle/activate-kmstlsvenv.sh
@@ -37,6 +37,7 @@ activate_kmstlsvenv() {
     PYTHON="$(find_python3 2>/dev/null)" || return
     echo "Finding Python3 binary... done."
 
+    echo "Creating virtual environment 'kmstlsvenv'..."
     venvcreate "${PYTHON:?}" kmstlsvenv || return
 
     local packages=(
@@ -69,6 +70,7 @@ activate_kmstlsvenv() {
         return "$ret"
       }
     fi
+    echo "Creating virtual environment 'kmstlsvenv'... done."
   fi
 }
 

--- a/.evergreen/csfle/activate-kmstlsvenv.sh
+++ b/.evergreen/csfle/activate-kmstlsvenv.sh
@@ -34,8 +34,10 @@ activate_kmstlsvenv() {
     . ../find-python3.sh || return
 
     echo "Creating virtual environment 'kmstlsvenv'..."
-
-    venvcreate "$(find_python3 2>/dev/null)" kmstlsvenv || return
+    echo "Finding Python3 binary..."
+    PYTHON="$(find_python3 2>/dev/null)"
+    echo "Finding Python3 binary... done."
+    venvcreate $PYTHON kmstlsvenv || return
 
     local packages=(
       "boto3~=1.19.0"

--- a/.evergreen/find-python3.sh
+++ b/.evergreen/find-python3.sh
@@ -198,6 +198,8 @@ find_python3() (
   local -a bins=()
   local bin=""
 
+  trap "echo 'find_python3 failed!'" EXIT
+
   # The list of Python binaries to test for venv or virtualenv support.
   # The binaries are tested in the order of their position in the array.
   {
@@ -239,8 +241,6 @@ find_python3() (
     # Some environments trigger an unbound variable error if "${bins[@]}" is empty when used below.
     if (("${#bins[@]}" == 0)); then
       echo "Could not find any python3 binaries!"
-      echo "If you are suppressing stdout with 'find_python3 2>/dev/null' you may need to"
-      echo "remove it to aid in debugging."
       return 1
     fi
 
@@ -277,8 +277,6 @@ find_python3() (
 
     if [[ -z "$res" ]]; then
       echo "Could not find a python3 binary capable of creating a virtual environment!"
-      echo "If you are suppressing stdout with 'find_python3 2>/dev/null' you may need to"
-      echo "remove it to aid in debugging."
       return 1
     fi
   } 1>&2

--- a/.evergreen/find-python3.sh
+++ b/.evergreen/find-python3.sh
@@ -198,8 +198,6 @@ find_python3() (
   local -a bins=()
   local bin=""
 
-  trap "echo 'find_python3 failed!'" EXIT
-
   # The list of Python binaries to test for venv or virtualenv support.
   # The binaries are tested in the order of their position in the array.
   {

--- a/.evergreen/find-python3.sh
+++ b/.evergreen/find-python3.sh
@@ -239,6 +239,8 @@ find_python3() (
     # Some environments trigger an unbound variable error if "${bins[@]}" is empty when used below.
     if (("${#bins[@]}" == 0)); then
       echo "Could not find any python3 binaries!"
+      echo "If you are suppressing stdout with 'find_python3 2>/dev/null' you may need to"
+      echo "remove it to aid in debugging."
       return 1
     fi
 
@@ -275,6 +277,8 @@ find_python3() (
 
     if [[ -z "$res" ]]; then
       echo "Could not find a python3 binary capable of creating a virtual environment!"
+      echo "If you are suppressing stdout with 'find_python3 2>/dev/null' you may need to"
+      echo "remove it to aid in debugging."
       return 1
     fi
   } 1>&2

--- a/.evergreen/ocsp/activate-ocspvenv.sh
+++ b/.evergreen/ocsp/activate-ocspvenv.sh
@@ -42,6 +42,7 @@ activate_ocspvenv() {
       deactivate || return 1 # Deactivation should never fail!
       return "$ret"
     }
+    echo "Creating virtual environment 'ocspvenv'... done."
   fi
 }
 

--- a/.evergreen/ocsp/activate-ocspvenv.sh
+++ b/.evergreen/ocsp/activate-ocspvenv.sh
@@ -34,8 +34,10 @@ activate_ocspvenv() {
     . ../find-python3.sh || return
 
     echo "Creating virtual environment 'ocspvenv'..."
-
-    venvcreate "$(find_python3 2>/dev/null)" ocspvenv || return
+    echo "Finding Python3 binary..."
+    PYTHON="$(find_python3 2>/dev/null)"
+    echo "Finding Python3 binary... done."
+    venvcreate $PYTHON ocspvenv || return
 
     python -m pip install -q -r mock-ocsp-responder-requirements.txt || {
       local -r ret="$?"

--- a/.evergreen/ocsp/activate-ocspvenv.sh
+++ b/.evergreen/ocsp/activate-ocspvenv.sh
@@ -33,23 +33,11 @@ activate_ocspvenv() {
     # shellcheck source=.evergreen/find-python3.sh
     . ../find-python3.sh || return
 
-    venvcreate "$(find_python3)" ocspvenv || return
+    echo "Creating virtual environment 'ocspvenv'..."
 
-    if [[ "$OSTYPE" == cygwin && "$HOSTTYPE" == x86_64 ]]; then
-      local -r windows_os_name="$(systeminfo.exe /FO LIST | perl -lne 'print $1 if m/^OS Name:\s+(.*)$/' || true)"
+    venvcreate "$(find_python3 2>/dev/null)" ocspvenv || return
 
-      if [[ "$windows_os_name" =~ 2016 ]]; then
-        # Avoid `RuntimeError: Could not determine home directory.` on
-        # windows-64-2016. See BUILD-16233.
-        python -m pip install -U "setuptools<65.0" || {
-          local -r ret="$?"
-          deactivate || return 1 # Deactivation should never fail!
-          return "$ret"
-        }
-      fi
-    fi
-
-    python -m pip install -r mock-ocsp-responder-requirements.txt || {
+    python -m pip install -q -r mock-ocsp-responder-requirements.txt || {
       local -r ret="$?"
       deactivate || return 1 # Deactivation should never fail!
       return "$ret"

--- a/.evergreen/ocsp/activate-ocspvenv.sh
+++ b/.evergreen/ocsp/activate-ocspvenv.sh
@@ -33,11 +33,12 @@ activate_ocspvenv() {
     # shellcheck source=.evergreen/find-python3.sh
     . ../find-python3.sh || return
 
-    echo "Creating virtual environment 'ocspvenv'..."
     echo "Finding Python3 binary..."
-    PYTHON="$(find_python3 2>/dev/null)"
+    PYTHON="$(find_python3 2>/dev/null)" || return
     echo "Finding Python3 binary... done."
-    venvcreate $PYTHON ocspvenv || return
+
+    echo "Creating virtual environment 'ocspvenv'..."
+    venvcreate "${PYTHON:?}" ocspvenv || return
 
     python -m pip install -q -r mock-ocsp-responder-requirements.txt || {
       local -r ret="$?"

--- a/.evergreen/run-load-balancer.sh
+++ b/.evergreen/run-load-balancer.sh
@@ -77,8 +77,8 @@ EOF_HAPROXY_CONFIG
 }
 
 stop() {
-  echo "Stopping HAProxy..."
   if [ -f "$DRIVERS_TOOLS/haproxy.pid" ]; then
+    echo "Stopping HAProxy..."
     kill -USR1 $(cat $DRIVERS_TOOLS/haproxy.pid)
     rm $DRIVERS_TOOLS/haproxy.conf $DRIVERS_TOOLS/haproxy.pid
   fi

--- a/.evergreen/run-load-balancer.sh
+++ b/.evergreen/run-load-balancer.sh
@@ -77,7 +77,7 @@ EOF_HAPROXY_CONFIG
 }
 
 stop() {
-  if [ -f "$DRIVERS_TOOLS/haproxy.pid" ]; then
+  if [[ -f "$DRIVERS_TOOLS/haproxy.pid" ]]; then
     echo "Stopping HAProxy..."
     kill -USR1 $(cat $DRIVERS_TOOLS/haproxy.pid)
     rm $DRIVERS_TOOLS/haproxy.conf $DRIVERS_TOOLS/haproxy.pid

--- a/.evergreen/run-load-balancer.sh
+++ b/.evergreen/run-load-balancer.sh
@@ -78,8 +78,10 @@ EOF_HAPROXY_CONFIG
 
 stop() {
   echo "Stopping HAProxy..."
-  kill -USR1 $(cat $DRIVERS_TOOLS/haproxy.pid)
-  rm $DRIVERS_TOOLS/haproxy.conf $DRIVERS_TOOLS/haproxy.pid
+  if [ -f "$DRIVERS_TOOLS/haproxy.pid" ]; then
+    kill -USR1 $(cat $DRIVERS_TOOLS/haproxy.pid)
+    rm $DRIVERS_TOOLS/haproxy.conf $DRIVERS_TOOLS/haproxy.pid
+  fi
 }
 
 case "$1" in

--- a/.evergreen/serverless/create-instance.sh
+++ b/.evergreen/serverless/create-instance.sh
@@ -55,7 +55,9 @@ DIR=$(dirname $0)
 
 # Ensure that a Python binary is available for JSON decoding
 . $DIR/../find-python3.sh || exit 1
+echo "Finding Python3 binary..."
 PYTHON_BINARY="$(find_python3 2>/dev/null)" || exit 1
+echo "Finding Python3 binary... done."
 
 echo "Creating new serverless instance \"$SERVERLESS_INSTANCE_NAME\"..."
 

--- a/.evergreen/serverless/create-instance.sh
+++ b/.evergreen/serverless/create-instance.sh
@@ -55,7 +55,7 @@ DIR=$(dirname $0)
 
 # Ensure that a Python binary is available for JSON decoding
 . $DIR/../find-python3.sh || exit 1
-PYTHON_BINARY="$(find_python3)" || exit 1
+PYTHON_BINARY="$(find_python3 2>/dev/null)" || exit 1
 
 echo "Creating new serverless instance \"$SERVERLESS_INSTANCE_NAME\"..."
 

--- a/.evergreen/start-orchestration.sh
+++ b/.evergreen/start-orchestration.sh
@@ -25,7 +25,9 @@ det_evergreen_dir="$(dirname "${BASH_SOURCE[0]}")"
 
 cd "$MONGO_ORCHESTRATION_HOME"
 
+echo "Finding Python3 binary..."
 PYTHON="$(find_python3 2>/dev/null)"
+echo "Finding Python3 binary... done."
 
 venvcreate "$PYTHON" venv
 

--- a/.evergreen/start-orchestration.sh
+++ b/.evergreen/start-orchestration.sh
@@ -26,13 +26,15 @@ det_evergreen_dir="$(dirname "${BASH_SOURCE[0]}")"
 cd "$MONGO_ORCHESTRATION_HOME"
 
 echo "Finding Python3 binary..."
-PYTHON="$(find_python3 2>/dev/null)"
+PYTHON="$(find_python3 2>/dev/null)" || return
 echo "Finding Python3 binary... done."
 
-venvcreate "$PYTHON" venv
+echo "Creating virtual environment 'venv'..."
+venvcreate "${PYTHON:?}" venv
+echo "Creating virtual environment 'venv'... done."
 
 # Install from github to get the latest mongo-orchestration.
-python -m pip install --upgrade 'https://github.com/mongodb/mongo-orchestration/archive/master.tar.gz'
+python -m pip install -q --upgrade 'https://github.com/mongodb/mongo-orchestration/archive/master.tar.gz'
 python -m pip list
 cd -
 

--- a/.evergreen/start-orchestration.sh
+++ b/.evergreen/start-orchestration.sh
@@ -25,7 +25,7 @@ det_evergreen_dir="$(dirname "${BASH_SOURCE[0]}")"
 
 cd "$MONGO_ORCHESTRATION_HOME"
 
-PYTHON="$(find_python3)"
+PYTHON="$(find_python3 2>/dev/null)"
 
 venvcreate "$PYTHON" venv
 

--- a/.evergreen/venv-utils.sh
+++ b/.evergreen/venv-utils.sh
@@ -78,7 +78,7 @@ venvcreate() {
 
     venvactivate "$venv_path" || continue
 
-    if ! python -m pip install -U pip; then
+    if ! python -m pip install -q -U pip; then
       deactivate || return 1 # Deactivation should never fail!
       continue
     fi
@@ -90,7 +90,7 @@ venvcreate() {
     # These packages must be upgraded *after* pip, *separately*, as some old
     # versions of pip do not handle their simultaneous installation properly.
     # See: https://github.com/pypa/pip/issues/4253
-    if ! python -m pip install -U setuptools wheel; then
+    if ! python -m pip install -q -U setuptools wheel; then
       deactivate || return 1 # Deactivation should never fail!
       continue
     fi


### PR DESCRIPTION
Make the EVG outputs quieter:

- Use `$(find_python3 2>/dev/null)` in more places
- Use `pip install -q` for quieter pip installs
- Avoid error when trying to shut down an HAProxy that was not running
- Remove legacy code in venv scripts supporting Windows 2016