### PR TITLE
DRIVERS-2585 Migrate OIDC Secrets Handling

### DIFF
--- a/.evergreen/auth_aws/setup_secrets.py
+++ b/.evergreen/auth_aws/setup_secrets.py
@@ -5,7 +5,6 @@ Script for fetching AWS Secrets Vault secrets for use in testing.
 import argparse
 import json
 import os
-import yaml
 import boto3
 
 

--- a/.evergreen/auth_oidc/utils.py
+++ b/.evergreen/auth_oidc/utils.py
@@ -8,36 +8,16 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 aws_lib = os.path.join(os.path.dirname(HERE), 'auth_aws', 'lib')
 sys.path.insert(0, aws_lib)
 from aws_handle_oidc_creds import get_id_token, MOCK_ENDPOINT
+aws_root = os.path.join(os.path.dirname(HERE), 'auth_aws')
+sys.path.insert(0, aws_root)
+from setup_secrets import get_secrets as root_get_secrets
 
 DEFAULT_CLIENT = "0oadp0hpl7q3UIehP297"
 
 
 def get_secrets():
     """Get the driver secret values."""
-    # Handle local credentials.
-    if "AWS_SESSION_TOKEN" not in os.environ:
-        if "AWS_ROLE_ARN" in os.environ:
-            session = boto3.Session(aws_access_key_id=os.environ['AWS_ACCESS_KEY_ID'], aws_secret_access_key=os.environ['AWS_SECRET_ACCESS_KEY'])
-            client = session.client(service_name='sts', region_name='us-west-2')
-            creds = client.assume_role(RoleArn=os.environ['AWS_ROLE_ARN'], RoleSessionName='test')['Credentials']
-            os.environ['AWS_ACCESS_KEY_ID'] = creds['AccessKeyId']
-            os.environ['AWS_SECRET_ACCESS_KEY'] = creds['SecretAccessKey']
-            os.environ['AWS_SESSION_TOKEN'] = creds['SessionToken']
-
-        else:
-            raise ValueError('Missing AWS credentials')
-
-    # Create a session using the given creds
-    session = boto3.Session(aws_access_key_id=os.environ['AWS_ACCESS_KEY_ID'], aws_secret_access_key=os.environ['AWS_SECRET_ACCESS_KEY'], aws_session_token=os.environ['AWS_SESSION_TOKEN'])
-    client = session.client(service_name='secretsmanager', region_name='us-west-2')
-    try:
-        get_secret_value_response = client.get_secret_value(
-            SecretId='drivers/test'
-        )
-    except Exception as e:
-        # For a list of exceptions thrown, see
-        # https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html
-        raise e
-
-    # Decrypts secret using the associated KMS key.
-    return json.loads(get_secret_value_response['SecretString'])
+    secrets = root_get_secrets(["drivers/oidc"], "us-east-1", None)[0]
+    for key in list(secrets):
+        secrets[key.lower()] = secrets[key]
+    return secrets


### PR DESCRIPTION
Migrate the OIDC Secrets handling to use the new `setup_secrets.py` script.

Tested in https://spruce.mongodb.com/task/mongo_python_driver_oidc_auth_test__platform~rhel8_python_version~3.9_oidc_auth_test_latest_patch_f2867a9abf277e664b46d3d30dd380e6ae77c9d4_64ee990cc9ec4495336145c5_23_08_30_01_19_18/logs?execution=0.