### PR TITLE
add unique function generation

### DIFF
--- a/.evergreen/atlas/setup-atlas-cluster.sh
+++ b/.evergreen/atlas/setup-atlas-cluster.sh
@@ -25,7 +25,7 @@ DRIVERS_ATLAS_GROUP_ID
 DRIVERS_ATLAS_LAMBDA_USER
 DRIVERS_ATLAS_LAMBDA_PASSWORD
 LAMBDA_STACK_NAME
-TASK_ID
+task_id
 )
 
 # Ensure that all variables required to run the test are set, otherwise throw

--- a/.evergreen/atlas/setup-atlas-cluster.sh
+++ b/.evergreen/atlas/setup-atlas-cluster.sh
@@ -25,6 +25,7 @@ DRIVERS_ATLAS_GROUP_ID
 DRIVERS_ATLAS_LAMBDA_USER
 DRIVERS_ATLAS_LAMBDA_PASSWORD
 LAMBDA_STACK_NAME
+TASK_ID
 )
 
 # Ensure that all variables required to run the test are set, otherwise throw

--- a/.evergreen/atlas/setup-variables.sh
+++ b/.evergreen/atlas/setup-variables.sh
@@ -10,7 +10,7 @@ set -o errexit  # Exit the script with error if any of the commands fail
 # FUNCTION_NAME: Uses the stack name plus the current commit sha to create a unique cluster and function.
 # ATLAS_BASE_URL: Where the Atlas API root resides.
 # task_id: The `task_id` evergreen expansion associated with the CI run (or a unique identifier with which to create the function name).
-#          Note: This MUST be unique per-CI task.  Otherwise, multiple tasks calling this script may attempt to create lambda functions with the same name.
+#          Note: This MUST be unique per-CI task.  Otherwise, multiple tasks calling this script may attempt to create clusters with the same name.
 
 
 # The Atlas API version

--- a/.evergreen/atlas/setup-variables.sh
+++ b/.evergreen/atlas/setup-variables.sh
@@ -9,7 +9,8 @@ set -o errexit  # Exit the script with error if any of the commands fail
 #
 # FUNCTION_NAME: Uses the stack name plus the current commit sha to create a unique cluster and function.
 # ATLAS_BASE_URL: Where the Atlas API root resides.
-# TASK_ID: The `task_id` evergreen expansion associated with the CI run.
+# task_id: The `task_id` evergreen expansion associated with the CI run (or a unique identifier with which to create the function name).
+#          Note: This MUST be unique per-CI task.  Otherwise, multiple tasks calling this script may attempt to create lambda functions with the same name.
 
 
 # The Atlas API version
@@ -22,4 +23,4 @@ ATLAS_BASE_URL="https://cloud.mongodb.com/api/atlas/$ATLAS_API_VERSION"
 TASK_NAME=$(task_id | base64 | head -c 8)
 
 # Add git commit to name of function and cluster.
-FUNCTION_NAME="${LAMBDA_STACK_NAME}-${task_id | base64 | head -c 8}-$(git rev-parse --short HEAD)"
+FUNCTION_NAME="${LAMBDA_STACK_NAME}-${TASK_NAME}-$(git rev-parse --short HEAD)"

--- a/.evergreen/atlas/setup-variables.sh
+++ b/.evergreen/atlas/setup-variables.sh
@@ -18,5 +18,8 @@ ATLAS_API_VERSION="v1.0"
 # support testing cluster outages.
 ATLAS_BASE_URL="https://cloud.mongodb.com/api/atlas/$ATLAS_API_VERSION"
 
+# create a unique per CI task tag for the function.
+TASK_NAME=$(task_id | base64 | head -c 8)
+
 # Add git commit to name of function and cluster.
-FUNCTION_NAME="${LAMBDA_STACK_NAME}-${TASK_ID | base64 | head -c 8}-$(git rev-parse --short HEAD)"
+FUNCTION_NAME="${LAMBDA_STACK_NAME}-${task_id | base64 | head -c 8}-$(git rev-parse --short HEAD)"

--- a/.evergreen/atlas/setup-variables.sh
+++ b/.evergreen/atlas/setup-variables.sh
@@ -19,4 +19,4 @@ ATLAS_API_VERSION="v1.0"
 ATLAS_BASE_URL="https://cloud.mongodb.com/api/atlas/$ATLAS_API_VERSION"
 
 # Add git commit to name of function and cluster.
-FUNCTION_NAME="${LAMBDA_STACK_NAME}-${TASK_ID}-$(git rev-parse --short HEAD)"
+FUNCTION_NAME="${LAMBDA_STACK_NAME}-${TASK_ID | base64 | head -c 8}-$(git rev-parse --short HEAD)"

--- a/.evergreen/atlas/setup-variables.sh
+++ b/.evergreen/atlas/setup-variables.sh
@@ -20,7 +20,7 @@ ATLAS_API_VERSION="v1.0"
 ATLAS_BASE_URL="https://cloud.mongodb.com/api/atlas/$ATLAS_API_VERSION"
 
 # create a unique per CI task tag for the function.
-TASK_NAME=$(task_id | base64 | head -c 8)
+TASK_NAME=$(echo $task_id | base64 | head -c 8)
 
 # Add git commit to name of function and cluster.
 FUNCTION_NAME="${LAMBDA_STACK_NAME}-${TASK_NAME}-$(git rev-parse --short HEAD)"

--- a/.evergreen/atlas/setup-variables.sh
+++ b/.evergreen/atlas/setup-variables.sh
@@ -9,6 +9,7 @@ set -o errexit  # Exit the script with error if any of the commands fail
 #
 # FUNCTION_NAME: Uses the stack name plus the current commit sha to create a unique cluster and function.
 # ATLAS_BASE_URL: Where the Atlas API root resides.
+# TASK_ID: The `task_id` evergreen expansion associated with the CI run.
 
 
 # The Atlas API version
@@ -18,4 +19,4 @@ ATLAS_API_VERSION="v1.0"
 ATLAS_BASE_URL="https://cloud.mongodb.com/api/atlas/$ATLAS_API_VERSION"
 
 # Add git commit to name of function and cluster.
-FUNCTION_NAME="${LAMBDA_STACK_NAME}-$(git rev-parse --short HEAD)"
+FUNCTION_NAME="${LAMBDA_STACK_NAME}-${TASK_ID}-$(git rev-parse --short HEAD)"

--- a/.evergreen/atlas/teardown-atlas-cluster.sh
+++ b/.evergreen/atlas/teardown-atlas-cluster.sh
@@ -18,7 +18,7 @@ DRIVERS_ATLAS_PUBLIC_API_KEY
 DRIVERS_ATLAS_PRIVATE_API_KEY
 DRIVERS_ATLAS_GROUP_ID
 LAMBDA_STACK_NAME
-TASK_ID
+task_id
 )
 
 # Ensure that all variables required to run the test are set, otherwise throw

--- a/.evergreen/atlas/teardown-atlas-cluster.sh
+++ b/.evergreen/atlas/teardown-atlas-cluster.sh
@@ -18,6 +18,7 @@ DRIVERS_ATLAS_PUBLIC_API_KEY
 DRIVERS_ATLAS_PRIVATE_API_KEY
 DRIVERS_ATLAS_GROUP_ID
 LAMBDA_STACK_NAME
+TASK_ID
 )
 
 # Ensure that all variables required to run the test are set, otherwise throw


### PR DESCRIPTION
The setup and teardown atlas cluster scripts create unique clusters per-commit.  This can result in multiple CI tasks for the same commit attempting to create the same cluster.

This PR uses the `task_id` (a default evergreen expansion) to ensure that generated clusters are unique per-task.

Here's a patch from Node: https://spruce.mongodb.com/version/64f8955c3627e0397fdb50c0/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

Note that this patch is failing because of unrelated `npm` version issues (we're fixing this separately) but you can see the cluster successfully spins up and tears down.