### PR TITLE
DRIVERS-2585 Make the Secrets Access errors more user friendly

### DIFF
--- a/.evergreen/auth_aws/activate-authawsvenv.sh
+++ b/.evergreen/auth_aws/activate-authawsvenv.sh
@@ -41,7 +41,7 @@ activate_authawsvenv() {
     venvcreate "${PYTHON:?}" authawsvenv || return
 
     local packages=(
-      "boto3~=1.26.0"
+      "boto3~=1.28.0"
       "pyop~=3.4.0"
       "pymongo[aws]~=4.0"
     )

--- a/.evergreen/auth_oidc/activate-authoidcvenv.sh
+++ b/.evergreen/auth_oidc/activate-authoidcvenv.sh
@@ -41,7 +41,7 @@ activate_authoidcvenv() {
     venvcreate "${PYTHON:?}" authoidcvenv || return
 
     local packages=(
-      "boto3~=1.19.0"
+      "boto3~=1.28.0"
       "pyop~=3.4.0"
       "azure-identity"
       "azure-keyvault-secrets"


### PR DESCRIPTION
Instead of a traceback, they'll see something like:

```

ERROR: The SSO session associated with this profile has expired or is otherwise invalid. To refresh this SSO session run aws sso login with the corresponding profile.

```