### PR TITLE
Update download-mongodb.sh

### DIFF
--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -56,12 +56,12 @@ get_mongodb_download_url_for ()
    VERSION_MONGOSH="1.8.1"
    # Set VERSION_RAPID to the latest rapid release each quarter.
    VERSION_RAPID="6.3.1"
-   VERSION_70="7.0.0-rc7"
+   VERSION_70="7.0.1"
    VERSION_60_LATEST="v6.0-latest"
    VERSION_60="6.0.9"
    # The perf version must always remain pinned to the same patch
    VERSION_60_PERF="6.0.6"
-   VERSION_50="5.0.19"
+   VERSION_50="5.0.20"
    VERSION_44="4.4.23"
    VERSION_42="4.2.24"
    VERSION_40="4.0.28"


### PR DESCRIPTION
Update 5.0 and 7.0 to latest patch.

I noticed also that the test suite doesn't include 5.0 or 7.0 tasks in the various matrices, so there is no test coverage for either of these.  I validated the version numbers using the `m` tool:

```
m 5.0.20-ent
m 7.0.1-ent
```