### PR TITLE
DRIVERS-2723: ensure atlas cluster names are unique

### DIFF
--- a/.evergreen/atlas/setup-atlas-cluster.sh
+++ b/.evergreen/atlas/setup-atlas-cluster.sh
@@ -26,6 +26,7 @@ DRIVERS_ATLAS_LAMBDA_USER
 DRIVERS_ATLAS_LAMBDA_PASSWORD
 LAMBDA_STACK_NAME
 task_id
+execution
 )
 
 # Ensure that all variables required to run the test are set, otherwise throw

--- a/.evergreen/atlas/setup-variables.sh
+++ b/.evergreen/atlas/setup-variables.sh
@@ -19,14 +19,11 @@ ATLAS_API_VERSION="v1.0"
 # support testing cluster outages.
 ATLAS_BASE_URL="https://cloud.mongodb.com/api/atlas/$ATLAS_API_VERSION"
 
-echo "logs ***********************"
-echo $task_id
-temp=$($task_id | base64)
-echo $temp
-echo "logs ***********************"
-
 # create a unique per CI task tag for the function.
-TASK_NAME=$(echo $task_id | base64 | head -c 8)
+# task_id has the structure $projectID_$variantName_$taskName_$commitHash_$createTime, which is unique per task per ci run per project.
+# task_id is NOT unique across restarts of the same task though, so we include execution to ensure that it is unique for every restart too.
+# the generated string is hashed to ensure the prefix is unique for every id
+TASK_ID=$(echo "${task_id}-${execution}" | md5)
 
 # Add git commit to name of function and cluster.
-FUNCTION_NAME="${LAMBDA_STACK_NAME}-${TASK_NAME}-$(git rev-parse --short HEAD)"
+FUNCTION_NAME="${LAMBDA_STACK_NAME}-${TASK_ID}"

--- a/.evergreen/atlas/setup-variables.sh
+++ b/.evergreen/atlas/setup-variables.sh
@@ -27,3 +27,6 @@ TASK_ID=$(echo "${task_id}-${execution}" | base64)
 
 # Add git commit to name of function and cluster.
 FUNCTION_NAME="${LAMBDA_STACK_NAME}-${TASK_ID}"
+
+echo $FUNCTION_NAME | wc -c 
+echo $FUNCTION_NAME

--- a/.evergreen/atlas/setup-variables.sh
+++ b/.evergreen/atlas/setup-variables.sh
@@ -19,14 +19,13 @@ ATLAS_API_VERSION="v1.0"
 # support testing cluster outages.
 ATLAS_BASE_URL="https://cloud.mongodb.com/api/atlas/$ATLAS_API_VERSION"
 
+echo "${task_id}-${execution}"
+
 # create a unique per CI task tag for the function.
 # task_id has the structure $projectID_$variantName_$taskName_$commitHash_$createTime, which is unique per task per ci run per project.
 # task_id is NOT unique across restarts of the same task though, so we include execution to ensure that it is unique for every restart too.
-# the generated string is hashed to ensure the prefix is unique for every id
-TASK_ID=$(echo "${task_id}-${execution}" | tr '_' '-')
+# the generated string is hashed to ensure the prefix is unique for every 
+TASK_ID=$(node -e "process.stdout.write(require('crypto').createHash('md5').update(process.argv[1]).digest().toString('hex'))" "${task_id}-${execution}")
 
 # Add git commit to name of function and cluster.
 FUNCTION_NAME="${LAMBDA_STACK_NAME}-${TASK_ID}"
-
-echo $FUNCTION_NAME | wc -c 
-echo $FUNCTION_NAME

--- a/.evergreen/atlas/setup-variables.sh
+++ b/.evergreen/atlas/setup-variables.sh
@@ -23,7 +23,7 @@ ATLAS_BASE_URL="https://cloud.mongodb.com/api/atlas/$ATLAS_API_VERSION"
 # task_id has the structure $projectID_$variantName_$taskName_$commitHash_$createTime, which is unique per task per ci run per project.
 # task_id is NOT unique across restarts of the same task though, so we include execution to ensure that it is unique for every restart too.
 # the generated string is hashed to ensure the prefix is unique for every id
-TASK_ID=$(echo "${task_id}-${execution}" | base64 | tr -d '[:space:]')
+TASK_ID=$(echo "${task_id}-${execution}" | tr '_' '-')
 
 # Add git commit to name of function and cluster.
 FUNCTION_NAME="${LAMBDA_STACK_NAME}-${TASK_ID}"

--- a/.evergreen/atlas/setup-variables.sh
+++ b/.evergreen/atlas/setup-variables.sh
@@ -23,7 +23,7 @@ ATLAS_BASE_URL="https://cloud.mongodb.com/api/atlas/$ATLAS_API_VERSION"
 # task_id has the structure $projectID_$variantName_$taskName_$commitHash_$createTime, which is unique per task per ci run per project.
 # task_id is NOT unique across restarts of the same task though, so we include execution to ensure that it is unique for every restart too.
 # the generated string is hashed to ensure the prefix is unique for every id
-TASK_ID=$(echo "${task_id}-${execution}" | md5)
+TASK_ID=$(echo "${task_id}-${execution}" | base64)
 
 # Add git commit to name of function and cluster.
 FUNCTION_NAME="${LAMBDA_STACK_NAME}-${TASK_ID}"

--- a/.evergreen/atlas/setup-variables.sh
+++ b/.evergreen/atlas/setup-variables.sh
@@ -19,6 +19,12 @@ ATLAS_API_VERSION="v1.0"
 # support testing cluster outages.
 ATLAS_BASE_URL="https://cloud.mongodb.com/api/atlas/$ATLAS_API_VERSION"
 
+echo "logs ***********************"
+echo $task_id
+temp=$($task_id | base64)
+echo $temp
+echo "logs ***********************"
+
 # create a unique per CI task tag for the function.
 TASK_NAME=$(echo $task_id | base64 | head -c 8)
 

--- a/.evergreen/atlas/setup-variables.sh
+++ b/.evergreen/atlas/setup-variables.sh
@@ -23,7 +23,7 @@ ATLAS_BASE_URL="https://cloud.mongodb.com/api/atlas/$ATLAS_API_VERSION"
 # task_id has the structure $projectID_$variantName_$taskName_$commitHash_$createTime, which is unique per task per ci run per project.
 # task_id is NOT unique across restarts of the same task though, so we include execution to ensure that it is unique for every restart too.
 # the generated string is hashed to ensure the prefix is unique for every id
-TASK_ID=$(echo "${task_id}-${execution}" | base64)
+TASK_ID=$(echo "${task_id}-${execution}" | base64 | tr -d '[:space:]')
 
 # Add git commit to name of function and cluster.
 FUNCTION_NAME="${LAMBDA_STACK_NAME}-${TASK_ID}"

--- a/.evergreen/atlas/teardown-atlas-cluster.sh
+++ b/.evergreen/atlas/teardown-atlas-cluster.sh
@@ -19,6 +19,7 @@ DRIVERS_ATLAS_PRIVATE_API_KEY
 DRIVERS_ATLAS_GROUP_ID
 LAMBDA_STACK_NAME
 task_id
+execution
 )
 
 # Ensure that all variables required to run the test are set, otherwise throw


### PR DESCRIPTION
The previous changes to make cluster names unique did not actually produce unique cluster names.  each task id starts with the project name, so piping the task_id into `base64 | head -c 8` produces the same string for each evergreen project.

This PR does two things:

- The task id is now hashed to ensure that it is unique per-commit per-CI run per-driver
- the `execution` expansion is also included, to ensure function names are unique across restarts

patch in Node showing unique cluster names for both tasks that use these scripts in CI: https://spruce.mongodb.com/version/65035e55d6d80a62019a64bc/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC