### PR TITLE
DRIVERS-2736 Update Drivers-Evergreen-Tools for Supported Build Hosts

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -518,6 +518,33 @@ tasks:
 
 # Standard test tasks {{{
 
+    - name: "test-7.0-standalone"
+      tags: ["7.0", "standalone"]
+      commands:
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            VERSION: "7.0"
+            TOPOLOGY: "server"
+        - func: "run tests"
+
+    - name: "test-7.0-replica_set"
+      tags: ["7.0", "replica_set"]
+      commands:
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            VERSION: "7.0"
+            TOPOLOGY: "replica_set"
+        - func: "run tests"
+
+    - name: "test-7.0-sharded_cluster"
+      tags: ["7.0", "sharded_cluster"]
+      commands:
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            VERSION: "7.0"
+            TOPOLOGY: "sharded_cluster"
+        - func: "run tests"
+
     - name: "test-6.0-standalone"
       tags: ["6.0", "standalone"]
       commands:
@@ -771,37 +798,25 @@ axes:
         display_name: "RHEL 8"
         run_on: rhel87-small
 
-  # OSes that support versions of MongoDB without SSL.
-  - id: os-nossl
-    display_name: OS
-    values:
+      - id: macos-1100
+        display_name: "macOS 11.00"
+        run_on: macos-1100
 
-      - id: macos-1014
-        display_name: "macOS 10.14"
-        run_on: macos-1014
-
-  - id: os-windows
-    display_name: OS
-    values:
       - id: windows-64-vsMulti-small
         display_name: "Windows 64"
         run_on: windows-64-vsMulti-small
-
-  # OSes that support versions of MongoDB>=3.6 with SSL.
-  - id: os-requires-36
-    display_name: OS
-    values:
-      - id: rhe87-small
-        display_name: "RHEL 8"
-        run_on: rhel87-small
 
   # OSes that support versions of MongoDB>=4.4 with SSL.
   - id: os-requires-44
     display_name: OS
     values:
 
+      - id: debian10
+        display_name: "Debian 10.0"
+        run_on: debian10-small
+
       - id: ubuntu-20.04
-        display_name: "Ubuntu 20.04 (Requires 4.4)"
+        display_name: "Ubuntu 20.04"
         run_on: ubuntu2004-test
 
       - id: ubuntu2004-arm64-small
@@ -810,11 +825,11 @@ axes:
 
       - id: rhel87-power8
         display_name: "RHEL 8 (POWER8)"
-        run_on: rhel87-power8
+        run_on: rhel81-power8-small
 
-      - id: ubuntu2004-zseries-small
-        display_name: "Ubuntu 20.04 (zSeries)"
-        run_on: ubuntu2004-zseries-small
+      - id: rhel83-zseries-small
+        display_name: "RHEL8 (zSeries)"
+        run_on: rhel83-zseries-small
 
   - id: topology
     display_name: Topology
@@ -909,7 +924,7 @@ buildvariants:
 - name: releng-release-archive-creator
   display_name: "** Release Archive Creator"
   run_on:
-    - ubuntu1404-build
+    - ubuntu2004-large
   tasks:
     - ".releng" # Run all tasks with the "releng" tag
 
@@ -917,33 +932,6 @@ buildvariants:
 - matrix_name: "tests-all"
   matrix_spec: {"os-fully-featured": "*", auth: "*", ssl: "*" }
   display_name: "${os-fully-featured} ${auth} ${ssl}"
-  tasks:
-     - name: "test-latest-replica_set"
-     - name: "test-latest-sharded_cluster"
-     - name: "test-latest-standalone"
-     - name: "test-latest-load_balancer"
-     - name: "test-6.0-replica_set"
-     - name: "test-6.0-sharded_cluster"
-     - name: "test-6.0-standalone"
-     - name: "test-5.0-replica_set"
-     - name: "test-5.0-sharded_cluster"
-     - name: "test-5.0-standalone"
-     - name: "test-4.4-replica_set"
-     - name: "test-4.4-sharded_cluster"
-     - name: "test-4.4-standalone"
-     - name: "test-4.2-replica_set"
-     - name: "test-4.2-sharded_cluster"
-     - name: "test-4.2-standalone"
-     - name: "test-4.0-replica_set"
-     - name: "test-4.0-sharded_cluster"
-     - name: "test-4.0-standalone"
-     - name: "test-3.6-replica_set"
-     - name: "test-3.6-sharded_cluster"
-     - name: "test-3.6-standalone"
-
-- matrix_name: "tests-nossl"
-  matrix_spec: {"os-nossl": "*", auth: "*", ssl: "nossl" }
-  display_name: "${os-nossl} ${auth} ${ssl}"
   tasks:
      - name: "test-latest-replica_set"
      - name: "test-latest-sharded_cluster"
@@ -993,59 +981,30 @@ buildvariants:
 
 # Storage Engine Tests on Ubuntu 20.04
 - matrix_name: "tests-storage-engines"
-  matrix_spec: {"os-fully-featured": "ubuntu-2004", storage-engine: "*" }
-  display_name: "${os-fully-featured} ${storage-engine}"
+  matrix_spec: {"os-requires-44": "ubuntu-20.04", storage-engine: "*" }
+  display_name: "${os-requires-44} ${storage-engine}"
   rules:
     - if:
-        os-fully-featured: "*"
+        os-requires-44: "*"
         storage-engine: ["mmapv1"]
       then:
         add_tasks:
           - "test-4.4-standalone"
     - if:
-        os-fully-featured: "*"
+        os-requires-44: "*"
         storage-engine: ["inmemory"]
       then:
         add_tasks:
           - "test-latest-standalone"
+          - "test-7.0-standalone"
           - "test-6.0-standalone"
           - "test-5.0-standalone"
     - if:
-        os-fully-featured: "*"
+        os-requires-44: "*"
         storage-engine: "wiredtiger"
       then:
         add_tasks:
           - "test-5.0-standalone"
-
-- matrix_name: "tests-windows"
-  matrix_spec: {os-windows: "*", auth: "*", ssl: "*" }
-  display_name: "${os-windows} ${auth} ${ssl}"
-  tasks:
-     - name: "test-latest-replica_set"
-     - name: "test-latest-sharded_cluster"
-     - name: "test-latest-standalone"
-     - name: "test-latest-load_balancer"
-     - name: "test-7.0-replica_set"
-     - name: "test-7.0-sharded_cluster"
-     - name: "test-7.0-standalone"
-     - name: "test-6.0-replica_set"
-     - name: "test-6.0-sharded_cluster"
-     - name: "test-6.0-standalone"
-     - name: "test-5.0-replica_set"
-     - name: "test-5.0-sharded_cluster"
-     - name: "test-5.0-standalone"
-     - name: "test-4.4-replica_set"
-     - name: "test-4.4-sharded_cluster"
-     - name: "test-4.4-standalone"
-     - name: "test-4.2-replica_set"
-     - name: "test-4.2-sharded_cluster"
-     - name: "test-4.2-standalone"
-     - name: "test-4.0-replica_set"
-     - name: "test-4.0-sharded_cluster"
-     - name: "test-4.0-standalone"
-     - name: "test-3.6-replica_set"
-     - name: "test-3.6-sharded_cluster"
-     - name: "test-3.6-standalone"
 
 - matrix_name: "serverless"
   matrix_spec:
@@ -1061,7 +1020,8 @@ buildvariants:
       # Ubuntu16.04 ppc64le is only supported by MongoDB 3.4+
       # Ubuntu16.04 aarch64 is only supported by MongoDB 3.4+
       # Ubuntu16.04 s390x is only supported by MongoDB 3.4+
-      # Ubuntu16.04 (x86) only supports MongoDB 3.2+
+      # Ubuntu20.04 only supports MongoDB 4.4+
+      # Debian 10.0 only supports MongoDB 4.2+
       # Debian 8.1 only supports MongoDB 3.4+
       # SUSE12 s390x is only supported by MongoDB 3.4+
       # No enterprise build for Archlinux, SSL not available

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1016,6 +1016,7 @@ buildvariants:
       # Ubuntu16.04 ppc64le is only supported by MongoDB 3.4+
       # Ubuntu16.04 aarch64 is only supported by MongoDB 3.4+
       # Ubuntu16.04 s390x is only supported by MongoDB 3.4+
+      # Ubuntu16.04 (x86) only supports MongoDB 3.2+
       # Ubuntu20.04 only supports MongoDB 4.4+
       # Debian 10.0 only supports MongoDB 4.2+
       # Debian 8.1 only supports MongoDB 3.4+

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -959,9 +959,9 @@ buildvariants:
      - name: "test-3.6-sharded_cluster"
      - name: "test-3.6-standalone"
 
-- matrix_name: "tests-os-requires-50"
-  matrix_spec: {"os-requires-50": "*", auth: "*", ssl: "*" }
-  display_name: "${os-requires-50} ${auth} ${ssl}"
+- matrix_name: "tests-os-fully-featured"
+  matrix_spec: {"os-fully-featured": "*", auth: "*", ssl: "*" }
+  display_name: "${os-fully-featured} ${auth} ${ssl}"
   tasks:
      - name: "test-latest-replica_set"
      - name: "test-latest-sharded_cluster"
@@ -978,30 +978,29 @@ buildvariants:
 
 # Storage Engine Tests on Ubuntu 20.04
 - matrix_name: "tests-storage-engines"
-  matrix_spec: {"os-requires-50": "ubuntu-20.04", storage-engine: "*" }
-  display_name: "${os-requires-50} ${storage-engine}"
+  matrix_spec: {"os-fully-featured": "ubuntu-20.04", storage-engine: "*" }
+  display_name: "${os-fully-featured} ${storage-engine}"
   rules:
     - if:
-        os-requires-50: "*"
+        os-fully-featured: "*"
         storage-engine: ["mmapv1"]
       then:
         add_tasks:
-          - "test-4.4-standalone"
+          - "test-3.6-standalone"
     - if:
-        os-requires-50: "*"
+        os-fully-featured: "*"
         storage-engine: ["inmemory"]
       then:
         add_tasks:
           - "test-latest-standalone"
           - "test-7.0-standalone"
-          - "test-6.0-standalone"
-          - "test-5.0-standalone"
+          - "test-3.6-standalone"
     - if:
-        os-requires-50: "*"
+        os-fully-featured: "*"
         storage-engine: "wiredtiger"
       then:
         add_tasks:
-          - "test-5.0-standalone"
+          - "test-3.6-standalone"
 
 - matrix_name: "serverless"
   matrix_spec:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -733,6 +733,10 @@ axes:
         display_name: "latest"
         variables:
            VERSION: "latest"
+      - id: "7.0"
+        display_name: "7.0"
+        variables:
+           VERSION: "7.0"
       - id: "6.0"
         display_name: "6.0"
         variables:
@@ -763,9 +767,9 @@ axes:
     display_name: OS
     values:
 
-      - id: ubuntu-1804
-        display_name: "Ubuntu 18.04"
-        run_on: ubuntu1804-small
+      - id: rhel87-small
+        display_name: "RHEL 8"
+        run_on: rhel87-small
 
   # OSes that support versions of MongoDB without SSL.
   - id: os-nossl
@@ -787,37 +791,30 @@ axes:
   - id: os-requires-36
     display_name: OS
     values:
-      - id: debian81-test
-        display_name: "Debian 8.1"
-        run_on: debian81-test
+      - id: rhe87-small
+        display_name: "RHEL 8"
+        run_on: rhel87-small
 
-      - id: rhel70-small
-        display_name: "RHEL 7.0"
-        run_on: rhel70-small
-
-  # OSes that support versions of MongoDB>=4.2 with SSL.
-  - id: os-requires-42
+  # OSes that support versions of MongoDB>=4.4 with SSL.
+  - id: os-requires-44
     display_name: OS
     values:
-      - id: debian92-test
-        display_name: "Debian 9.2"
-        run_on: debian92-test
 
-      - id: ubuntu-18.04
-        display_name: "Ubuntu 18.04 (Requires 4.2)"
-        run_on: ubuntu1804-test
+      - id: ubuntu-20.04
+        display_name: "Ubuntu 20.04 (Requires 4.4)"
+        run_on: ubuntu2004-test
 
-      - id: ubuntu1804-arm64-small
+      - id: ubuntu2004-arm64-small
         display_name: "Ubuntu 18.04 (ARM64)"
-        run_on: ubuntu1804-arm64-small
+        run_on: ubuntu2004-arm64-small
 
-      - id: rhel81-power8
-        display_name: "RHEL 8.1 (POWER8)"
-        run_on: rhel81-power8
+      - id: rhel87-power8
+        display_name: "RHEL 8 (POWER8)"
+        run_on: rhel87-power8
 
-      - id: ubuntu1804-zseries-small
-        display_name: "Ubuntu 18.04 (zSeries)"
-        run_on: ubuntu1804-zseries-small
+      - id: ubuntu2004-zseries-small
+        display_name: "Ubuntu 20.04 (zSeries)"
+        run_on: ubuntu2004-zseries-small
 
   - id: topology
     display_name: Topology
@@ -952,6 +949,9 @@ buildvariants:
      - name: "test-latest-sharded_cluster"
      - name: "test-latest-standalone"
      - name: "test-latest-load_balancer"
+     - name: "test-7.0-replica_set"
+     - name: "test-7.0-sharded_cluster"
+     - name: "test-7.0-standalone"
      - name: "test-6.0-replica_set"
      - name: "test-6.0-sharded_cluster"
      - name: "test-6.0-standalone"
@@ -971,31 +971,29 @@ buildvariants:
      - name: "test-3.6-sharded_cluster"
      - name: "test-3.6-standalone"
 
-- matrix_name: "tests-os-requires-36"
-  matrix_spec: {"os-requires-36": "*", auth: "*", ssl: "*" }
-  display_name: "${os-requires-36} ${auth} ${ssl}"
+- matrix_name: "tests-os-requires-44"
+  matrix_spec: {"os-requires-44": "*", auth: "*", ssl: "*" }
+  display_name: "${os-requires-44} ${auth} ${ssl}"
   tasks:
      - name: "test-latest-replica_set"
      - name: "test-latest-sharded_cluster"
      - name: "test-latest-standalone"
-     - name: "test-3.6-replica_set"
-     - name: "test-3.6-sharded_cluster"
-     - name: "test-3.6-standalone"
+     - name: "test-7.0-replica_set"
+     - name: "test-7.0-sharded_cluster"
+     - name: "test-7.0-standalone"
+     - name: "test-6.0-replica_set"
+     - name: "test-6.0-sharded_cluster"
+     - name: "test-6.0-standalone"
+     - name: "test-5.0-replica_set"
+     - name: "test-5.0-sharded_cluster"
+     - name: "test-5.0-standalone"
+     - name: "test-4.4-replica_set"
+     - name: "test-4.4-sharded_cluster"
+     - name: "test-4.4-standalone"
 
-- matrix_name: "tests-os-requires-42"
-  matrix_spec: {"os-requires-42": "*", auth: "*", ssl: "*" }
-  display_name: "${os-requires-42} ${auth} ${ssl}"
-  tasks:
-     - name: "test-latest-replica_set"
-     - name: "test-latest-sharded_cluster"
-     - name: "test-latest-standalone"
-     - name: "test-4.2-replica_set"
-     - name: "test-4.2-sharded_cluster"
-     - name: "test-4.2-standalone"
-
-# Storage Engine Tests on Ubuntu 18.04
+# Storage Engine Tests on Ubuntu 20.04
 - matrix_name: "tests-storage-engines"
-  matrix_spec: {"os-fully-featured": "ubuntu-1804", storage-engine: "*" }
+  matrix_spec: {"os-fully-featured": "ubuntu-2004", storage-engine: "*" }
   display_name: "${os-fully-featured} ${storage-engine}"
   rules:
     - if:
@@ -1003,7 +1001,7 @@ buildvariants:
         storage-engine: ["mmapv1"]
       then:
         add_tasks:
-          - "test-3.6-standalone"
+          - "test-4.4-standalone"
     - if:
         os-fully-featured: "*"
         storage-engine: ["inmemory"]
@@ -1011,13 +1009,13 @@ buildvariants:
         add_tasks:
           - "test-latest-standalone"
           - "test-6.0-standalone"
-          - "test-3.6-standalone"
+          - "test-5.0-standalone"
     - if:
         os-fully-featured: "*"
         storage-engine: "wiredtiger"
       then:
         add_tasks:
-          - "test-3.6-standalone"
+          - "test-5.0-standalone"
 
 - matrix_name: "tests-windows"
   matrix_spec: {os-windows: "*", auth: "*", ssl: "*" }
@@ -1027,6 +1025,9 @@ buildvariants:
      - name: "test-latest-sharded_cluster"
      - name: "test-latest-standalone"
      - name: "test-latest-load_balancer"
+     - name: "test-7.0-replica_set"
+     - name: "test-7.0-sharded_cluster"
+     - name: "test-7.0-standalone"
      - name: "test-6.0-replica_set"
      - name: "test-6.0-sharded_cluster"
      - name: "test-6.0-standalone"
@@ -1048,9 +1049,9 @@ buildvariants:
 
 - matrix_name: "serverless"
   matrix_spec:
-    os-requires-42:
-      - "ubuntu-18.04"
-  display_name: "Serverless ${os-requires-42}"
+    os-requires-44:
+      - "ubuntu-20.04"
+  display_name: "Serverless ${os-requires-44}"
   tasks:
     - "serverless_task_group"
 
@@ -1073,4 +1074,3 @@ buildvariants:
       # Debian 7.1 does not support MongoDB 2.4
       # SUSE12 x86_64 is only supported by MongoDB 3.2+
       # vim: set et sw=2 ts=2 :
-

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -794,7 +794,7 @@ axes:
     display_name: OS
     values:
 
-      - id: rhel87-small
+      - id: rhel8
         display_name: "RHEL 8"
         run_on: rhel87-small
 
@@ -959,9 +959,9 @@ buildvariants:
      - name: "test-3.6-sharded_cluster"
      - name: "test-3.6-standalone"
 
-- matrix_name: "tests-os-fully-featured"
-  matrix_spec: {"os-fully-featured": "*", auth: "*", ssl: "*" }
-  display_name: "${os-fully-featured} ${auth} ${ssl}"
+- matrix_name: "tests-os-requires-50"
+  matrix_spec: {"os-requires-50": "*", auth: "*", ssl: "*" }
+  display_name: "${os-requires-50} ${auth} ${ssl}"
   tasks:
      - name: "test-latest-replica_set"
      - name: "test-latest-sharded_cluster"
@@ -978,7 +978,7 @@ buildvariants:
 
 # Storage Engine Tests on Ubuntu 20.04
 - matrix_name: "tests-storage-engines"
-  matrix_spec: {"os-fully-featured": "ubuntu-20.04", storage-engine: "*" }
+  matrix_spec: {"os-fully-featured": "rhel8", storage-engine: "*" }
   display_name: "${os-fully-featured} ${storage-engine}"
   rules:
     - if:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -806,8 +806,8 @@ axes:
         display_name: "Windows 64"
         run_on: windows-64-vsMulti-small
 
-  # OSes that support versions of MongoDB>=4.4 with SSL.
-  - id: os-requires-44
+  # OSes that support versions of MongoDB>=5.0 with SSL.
+  - id: os-requires-50
     display_name: OS
     values:
 
@@ -959,9 +959,9 @@ buildvariants:
      - name: "test-3.6-sharded_cluster"
      - name: "test-3.6-standalone"
 
-- matrix_name: "tests-os-requires-44"
-  matrix_spec: {"os-requires-44": "*", auth: "*", ssl: "*" }
-  display_name: "${os-requires-44} ${auth} ${ssl}"
+- matrix_name: "tests-os-requires-50"
+  matrix_spec: {"os-requires-50": "*", auth: "*", ssl: "*" }
+  display_name: "${os-requires-50} ${auth} ${ssl}"
   tasks:
      - name: "test-latest-replica_set"
      - name: "test-latest-sharded_cluster"
@@ -975,23 +975,20 @@ buildvariants:
      - name: "test-5.0-replica_set"
      - name: "test-5.0-sharded_cluster"
      - name: "test-5.0-standalone"
-     - name: "test-4.4-replica_set"
-     - name: "test-4.4-sharded_cluster"
-     - name: "test-4.4-standalone"
 
 # Storage Engine Tests on Ubuntu 20.04
 - matrix_name: "tests-storage-engines"
-  matrix_spec: {"os-requires-44": "ubuntu-20.04", storage-engine: "*" }
-  display_name: "${os-requires-44} ${storage-engine}"
+  matrix_spec: {"os-requires-50": "ubuntu-20.04", storage-engine: "*" }
+  display_name: "${os-requires-50} ${storage-engine}"
   rules:
     - if:
-        os-requires-44: "*"
+        os-requires-50: "*"
         storage-engine: ["mmapv1"]
       then:
         add_tasks:
           - "test-4.4-standalone"
     - if:
-        os-requires-44: "*"
+        os-requires-50: "*"
         storage-engine: ["inmemory"]
       then:
         add_tasks:
@@ -1000,7 +997,7 @@ buildvariants:
           - "test-6.0-standalone"
           - "test-5.0-standalone"
     - if:
-        os-requires-44: "*"
+        os-requires-50: "*"
         storage-engine: "wiredtiger"
       then:
         add_tasks:
@@ -1008,9 +1005,9 @@ buildvariants:
 
 - matrix_name: "serverless"
   matrix_spec:
-    os-requires-44:
+    os-requires-50:
       - "ubuntu-20.04"
-  display_name: "Serverless ${os-requires-44}"
+  display_name: "Serverless ${os-requires-50}"
   tasks:
     - "serverless_task_group"
 


### PR DESCRIPTION
Cleans up EVG testing matrix for currently supported server versions and distros.
Full passing patch build [here](https://spruce.mongodb.com/version/651484e2d1fe074855e98a6d/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)