### PR TITLE
Address build failures due to Python 3 binary lookup

### DIFF
--- a/.evergreen/run-orchestration.sh
+++ b/.evergreen/run-orchestration.sh
@@ -30,9 +30,10 @@ DIR=$(dirname $0)
 # Functions to fetch MongoDB binaries.
 . $DIR/download-mongodb.sh
 
-. $DIR/find-python3.sh
+# To continue supporting `sh run-orchestration.sh` for backwards-compatibility,
+# explicitly invoke Bash as a subshell here when running `find_python3`.
 echo "Finding Python3 binary..."
-PYTHON="$(find_python3 2>/dev/null)"
+PYTHON="$(bash -c ". $DIR/find-python3.sh && find_python3 2>/dev/null")"
 echo "Finding Python3 binary... done."
 
 get_distro

--- a/.evergreen/run-orchestration.sh
+++ b/.evergreen/run-orchestration.sh
@@ -30,17 +30,10 @@ DIR=$(dirname $0)
 # Functions to fetch MongoDB binaries.
 . $DIR/download-mongodb.sh
 
-# Find python3 if we are running in bash, otherwise prefer a
-# python3 binary over python, since some modern build hosts
-# only have the python3 binary.
-export PYTHON
-PYTHON=$(command -v python3 || command -v python)
-if [ -n "$BASH" ]; then
-  . $DIR/find-python3.sh
-  echo "Finding Python3 binary..."
-  PYTHON="$(find_python3 2>/dev/null)"
-  echo "Finding Python3 binary... done."
-fi
+. $DIR/find-python3.sh
+echo "Finding Python3 binary..."
+PYTHON="$(find_python3 2>/dev/null)"
+echo "Finding Python3 binary... done."
 
 get_distro
 if [ -z "$MONGODB_DOWNLOAD_URL" ]; then
@@ -107,7 +100,7 @@ fi
 export ORCHESTRATION_URL="http://localhost:8889/v1/${TOPOLOGY}s"
 
 # Start mongo-orchestration
-bash $DIR/start-orchestration.sh "$MONGO_ORCHESTRATION_HOME"
+PYTHON="${PYTHON:?}" bash $DIR/start-orchestration.sh "$MONGO_ORCHESTRATION_HOME"
 
 if ! curl --silent --show-error --data @"$ORCHESTRATION_FILE" "$ORCHESTRATION_URL" --max-time 600 --fail -o tmp.json; then
   echo Failed to start cluster, see $MONGO_ORCHESTRATION_HOME/out.log:

--- a/.evergreen/start-orchestration.sh
+++ b/.evergreen/start-orchestration.sh
@@ -25,11 +25,12 @@ det_evergreen_dir="$(dirname "${BASH_SOURCE[0]}")"
 
 cd "$MONGO_ORCHESTRATION_HOME"
 
-if [ -z "$PYTHON" ];then
+if [[ -z "${PYTHON:-}" ]]; then
   echo "Finding Python3 binary..."
   PYTHON="$(find_python3 2>/dev/null)"
   echo "Finding Python3 binary... done."
 else
+  # May have already been found by run-orchestration.sh. Avoid redundant lookup.
   echo "Using Python3 binary: $PYTHON"
 fi
 

--- a/action.yml
+++ b/action.yml
@@ -52,7 +52,7 @@ runs:
         STORAGE_ENGINE: ${{ inputs.storage-engine }}
         REQUIRE_API_VERSION: ${{ inputs.require-api-version }}
         SKIP_LEGACY_SHELL: ${{ inputs.skip-legacy-shell }}
-      shell: sh
+      shell: bash
     - id: "get-cluster-uri"
       name: "Expose Cluster URI"
       run: echo "cluster-uri=$(cat ${{ github.action_path }}/uri.txt)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Partially reverts some changes made in https://github.com/mongodb-labs/drivers-evergreen-tools/pull/352 concerning Python 3 binary lookup (motivated by [a stray explicit call to `python`](https://github.com/mongodb-labs/drivers-evergreen-tools/commit/f825f86fae3e5eecfa5da05a510ec5962fc7de88#diff-5eb412fc2cdeb6fab58a38e622949bedbda012b8bcb61e5e6daec62e5168af87L101)) to address build failures on some EVG distros where neither `python` nor `python3` are available in default binary paths.

The `Using Python3 binary: $PYTHON` case added in https://github.com/mongodb-labs/drivers-evergreen-tools/pull/352 is preserved to avoid a redundant call to `find_python3` when `start-orchestration.sh` is invoked via `run-orchestration.sh` (which already called `find_python3`). This _might_ still break EVG builds that happen to set the `PYTHON` environment variable before invoking `start-orchestration.sh` directly (instead of through `run-orchestration.sh`) if `PYTHON` is set to a Python binary that is not 3.0+ or does not support venv. If that is the case, this too can be reverted to the prior unconditional call to `find_python3`.