### PR TITLE
DRIVERS-2743 skip Python 3.12

### DIFF
--- a/.evergreen/find-python3.sh
+++ b/.evergreen/find-python3.sh
@@ -53,7 +53,7 @@ is_python3() (
 
   if ! $("$bin" -c "import sys; exit(sys.version_info[0] == 3 and sys.version_info[1] == 12)"); then
     echo "Detected Python 3.12. Skipping due to failures to start mock KMS server. Refer: DRIVERS-2743"
-    exit 1
+    return 1
   fi
 
   # Evaluate result of this function.

--- a/.evergreen/find-python3.sh
+++ b/.evergreen/find-python3.sh
@@ -51,6 +51,11 @@ is_python3() (
   # For diagnostic purposes.
   echo " - $bin: $version_output"
 
+  if ! $("$bin" -c "import sys; exit(sys.version_info[0] == 3 and sys.version_info[1] == 12)"); then
+    echo "Detected Python 3.12. Skipping due to failures to start mock KMS server. Refer: DRIVERS-2743"
+    exit 1
+  fi
+
   # Evaluate result of this function.
   # Note: Python True (1) and False (0) is treated as fail (1) and success (0)
   # by Bash; therefore `is_python3` returns "true" when `v < 3` is false.


### PR DESCRIPTION
# Summary

- Skip Python version 3.12 when selecting Python

PR was tested by modifying the C driver config to test an Ubuntu 20.04 variant: 
- Before PR (failing): https://spruce.mongodb.com/version/651d7eaa32f4177fe5a3bdad
- After PR (passing): https://spruce.mongodb.com/version/651d8991850e6195dac11cfe.

Many C driver tasks use Ubuntu 18.04, which does not appear affected (Ubuntu 18.04 reports Python 3.11.4)

# Background & Motivation

Test failures are reported by multiple driver teams starting the mock KMIP server. Example failures in [Node](https://parsley.mongodb.com/evergreen/mongo_node_driver_next_rhel8_no_auth_tests_test_4.2_server_noauth_33933ba119df7a50ae48517c374de83ea2d19abf_23_10_04_13_52_56/0/task?bookmarks=0,7989&shareLine=288) and [Java](https://spruce.mongodb.com/task/mongo_java_driver_tests_jdk8_unsecure__version~latest_os~linux_topology~standalone_auth~noauth_ssl~nossl_jdk~jdk8_test_92c90c6b77065a551fc7d7cd7f0a3f820f7ca8bf_23_10_04_10_28_35/logs?execution=0&sortBy=STATUS&sortDir=ASC) include the tracebacks:

```
Traceback (most recent call last):
  File "/data/mci/874b423f0400c073b8557a88f0546518/drivers-evergreen-tools/.evergreen/csfle/kms_kmip_server.py", line 52, in <module>
    main()
  File "/data/mci/874b423f0400c073b8557a88f0546518/drivers-evergreen-tools/.evergreen/csfle/kms_kmip_server.py", line 46, in main
    with server:
  File "/data/mci/874b423f0400c073b8557a88f0546518/drivers-evergreen-tools/.evergreen/csfle/kmstlsvenv/lib/python3.12/site-packages/kmip/services/server/server.py", line 475, in __enter__
    self.start()
  File "/data/mci/874b423f0400c073b8557a88f0546518/drivers-evergreen-tools/.evergreen/csfle/kmstlsvenv/lib/python3.12/site-packages/kmip/services/server/server.py", line 290, in start
    self._socket = ssl.wrap_socket(
                   ^^^^^^^^^^^^^^^
```

Python 3.12 [removed `ssl.wrap_socket`](https://docs.python.org/3.12/whatsnew/3.12.html#ssl):

> Remove the `ssl.wrap_socket()` function

PyKMIP uses `ssl.wrap_socket()`. kms_http_common.py [uses `ssl.wrap_socket()`](https://github.com/mongodb-labs/drivers-evergreen-tools/blob/43aa58331c258d911704aae63ecd996b60acaa56/.evergreen/csfle/kms_http_common.py#L138)

This is intended as a short term fix to unblock driver testing.
