### PR TITLE
DRIVERS-2416 Add support for a second Azure client

### DIFF
--- a/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
+++ b/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
@@ -90,10 +90,7 @@ echo "Untarring file ... end"
 popd
 
 # Start mongodb.
-AZUREKMS_SRC="$AZUREOIDC_DRIVERS_TOOLS/.evergreen/auth_oidc/azure/start-mongodb.sh" \
-AZUREKMS_DST="./" \
-    "$AZUREOIDC_DRIVERS_TOOLS"/.evergreen/csfle/azurekms/copy-file.sh
-AZUREKMS_CMD="./start-mongodb.sh" \
+AZUREKMS_CMD="./drivers-evergreen-tools/.evergreen/auth_oidc/azure/start-mongodb.sh" \
     "$AZUREOIDC_DRIVERS_TOOLS"/.evergreen/csfle/azurekms/run-command.sh
 
 # Run the self-test

--- a/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
+++ b/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
@@ -3,6 +3,8 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
+AZUREOIDC_DRIVERS_TOOLS=${AZUREOIDC_DRIVERS_TOOLS:-$DRIVERS_TOOLS}
+
 if [ -z "${AZUREOIDC_VMNAME_PREFIX:-}" ] || \
    [ -z "${AZUREOIDC_CLIENTID:-}" ] || \
    [ -z "${AZUREOIDC_TENANTID:-}" ] || \
@@ -57,8 +59,8 @@ export AZUREKMS_VMNAME="$AZUREOIDC_VMNAME"
 
 # Update expansions and env viles.
 echo "AZUREOIDC_VMNAME: $AZUREOIDC_VMNAME" > testazureoidc-expansions.yml
-echo "AZUREOIDC_VMNAME=${AZUREOIDC_VMNAME}" >> $AZUREOIDC_ENVPATH
-echo "AZUREOIDC_DRIVERS_TOOLS=${AZUREOIDC_DRIVERS_TOOLS}" >> $AZUREOIDC_ENVPATH
+echo "export AZUREOIDC_VMNAME=${AZUREOIDC_VMNAME}" >> $AZUREOIDC_ENVPATH
+echo "export AZUREOIDC_DRIVERS_TOOLS=${AZUREOIDC_DRIVERS_TOOLS}" >> $AZUREOIDC_ENVPATH
 
 # Install dependencies.
 AZUREKMS_SRC="$AZUREOIDC_DRIVERS_TOOLS/.evergreen/csfle/azurekms/remote-scripts/setup-azure-vm.sh" \
@@ -71,6 +73,21 @@ AZUREKMS_CMD="./setup-azure-vm.sh" \
 AZUREKMS_SRC=$AZUREOIDC_ENVPATH \
 AZUREKMS_DST="./" \
     "$AZUREOIDC_DRIVERS_TOOLS"/.evergreen/csfle/azurekms/copy-file.sh
+
+# Push Drivers Evergreen Tools onto the VM
+TARFILE=/tmp/drivers-evergreen-tools.tgz
+pushd $AZUREOIDC_DRIVERS_TOOLS
+git archive --format=tar.gz -o $TARFILE --prefix=drivers-evergreen-tools/ HEAD
+TARFILE_BASE=$(basename ${TARFILE})
+AZUREKMS_SRC=${TARFILE} \
+    AZUREKMS_DST="~/" \
+    $DRIVERS_TOOLS/.evergreen/csfle/azurekms/copy-file.sh
+echo "Copying files ... end"
+echo "Untarring file ... begin"
+AZUREKMS_CMD="tar xf ${TARFILE_BASE}" \
+  $DRIVERS_TOOLS/.evergreen/csfle/azurekms/run-command.sh
+echo "Untarring file ... end"
+popd
 
 # Start mongodb.
 AZUREKMS_SRC="$AZUREOIDC_DRIVERS_TOOLS/.evergreen/auth_oidc/azure/start-mongodb.sh" \

--- a/.evergreen/auth_oidc/azure/handle_secrets.py
+++ b/.evergreen/auth_oidc/azure/handle_secrets.py
@@ -26,7 +26,7 @@ def main():
 
     secrets = dict()
     for secret in ['RESOURCEGROUP', 'PUBLICKEY', 'PRIVATEKEY', 'TOKENCLIENT', 'AUTHCLAIM', 'AUTHPREFIX', 'IDENTITY',
-                   'CLIENTID2', 'AUTHPREFIX2']:
+                   'TOKENCLIENT2', 'IDENTITY2']:
         retrieved = client.get_secret(secret)
         secrets[secret] = retrieved.value
 
@@ -34,13 +34,12 @@ def main():
         fid.write(f'export AZUREOIDC_RESOURCEGROUP={secrets["RESOURCEGROUP"]}\n')
         fid.write(f'export AZUREKMS_RESOURCEGROUP={secrets["RESOURCEGROUP"]}\n')
         fid.write(f'export AZUREOIDC_TOKENCLIENT={secrets["TOKENCLIENT"]}\n')
+        fid.write(f'export AZUREOIDC_TOKENCLIENT2={secrets["TOKENCLIENT2"]}\n')
         fid.write(f'export AZUREOIDC_AUTHCLAIM={secrets["AUTHCLAIM"]}\n')
         fid.write(f'export AZUREOIDC_CLIENTID={client_id}\n')
-        fid.write(f'export AZUREOIDC_CLIENTID2={secrets["CLIENTID2"]}\n')
         fid.write(f'export AZUREOIDC_TENANTID={tenant_id}\n')
         fid.write(f'export AZUREOIDC_AUTHPREFIX={secrets["AUTHPREFIX"]}\n')
-        fid.write(f'export AZUREOIDC_AUTHPREFIX2={secrets["AUTHPREFIX2"]}\n')
-        fid.write(f'export AZUREKMS_IDENTITY={secrets["IDENTITY"]}\n')
+        fid.write(f'export AZUREKMS_IDENTITY="{secrets["IDENTITY"]} {secrets["IDENTITY2"]}"\n')
 
     if os.path.exists(private_key_file):
         os.remove(private_key_file)

--- a/.evergreen/auth_oidc/azure/handle_secrets.py
+++ b/.evergreen/auth_oidc/azure/handle_secrets.py
@@ -25,7 +25,8 @@ def main():
     client = SecretClient(vault_url=vault_uri, credential=credential)
 
     secrets = dict()
-    for secret in ['RESOURCEGROUP', 'PUBLICKEY', 'PRIVATEKEY', 'TOKENCLIENT', 'AUTHCLAIM', 'AUTHPREFIX', 'IDENTITY']:
+    for secret in ['RESOURCEGROUP', 'PUBLICKEY', 'PRIVATEKEY', 'TOKENCLIENT', 'AUTHCLAIM', 'AUTHPREFIX', 'IDENTITY',
+                   'CLIENTID2', 'AUTHPREFIX2']:
         retrieved = client.get_secret(secret)
         secrets[secret] = retrieved.value
 
@@ -35,8 +36,10 @@ def main():
         fid.write(f'export AZUREOIDC_TOKENCLIENT={secrets["TOKENCLIENT"]}\n')
         fid.write(f'export AZUREOIDC_AUTHCLAIM={secrets["AUTHCLAIM"]}\n')
         fid.write(f'export AZUREOIDC_CLIENTID={client_id}\n')
+        fid.write(f'export AZUREOIDC_CLIENTID2={secrets["CLIENTID2"]}\n')
         fid.write(f'export AZUREOIDC_TENANTID={tenant_id}\n')
         fid.write(f'export AZUREOIDC_AUTHPREFIX={secrets["AUTHPREFIX"]}\n')
+        fid.write(f'export AZUREOIDC_AUTHPREFIX2={secrets["AUTHPREFIX2"]}\n')
         fid.write(f'export AZUREKMS_IDENTITY={secrets["IDENTITY"]}\n')
 
     if os.path.exists(private_key_file):

--- a/.evergreen/auth_oidc/azure/start-mongodb.sh
+++ b/.evergreen/auth_oidc/azure/start-mongodb.sh
@@ -12,6 +12,7 @@ export ORCHESTRATION_FILE=auth-oidc.json
 export DRIVERS_TOOLS=$HOME/drivers-evergreen-tools
 export PROJECT_ORCHESTRATION_HOME=$DRIVERS_TOOLS/.evergreen/orchestration
 export MONGO_ORCHESTRATION_HOME=$HOME
+export SKIP_LEGACY_SHELL=true
 export NO_IPV6=${NO_IPV6:-""}
 
 cd $DRIVERS_TOOLS/.evergreen/auth_oidc

--- a/.evergreen/auth_oidc/azure/start-mongodb.sh
+++ b/.evergreen/auth_oidc/azure/start-mongodb.sh
@@ -14,10 +14,6 @@ export PROJECT_ORCHESTRATION_HOME=$DRIVERS_TOOLS/.evergreen/orchestration
 export MONGO_ORCHESTRATION_HOME=$HOME
 export NO_IPV6=${NO_IPV6:-""}
 
-if [ ! -d $DRIVERS_TOOLS ]; then
-    git clone https://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
-fi
-
 cd $DRIVERS_TOOLS/.evergreen/auth_oidc
 . ./activate-authoidcvenv.sh
 python oidc_write_orchestration.py --azure

--- a/.evergreen/auth_oidc/azure/test.py
+++ b/.evergreen/auth_oidc/azure/test.py
@@ -1,4 +1,5 @@
 from pymongo import MongoClient
+from functools import partial
 import os
 import json
 from urllib.request import urlopen, Request
@@ -8,9 +9,8 @@ from pymongo.auth import _AUTH_MAP, _authenticate_oidc
 _AUTH_MAP["MONGODB-OIDC"] = _authenticate_oidc
 
 app_id = os.environ['AZUREOIDC_CLIENTID']
-client_id = os.environ['AZUREOIDC_TOKENCLIENT']
 
-def callback(client_info, server_info):
+def callback(client_id, client_info, server_info):
     url = "http://169.254.169.254/metadata/identity/oauth2/token"
     url += "?api-version=2018-02-01"
     url += f"&resource=api://{app_id}"
@@ -41,8 +41,7 @@ def callback(client_info, server_info):
             raise ValueError(msg)
     return dict(access_token=data['access_token'])
 
-
-props = dict(request_token_callback=callback)
+props = dict(request_token_callback=partial(callback(os.environ['AZUREOIDC_TOKENCLIENT'])))
 print('Testing MONGODB-OIDC on azure...')
 print('Testing resource 1...')
 c = MongoClient('mongodb://localhost:27017/?authMechanism=MONGODB-OIDC', authMechanismProperties=props)
@@ -51,7 +50,7 @@ c.close()
 print('Testing resource 1... done.')
 
 print('Testing resource 2...')
-client_id = os.environ['AZUREOIDC_TOKENCLIENT2']
+props = dict(request_token_callback=partial(callback(os.environ['AZUREOIDC_TOKENCLIENT2'])))
 c = MongoClient('mongodb://localhost:27017/?authMechanism=MONGODB-OIDC', authMechanismProperties=props)
 c.test.test.find_one({})
 c.close()

--- a/.evergreen/auth_oidc/azure/test.py
+++ b/.evergreen/auth_oidc/azure/test.py
@@ -8,11 +8,13 @@ from pymongo.auth import _AUTH_MAP, _authenticate_oidc
 _AUTH_MAP["MONGODB-OIDC"] = _authenticate_oidc
 
 app_id = os.environ['AZUREOIDC_CLIENTID']
+client_id = os.environ['AZUREOIDC_TOKENCLIENT']
 
 def callback(client_info, server_info):
     url = "http://169.254.169.254/metadata/identity/oauth2/token"
     url += "?api-version=2018-02-01"
     url += f"&resource=api://{app_id}"
+    url += f"&client_id={client_id}"
     headers = { "Metadata": "true", "Accept": "application/json" }
     request = Request(url, headers=headers)
     try:
@@ -49,7 +51,7 @@ c.close()
 print('Testing resource 1... done.')
 
 print('Testing resource 2...')
-app_id = os.environ['AZUREOIDC_CLIENTID2']
+client_id = os.environ['AZUREOIDC_TOKENCLIENT2']
 c = MongoClient('mongodb://localhost:27017/?authMechanism=MONGODB-OIDC', authMechanismProperties=props)
 c.test.test.find_one({})
 c.close()

--- a/.evergreen/auth_oidc/azure/test.py
+++ b/.evergreen/auth_oidc/azure/test.py
@@ -39,7 +39,6 @@ def callback(client_info, server_info):
             msg = "Azure IMDS response must contain %s, but was %s."
             msg = msg % (key, body)
             raise ValueError(msg)
-    print(data['access_token'])
     return dict(access_token=data['access_token'])
 
 

--- a/.evergreen/auth_oidc/azure/test.py
+++ b/.evergreen/auth_oidc/azure/test.py
@@ -39,6 +39,7 @@ def callback(client_info, server_info):
             msg = "Azure IMDS response must contain %s, but was %s."
             msg = msg % (key, body)
             raise ValueError(msg)
+    print(data['access_token'])
     return dict(access_token=data['access_token'])
 
 

--- a/.evergreen/auth_oidc/azure/test.py
+++ b/.evergreen/auth_oidc/azure/test.py
@@ -41,8 +41,18 @@ def callback(client_info, server_info):
 
 
 props = dict(request_token_callback=callback)
-print('Testing MONGODB-OIDC on azure')
+print('Testing MONGODB-OIDC on azure...')
+print('Testing resource 1...')
+c = MongoClient('mongodb://localhost:27017/?authMechanism=MONGODB-OIDC', authMechanismProperties=props)
+c.test.test.insert_one({})
+c.close()
+print('Testing resource 1... done.')
+
+print('Testing resource 2...')
+app_id = os.environ['AZUREOIDC_CLIENTID2']
 c = MongoClient('mongodb://localhost:27017/?authMechanism=MONGODB-OIDC', authMechanismProperties=props)
 c.test.test.find_one({})
 c.close()
+print('Testing resource 2... done.')
+print('Testing MONGODB-OIDC on azure... done.')
 print('Self test complete!')

--- a/.evergreen/auth_oidc/oidc_write_orchestration.py
+++ b/.evergreen/auth_oidc/oidc_write_orchestration.py
@@ -29,14 +29,14 @@ def azure():
         "clientId": client_id,
         "audience": f"api://{app_id}",
         "authorizationClaim": "groups",
-
+        
     },{
         "authNamePrefix": auth_name_prefix2,
         "issuer": f"https://sts.windows.net/{tenant_id}/",
         "clientId": client_id,
         "audience": f"api://{app_id2}",
         "authorizationClaim": "groups",
-
+        "matchPattern": auth_name_prefix2,
     }]
     providers = json.dumps(provider_info, separators=(',',':'))
 

--- a/.evergreen/auth_oidc/oidc_write_orchestration.py
+++ b/.evergreen/auth_oidc/oidc_write_orchestration.py
@@ -16,30 +16,19 @@ def azure():
     client_id = os.environ['AZUREOIDC_TOKENCLIENT']
     tenant_id = os.environ['AZUREOIDC_TENANTID']
     app_id = os.environ['AZUREOIDC_CLIENTID']
-    app_id2 = os.environ['AZUREOIDC_CLIENTID2']
     auth_name_prefix = os.environ['AZUREOIDC_AUTHPREFIX']
-    auth_name_prefix2 = os.environ['AZUREOIDC_AUTHPREFIX2']
 
     print("Bootstrapping OIDC config")
 
     # Write the oidc orchestration file.
-    provider_info = [{
+    provider_info = {
         "authNamePrefix": auth_name_prefix,
         "issuer": f"https://sts.windows.net/{tenant_id}/",
         "clientId": client_id,
         "audience": f"api://{app_id}",
-        "authorizationClaim": "groups",
-        "matchPattern": auth_name_prefix,
-        
-    },{
-        "authNamePrefix": auth_name_prefix2,
-        "issuer": f"https://sts.windows.net/{tenant_id}/",
-        "clientId": client_id,
-        "audience": f"api://{app_id2}",
-        "authorizationClaim": "groups",
-        "matchPattern": auth_name_prefix2,
-    }]
-    providers = json.dumps(provider_info, separators=(',',':'))
+        "authorizationClaim": "groups"
+    }
+    providers = json.dumps([provider_info], separators=(',',':'))
 
     data = {
         "id": "oidc-repl0",

--- a/.evergreen/auth_oidc/oidc_write_orchestration.py
+++ b/.evergreen/auth_oidc/oidc_write_orchestration.py
@@ -16,20 +16,29 @@ def azure():
     client_id = os.environ['AZUREOIDC_TOKENCLIENT']
     tenant_id = os.environ['AZUREOIDC_TENANTID']
     app_id = os.environ['AZUREOIDC_CLIENTID']
+    app_id2 = os.environ['AZUREOIDC_CLIENTID2']
     auth_name_prefix = os.environ['AZUREOIDC_AUTHPREFIX']
+    auth_name_prefix2 = os.environ['AZUREOIDC_AUTHPREFIX2']
 
     print("Bootstrapping OIDC config")
 
     # Write the oidc orchestration file.
-    provider_info = {
+    provider_info = [{
         "authNamePrefix": auth_name_prefix,
         "issuer": f"https://sts.windows.net/{tenant_id}/",
         "clientId": client_id,
         "audience": f"api://{app_id}",
         "authorizationClaim": "groups",
 
-    }
-    providers = json.dumps([provider_info], separators=(',',':'))
+    },{
+        "authNamePrefix": auth_name_prefix2,
+        "issuer": f"https://sts.windows.net/{tenant_id}/",
+        "clientId": client_id,
+        "audience": f"api://{app_id2}",
+        "authorizationClaim": "groups",
+
+    }]
+    providers = json.dumps(provider_info, separators=(',',':'))
 
     data = {
         "id": "oidc-repl0",

--- a/.evergreen/auth_oidc/oidc_write_orchestration.py
+++ b/.evergreen/auth_oidc/oidc_write_orchestration.py
@@ -29,6 +29,7 @@ def azure():
         "clientId": client_id,
         "audience": f"api://{app_id}",
         "authorizationClaim": "groups",
+        "matchPattern": auth_name_prefix,
         
     },{
         "authNamePrefix": auth_name_prefix2,

--- a/.evergreen/auth_oidc/setup_oidc.js
+++ b/.evergreen/auth_oidc/setup_oidc.js
@@ -11,13 +11,15 @@ console.log("Setting up User");
 const authorizationPrefix = process.env['AZUREOIDC_AUTHPREFIX'] || 'test1';
 const authorizationClaim = process.env['AZUREOIDC_AUTHCLAIM'] || 'readWrite';
 const role1Name = authorizationPrefix + '/' + authorizationClaim;
-const role2Name = 'test2/read';
+const authorizationPrefix2 = process.env['AZUREOIDC_AUTHPREFIX2'] || 'test2';
+const authorizationClaim2 = process.env['AZUREOIDC_AUTHCLAIM2'] || 'read';
+const role2Name = authorizationPrefix2 + '/' + authorizationClaim2;
 
 // Add the roles.
 console.log('Adding role:', role1Name);
-admin.runCommand({createRole: role1Name, roles:[{role: 'readWrite', db: 'test'}], privileges: []});
+admin.runCommand({createRole: role1Name, roles:[{role: authorizationClaim, db: 'test'}], privileges: []});
 
 console.log('Adding role:', role2Name);
-admin.runCommand({createRole: role2Name, roles:[{role: 'read', db: 'test'}], privileges: []});
+admin.runCommand({createRole: role2Name, roles:[{role: authorizationClaim2, db: 'test'}], privileges: []});
 
 }());

--- a/.evergreen/auth_oidc/setup_oidc.js
+++ b/.evergreen/auth_oidc/setup_oidc.js
@@ -11,15 +11,13 @@ console.log("Setting up User");
 const authorizationPrefix = process.env['AZUREOIDC_AUTHPREFIX'] || 'test1';
 const authorizationClaim = process.env['AZUREOIDC_AUTHCLAIM'] || 'readWrite';
 const role1Name = authorizationPrefix + '/' + authorizationClaim;
-const authorizationPrefix2 = process.env['AZUREOIDC_AUTHPREFIX2'] || 'test2';
-const authorizationClaim2 = process.env['AZUREOIDC_AUTHCLAIM2'] || 'read';
-const role2Name = authorizationPrefix2 + '/' + authorizationClaim2;
+const role2Name = 'test2/read';
 
 // Add the roles.
 console.log('Adding role:', role1Name);
-admin.runCommand({createRole: role1Name, roles:[{role: authorizationClaim, db: 'test'}], privileges: []});
+admin.runCommand({createRole: role1Name, roles:[{role: 'readWrite', db: 'test'}], privileges: []});
 
 console.log('Adding role:', role2Name);
-admin.runCommand({createRole: role2Name, roles:[{role: authorizationClaim2, db: 'test'}], privileges: []});
+admin.runCommand({createRole: role2Name, roles:[{role: 'read', db: 'test'}], privileges: []});
 
 }());


### PR DESCRIPTION
This infrastructure will be needed to support testing drivers with multiple clients on Azure.  I tested it locally by running `create_and_update_vm.sh` and ensuring that the self-test passes. 