### PR TITLE
DRIVERS-2747 Handle backwards compat for ECS task definition

### DIFF
--- a/.evergreen/auth_aws/aws_tester.py
+++ b/.evergreen/auth_aws/aws_tester.py
@@ -101,8 +101,13 @@ def setup_ecs():
         text = fid.read()
     if 'jammy' in text:
         task_definition = CONFIG[get_key('iam_auth_ecs_task_definition_jammy')]
+        if task_definition is None:
+            raise ValueError('Please set "iam_auth_ecs_task_definition_jammy" variable')
     elif 'focal' in text:
         task_definition = CONFIG[get_key('iam_auth_ecs_task_definition_focal')]
+        # Fall back to previous task definition for backward compat.
+        if task_definition is None:
+            task_definition = CONFIG[get_key('iam_auth_ecs_task_definition')]
     else:
         raise ValueError('Unsupported ubuntu release')
     run_test_command = f"{base_command} -d -v run_e2e_test --cluster {CONFIG[get_key('iam_auth_ecs_cluster')]} --task_definition {task_definition} --subnets {CONFIG[get_key('iam_auth_ecs_subnet_a')]} --subnets {CONFIG[get_key('iam_auth_ecs_subnet_b')]} --security_group {CONFIG[get_key('iam_auth_ecs_security_group')]} --files {mongo_binaries}/mongod:/root/mongod {mongo_binaries}/mongosh:/root/mongosh lib/ecs_hosted_test.js:/root/ecs_hosted_test.js {project_dir}:/root --script lib/ecs_hosted_test.sh"

--- a/.evergreen/auth_aws/aws_tester.py
+++ b/.evergreen/auth_aws/aws_tester.py
@@ -100,11 +100,11 @@ def setup_ecs():
     with open('/etc/lsb-release') as fid:
         text = fid.read()
     if 'jammy' in text:
-        task_definition = CONFIG[get_key('iam_auth_ecs_task_definition_jammy')]
+        task_definition = CONFIG.get(get_key('iam_auth_ecs_task_definition_jammy'), None)
         if task_definition is None:
             raise ValueError('Please set "iam_auth_ecs_task_definition_jammy" variable')
     elif 'focal' in text:
-        task_definition = CONFIG[get_key('iam_auth_ecs_task_definition_focal')]
+        task_definition = CONFIG.get(get_key('iam_auth_ecs_task_definition_focal'), None)
         # Fall back to previous task definition for backward compat.
         if task_definition is None:
             task_definition = CONFIG[get_key('iam_auth_ecs_task_definition')]


### PR DESCRIPTION
Testing in Python: https://spruce.mongodb.com/version/654964af0ae606025899bfb0/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC