### PR TITLE
Update MongoDB versions

### DIFF
--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -56,13 +56,13 @@ get_mongodb_download_url_for ()
    VERSION_MONGOSH="1.8.1"
    # Set VERSION_RAPID to the latest rapid release each quarter.
    VERSION_RAPID="6.3.1"
-   VERSION_70="7.0.2"
+   VERSION_70="7.0.4"
    VERSION_60_LATEST="v6.0-latest"
-   VERSION_60="6.0.10"
+   VERSION_60="6.0.12"
    # The perf version must always remain pinned to the same patch
    VERSION_60_PERF="6.0.6"
-   VERSION_50="5.0.21"
-   VERSION_44="4.4.25"
+   VERSION_50="5.0.23"
+   VERSION_44="4.4.26"
    VERSION_42="4.2.24"
    VERSION_40="4.0.28"
    VERSION_36="3.6.23"


### PR DESCRIPTION
This updates the patch versions for 7.0, 6.0, 5.0, and 4.4 to the latest releases.