### PR TITLE
DRIVERS-2416 Add docs and tests for azure oidc

### DIFF
--- a/.evergreen/auth_oidc/README.md
+++ b/.evergreen/auth_oidc/README.md
@@ -39,3 +39,7 @@ To set up the server auth roles, run `mongosh setup_oidc.js`.
 Then, tests can be run against the server.  Set `AWS_WEB_IDENTITY_TOKEN_FILE` to either `/tmp/tokens/test_user1` or `/tmp/tokens/test_user2` as desired.
 
 The token in `/tmp/tokens/test_user1_expires` can be used to test expired credentials.
+
+## Azure Testing
+
+See the readme [./azure/README.md].

--- a/.evergreen/auth_oidc/azure/README.md
+++ b/.evergreen/auth_oidc/azure/README.md
@@ -1,0 +1,49 @@
+# Azure OIDC Testing
+
+Testing OIDC with Azure integration involves launching an Azure VM,
+pushing the code to the VM, running the OIDC tests for the driver,
+and then tearing down the VM and its resources.
+
+There are a set of scripts that facilitate these operations.
+First, ensure you are running either locally or on an Evergreen host
+that has the Azure CLI 2.25+ installed.  At time of writing, distros with `az` installed include:
+
+- debian10
+- debian11
+- ubuntu2004
+- ubuntu2204
+
+Locally, it can be installed as `brew install az`.
+
+See https://wiki.corp.mongodb.com/display/DRIVERS/Using+AWS+Secrets+Manager+to+Store+Testing+Secrets for more background
+on how the secrets are managed for these tests.
+Additionally, there are secrets stored in the "OIDC-Key-Vault" in our Drivers Azure Subscription <TODO, link to the wiki>.
+
+To ensure proper setup and teardown, we use a task group in Evergreen config.  The setup portion 
+should run the equivalent of the following, substituting your driver name:
+
+```bash
+export AZUREOIDC_VMNAME_PREFIX="PYTHON_DRIVER"
+$DRIVERS_TOOLS/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
+```
+
+This script can be run locally or in CI.  The script also runs a self-test on the VM using the Python driver.
+
+Next, compile/build and bundle our driver and test code, and run the test:
+
+```bash
+# This variable points to the tarball that we will push to the VM and unpack.
+export AZUREOIDC_DRIVERS_TAR_FILE=/tmp/mongo-python-driver.tgz
+git archive -o $AZUREOIDC_DRIVERS_TAR_FILE HEAD
+# Define the command to run on the VM.
+# Ensure that we source the environment file created for us, set up any other variables we need,
+# and then run our test suite on the vm.
+export AZUREOIDC_TEST_CMD="source ./env.sh && OIDC_PROVIDER_NAME=azure ./.evergreen/run-mongodb-oidc-test.sh"
+bash $DRIVERS_TOOLS/.evergreen/auth_oidc/azure/run-driver-test.sh
+```
+
+Finally, we tear down the vm:
+
+```bash
+$DRIVERS_TOOLS/.evergreen/auth_oidc/azure/delete-vm.sh
+```

--- a/.evergreen/auth_oidc/azure/README.md
+++ b/.evergreen/auth_oidc/azure/README.md
@@ -5,6 +5,7 @@ pushing the code to the VM, running the OIDC tests for the driver,
 and then tearing down the VM and its resources.
 
 There are a set of scripts that facilitate these operations.
+They build on top of the scripts used in `csfle/azurekms`.
 First, ensure you are running either locally or on an Evergreen host
 that has the Azure CLI 2.25+ installed.  At time of writing, distros with `az` installed include:
 
@@ -16,8 +17,11 @@ that has the Azure CLI 2.25+ installed.  At time of writing, distros with `az` i
 Locally, it can be installed as `brew install az`.
 
 See https://wiki.corp.mongodb.com/display/DRIVERS/Using+AWS+Secrets+Manager+to+Store+Testing+Secrets for more background
-on how the secrets are managed for these tests.
-Additionally, there are secrets stored in the "OIDC-Key-Vault" in our Drivers Azure Subscription <TODO, link to the wiki>.
+on how the secrets are managed for these tests.  These secrets are used to log in to Azure, and the 
+rest of the secrets are fetched from the "OIDC-Key-Vault" in our Drivers Azure Subscription (https://portal.azure.com/#home).
+
+See the Azure machine flows section of the OIDC Configuration [wiki](https://wiki.corp.mongodb.com/display/ENG/OIDC+Configuration#OIDCConfiguration-ServiceAccounts/ManagedIdentities/MachineFlows) for more information
+about the Azure integration.
 
 To ensure proper setup and teardown, we use a task group in Evergreen config.  The setup portion 
 should run the equivalent of the following, substituting your driver name:

--- a/.evergreen/auth_oidc/azure/README.md
+++ b/.evergreen/auth_oidc/azure/README.md
@@ -42,6 +42,23 @@ export AZUREOIDC_TEST_CMD="source ./env.sh && OIDC_PROVIDER_NAME=azure ./.evergr
 bash $DRIVERS_TOOLS/.evergreen/auth_oidc/azure/run-driver-test.sh
 ```
 
+In your tests, you can use the environment variables in `env.sh` to define the `TOKEN_AUDIENCE` and `TOKEN_CLIENT_ID` 
+auth mechanism properties, e.g.
+
+```python
+TOKEN_AUDIENCE="api://" + os.environ["AZUREOIDC_CLIENTID"]
+TOKEN_CLIENT_ID=os.environ["AZUREOIDC_TOKENCLIENT"]  # For first user
+TOKEN_CLIENT_ID=os.environ["AZUREOIDC_TOKENCLIENT2"]  # For second user
+```
+
+Note: If you are creating a uri, you will have to escape `TOKEN_AUDIENCE` value, e.g.
+
+```bash
+MONGODB_URI="${MONGODB_URI}/?authMechanism=MONGODB-OIDC"
+MONGODB_URI="${MONGODB_URI}&authMechanismProperties=PROVIDER_NAME:azure"
+MONGODB_URI="${MONGODB_URI},TOKEN_AUDIENCE:api%3A%2F%2F${AZUREOIDC_CLIENTID}"
+```
+
 Finally, we tear down the vm:
 
 ```bash

--- a/.evergreen/auth_oidc/azure/README.md
+++ b/.evergreen/auth_oidc/azure/README.md
@@ -4,8 +4,20 @@ Testing OIDC with Azure integration involves launching an Azure VM,
 pushing the code to the VM, running the OIDC tests for the driver,
 and then tearing down the VM and its resources.
 
+## Background
+
 There are a set of scripts that facilitate these operations.
 They build on top of the scripts used in `csfle/azurekms`.
+
+See https://wiki.corp.mongodb.com/display/DRIVERS/Using+AWS+Secrets+Manager+to+Store+Testing+Secrets for more background
+on how the secrets are managed for these tests.  These secrets are used to log in to Azure, and the 
+rest of the secrets are fetched from the "OIDC-Key-Vault" in our Drivers Azure Subscription (https://portal.azure.com/#home).
+
+See the Azure machine flows section of the OIDC Configuration [wiki](https://wiki.corp.mongodb.com/display/ENG/OIDC+Configuration#OIDCConfiguration-ServiceAccounts/ManagedIdentities/MachineFlows) for more information
+about the Azure integration.
+
+## Prerequisites
+
 First, ensure you are running either locally or on an Evergreen host
 that has the Azure CLI 2.25+ installed.  At time of writing, distros with `az` installed include:
 
@@ -16,12 +28,7 @@ that has the Azure CLI 2.25+ installed.  At time of writing, distros with `az` i
 
 Locally, it can be installed as `brew install az`.
 
-See https://wiki.corp.mongodb.com/display/DRIVERS/Using+AWS+Secrets+Manager+to+Store+Testing+Secrets for more background
-on how the secrets are managed for these tests.  These secrets are used to log in to Azure, and the 
-rest of the secrets are fetched from the "OIDC-Key-Vault" in our Drivers Azure Subscription (https://portal.azure.com/#home).
-
-See the Azure machine flows section of the OIDC Configuration [wiki](https://wiki.corp.mongodb.com/display/ENG/OIDC+Configuration#OIDCConfiguration-ServiceAccounts/ManagedIdentities/MachineFlows) for more information
-about the Azure integration.
+## Usage
 
 To ensure proper setup and teardown, we use a task group in Evergreen config.  The setup portion 
 should run the equivalent of the following, substituting your driver name:
@@ -70,3 +77,16 @@ Finally, we tear down the vm:
 ```bash
 $DRIVERS_TOOLS/.evergreen/auth_oidc/azure/delete-vm.sh
 ```
+
+### Environment Variables
+
+Below is an explanantion of the environment variables stored in the Azure key vault.
+
+- AZUREOIDC_AUTHPREFIX - The auth prefix used for DB user and role names.
+- AZUREOIDC_AUTHCLAIM - The object ID of the Azure Group, used in the DB role name.
+- AZUREOIDC_CLIENTID - The client ID of the Azure App registration, used for the `TOKEN_AUDIENCE` auth mechanism property.
+- AZUREOIDC_TOKENCLIENT - The client ID of the first Azure Managed Identity, used for the `TOKEN_CLIENT_ID` auth mechanism property.
+- AZUREOIDC_TOKENCLIENT2 - The client ID of the second Azure Managed Identity, used for the `TOKEN_CLIENT_ID` auth mechanism property.
+- AZUREOIDC_TENANTID - The tenant ID of the Azure App registration, used to derive the `issuer` URI.
+- AZUREKMS_IDENTITY - A space separated string with the two Resource IDs of the managed identities (`/subscriptions/... /subscriptions/...`).  Used to assign the identities to the VM.
+- AZUREOIDC_RESOURCEGROUP - The name of the Azure Resource Group, used when accessing the VM through the CLI.

--- a/.evergreen/auth_oidc/azure/README.md
+++ b/.evergreen/auth_oidc/azure/README.md
@@ -36,7 +36,9 @@ This script can be run locally or in CI.  The script also runs a self-test on th
 Next, compile/build and bundle our driver and test code, and run the test:
 
 ```bash
-# This variable points to the tarball that we will push to the VM and unpack.
+# Prep the source tarball - first make sure the patch changes are committed before using `git archive`.
+git add .
+git commit -m "add files"
 export AZUREOIDC_DRIVERS_TAR_FILE=/tmp/mongo-python-driver.tgz
 git archive -o $AZUREOIDC_DRIVERS_TAR_FILE HEAD
 # Define the command to run on the VM.

--- a/.evergreen/auth_oidc/azure/README.md
+++ b/.evergreen/auth_oidc/azure/README.md
@@ -72,6 +72,9 @@ MONGODB_URI="${MONGODB_URI}&authMechanismProperties=PROVIDER_NAME:azure"
 MONGODB_URI="${MONGODB_URI},TOKEN_AUDIENCE:api%3A%2F%2F${AZUREOIDC_CLIENTID}"
 ```
 
+Note: since we will be testing with two different clients, the `TOKEN_CLIENT_ID` will need to be provided
+as an argument to `MongoClient` in the prose tests.
+
 Finally, we tear down the vm:
 
 ```bash

--- a/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
+++ b/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
@@ -14,7 +14,7 @@ fi
 AZUREOIDC_DRIVERS_TOOLS=${AZUREOIDC_DRIVERS_TOOLS:-$DRIVERS_TOOLS}
 
 echo "$AZUREOIDC_DRIVERS_TOOLS"
-cat "$AZUREOIDC_DRIVERS_TOOLS/.evergreen/auth_oidc/test.py"
+cat "$AZUREOIDC_DRIVERS_TOOLS/.evergreen/auth_oidc/azure/test.py"
 exit 1
 BASE_PATH="$AZUREOIDC_DRIVERS_TOOLS/.evergreen/auth_oidc"
 export AZUREKMS_PUBLICKEYPATH="$BASE_PATH/azure/keyfile.pub"

--- a/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
+++ b/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
@@ -3,32 +3,31 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-AZUREOIDC_DRIVERS_TOOLS=${AZUREOIDC_DRIVERS_TOOLS:-$DRIVERS_TOOLS}
-
-if [ -z "${AZUREOIDC_VMNAME_PREFIX:-}" ] || \
-   [ -z "${AZUREOIDC_CLIENTID:-}" ] || \
-   [ -z "${AZUREOIDC_TENANTID:-}" ] || \
-   [ -z "${AZUREOIDC_SECRET:-}" ] || \
-   [ -z "${AZUREOIDC_DRIVERS_TOOLS:-}" ]; then
+# Ensure required variables are set.
+if [ -z "${AZUREOIDC_VMNAME_PREFIX:-}" ]; then
     echo "Please set the following required environment variables"
     echo " AZUREOIDC_VMNAME_PREFIX to an identifier string no spaces (e.g. CDRIVER)"
-    echo " AZUREOIDC_CLIENTID"
-    echo " AZUREOIDC_TENANTID"
-    echo " AZUREOIDC_SECRET"
-    echo " AZUREOIDC_DRIVERS_TOOLS"
     exit 1
 fi
 
 # Set defaults.
+AZUREOIDC_DRIVERS_TOOLS=${AZUREOIDC_DRIVERS_TOOLS:-$DRIVERS_TOOLS}
 BASE_PATH="$AZUREOIDC_DRIVERS_TOOLS/.evergreen/auth_oidc"
 export AZUREKMS_PUBLICKEYPATH="$BASE_PATH/azure/keyfile.pub"
 export AZUREKMS_PRIVATEKEYPATH="$BASE_PATH/azure/keyfile"
-export AZUREKMS_CLIENTID=$AZUREOIDC_CLIENTID
 export AZUREKMS_VMNAME_PREFIX=$AZUREOIDC_VMNAME_PREFIX
-export AZUREKMS_TENANTID=$AZUREOIDC_TENANTID
-export AZUREKMS_SECRET=$AZUREOIDC_SECRET
 export AZUREOIDC_ENVPATH="$BASE_PATH/azure/env.sh"
 export AZUREKMS_IMAGE=${AZUREOIDC_IMAGE:-"Debian:debian-11:11:0.20221020.1174"}
+
+# Handle secrets from vault.
+cd $BASE_PATH
+. ./activate-authoidcvenv.sh
+bash ../auth_aws/setup_secrets.sh drivers/azureoidc
+source secrets-export.sh
+
+export AZUREKMS_TENANTID=$AZUREOIDC_TENANTID
+export AZUREKMS_SECRET=$AZUREOIDC_SECRET
+export AZUREKMS_CLIENTID=$AZUREOIDC_CLIENTID
 
 # Check for Azure Command-Line Interface (`az`) version 2.25.0 or newer.
 if ! command -v az &> /dev/null; then
@@ -46,9 +45,7 @@ fi
 # Login.
 "$AZUREOIDC_DRIVERS_TOOLS"/.evergreen/csfle/azurekms/login.sh
 
-# Handle secrets from vault.
-cd $BASE_PATH
-. ./activate-authoidcvenv.sh
+# Get the rest of the secrets from the Azure vault.
 python ./azure/handle_secrets.py
 source $AZUREOIDC_ENVPATH
 

--- a/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
+++ b/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
@@ -91,11 +91,5 @@ AZUREKMS_CMD="./drivers-evergreen-tools/.evergreen/auth_oidc/azure/start-mongodb
     "$AZUREOIDC_DRIVERS_TOOLS"/.evergreen/csfle/azurekms/run-command.sh
 
 # Run the self-test
-AZUREKMS_SRC="$AZUREOIDC_DRIVERS_TOOLS/.evergreen/auth_oidc/azure/test.py" \
-AZUREKMS_DST="./" \
-    "$AZUREOIDC_DRIVERS_TOOLS"/.evergreen/csfle/azurekms/copy-file.sh
-AZUREKMS_SRC="$AZUREOIDC_DRIVERS_TOOLS/.evergreen/auth_oidc/azure/run-test.sh" \
-AZUREKMS_DST="./" \
-    "$AZUREOIDC_DRIVERS_TOOLS"/.evergreen/csfle/azurekms/copy-file.sh
-AZUREKMS_CMD="./run-test.sh" \
+AZUREKMS_CMD="./drivers-evergreen-tools/.evergreen/auth_oidc/azure/run-test.sh" \
     "$AZUREOIDC_DRIVERS_TOOLS"/.evergreen/csfle/azurekms/run-command.sh

--- a/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
+++ b/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
@@ -47,8 +47,6 @@ fi
 
 # Get the rest of the secrets from the Azure vault.
 python ./azure/handle_secrets.py
-echo "hello! $AZUREOIDC_ENVPATH"
-exit 1
 source $AZUREOIDC_ENVPATH
 
 # Create VM.

--- a/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
+++ b/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
@@ -47,6 +47,8 @@ fi
 
 # Get the rest of the secrets from the Azure vault.
 python ./azure/handle_secrets.py
+echo "hello! $AZUREOIDC_ENVPATH"
+exit 1
 source $AZUREOIDC_ENVPATH
 
 # Create VM.

--- a/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
+++ b/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
@@ -12,6 +12,10 @@ fi
 
 # Set defaults.
 AZUREOIDC_DRIVERS_TOOLS=${AZUREOIDC_DRIVERS_TOOLS:-$DRIVERS_TOOLS}
+
+echo "$AZUREOIDC_DRIVERS_TOOLS"
+cat "$AZUREOIDC_DRIVERS_TOOLS/.evergreen/auth_oidc/test.py"
+exit 1
 BASE_PATH="$AZUREOIDC_DRIVERS_TOOLS/.evergreen/auth_oidc"
 export AZUREKMS_PUBLICKEYPATH="$BASE_PATH/azure/keyfile.pub"
 export AZUREKMS_PRIVATEKEYPATH="$BASE_PATH/azure/keyfile"
@@ -77,7 +81,7 @@ pushd $AZUREOIDC_DRIVERS_TOOLS
 git archive --format=tar.gz -o $TARFILE --prefix=drivers-evergreen-tools/ HEAD
 TARFILE_BASE=$(basename ${TARFILE})
 AZUREKMS_SRC=${TARFILE} \
-    AZUREKMS_DST="~/" \
+    AZUREKMS_DST="./" \
     $DRIVERS_TOOLS/.evergreen/csfle/azurekms/copy-file.sh
 echo "Copying files ... end"
 echo "Untarring file ... begin"

--- a/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
+++ b/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
@@ -12,10 +12,6 @@ fi
 
 # Set defaults.
 AZUREOIDC_DRIVERS_TOOLS=${AZUREOIDC_DRIVERS_TOOLS:-$DRIVERS_TOOLS}
-
-echo "$AZUREOIDC_DRIVERS_TOOLS"
-cat "$AZUREOIDC_DRIVERS_TOOLS/.evergreen/auth_oidc/azure/test.py"
-exit 1
 BASE_PATH="$AZUREOIDC_DRIVERS_TOOLS/.evergreen/auth_oidc"
 export AZUREKMS_PUBLICKEYPATH="$BASE_PATH/azure/keyfile.pub"
 export AZUREKMS_PRIVATEKEYPATH="$BASE_PATH/azure/keyfile"

--- a/.evergreen/auth_oidc/azure/run-driver-test.sh
+++ b/.evergreen/auth_oidc/azure/run-driver-test.sh
@@ -3,22 +3,20 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-DRIVERS_TOOLS=${AZUREOIDC_DRIVERS_TOOLS:-$DRIVERS_TOOLS}
+AZURE_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+pushd $AZURE_DIR
 
 # Check for inputs.
 if [ -z "${AZUREOIDC_DRIVERS_TAR_FILE:-}" ] || \
-   [ -z "${AZUREOIDC_TEST_CMD:-}" ] || \
-   [ -z "${DRIVERS_TOOLS:-}" ]; then
+   [ -z "${AZUREOIDC_TEST_CMD:-}" ]; then
     echo "Please set the following required environment variables"
     echo " AZUREOIDC_DRIVERS_TAR_FILE"
     echo " AZUREOIDC_TEST_CMD"
-    echo " DRIVERS_TOOLS"
     exit 1
 fi
 
 # Read in the env variables.
-AZURE_DIR=$DRIVERS_TOOLS/.evergreen/auth_oidc/azure
-source $AZURE_DIR/env.sh
+source ./env.sh
 
 # Set up variables.
 export AZUREKMS_RESOURCEGROUP=$AZUREOIDC_RESOURCEGROUP
@@ -29,13 +27,13 @@ export AZUREKMS_PRIVATEKEYPATH=$AZURE_DIR/keyfile
 DRIVER_TARFILE_BASE=$(basename ${AZUREOIDC_DRIVERS_TAR_FILE})
 AZUREKMS_SRC=${AZUREOIDC_DRIVERS_TAR_FILE} \
 AZUREKMS_DST="~/" \
-  $DRIVERS_TOOLS/.evergreen/csfle/azurekms/copy-file.sh
+  $AZURE_DIR/../../csfle/azurekms/copy-file.sh
 echo "Copying files ... end"
 echo "Untarring file ... begin"
 AZUREKMS_CMD="tar xf ${DRIVER_TARFILE_BASE}" \
-  $DRIVERS_TOOLS/.evergreen/csfle/azurekms/run-command.sh
+  $AZURE_DIR/../../csfle/azurekms/run-command.sh
 echo "Untarring file ... end"
 
 # Run the driver test.
 AZUREKMS_CMD="${AZUREOIDC_TEST_CMD}" \
-    $DRIVERS_TOOLS/.evergreen/csfle/azurekms/run-command.sh
+    $AZURE_DIR/../../csfle/azurekms/run-command.sh

--- a/.evergreen/auth_oidc/azure/run-driver-test.sh
+++ b/.evergreen/auth_oidc/azure/run-driver-test.sh
@@ -5,22 +5,25 @@ set -o nounset
 
 # Check for inputs.
 if [ -z "${AZUREOIDC_DRIVERS_TAR_FILE:-}" ] || \
-   [ -z "${AZUREOIDC_TEST_CMD:-}" ]; then
+   [ -z "${AZUREOIDC_TEST_CMD:-}" ] || \
+   [ -z "${AZUREOIDC_DRIVERS_TOOLS:-}" ] then;
     echo "Please set the following required environment variables"
     echo " AZUREOIDC_DRIVERS_TAR_FILE"
     echo " AZUREOIDC_TEST_CMD"
+    echo " AZUREOIDC_DRIVERS_TOOLS"
     exit 1
 fi
 
 # Read in the env variables.
-DIR=$(dirname $0)
-source $DIR/env.sh
+DRIVERS_TOOLS=$AZUREOIDC_DRIVERS_TOOLS
+AZURE_DIR=$DRIVERS_TOOLS/.evergreen/auth_oidc/azure
+source $AZURE_DIR/env.sh
 
 # Set up variables.
 DRIVERS_TOOLS=$AZUREOIDC_DRIVERS_TOOLS
 export AZUREKMS_RESOURCEGROUP=$AZUREOIDC_RESOURCEGROUP
 export AZUREKMS_VMNAME=$AZUREOIDC_VMNAME
-export AZUREKMS_PRIVATEKEYPATH=$DIR/keyfile
+export AZUREKMS_PRIVATEKEYPATH=$AZURE_DIR/keyfile
 
 # Set up the remote driver checkout.
 DRIVER_TARFILE_BASE=$(basename ${AZUREOIDC_DRIVERS_TAR_FILE})

--- a/.evergreen/auth_oidc/azure/run-driver-test.sh
+++ b/.evergreen/auth_oidc/azure/run-driver-test.sh
@@ -3,24 +3,24 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
+DRIVERS_TOOLS=${AZUREOIDC_DRIVERS_TOOLS:-$DRIVERS_TOOLS}
+
 # Check for inputs.
 if [ -z "${AZUREOIDC_DRIVERS_TAR_FILE:-}" ] || \
    [ -z "${AZUREOIDC_TEST_CMD:-}" ] || \
-   [ -z "${AZUREOIDC_DRIVERS_TOOLS:-}" ]; then
+   [ -z "${DRIVERS_TOOLS:-}" ]; then
     echo "Please set the following required environment variables"
     echo " AZUREOIDC_DRIVERS_TAR_FILE"
     echo " AZUREOIDC_TEST_CMD"
-    echo " AZUREOIDC_DRIVERS_TOOLS"
+    echo " DRIVERS_TOOLS"
     exit 1
 fi
 
 # Read in the env variables.
-DRIVERS_TOOLS=$AZUREOIDC_DRIVERS_TOOLS
 AZURE_DIR=$DRIVERS_TOOLS/.evergreen/auth_oidc/azure
 source $AZURE_DIR/env.sh
 
 # Set up variables.
-DRIVERS_TOOLS=$AZUREOIDC_DRIVERS_TOOLS
 export AZUREKMS_RESOURCEGROUP=$AZUREOIDC_RESOURCEGROUP
 export AZUREKMS_VMNAME=$AZUREOIDC_VMNAME
 export AZUREKMS_PRIVATEKEYPATH=$AZURE_DIR/keyfile

--- a/.evergreen/auth_oidc/azure/run-driver-test.sh
+++ b/.evergreen/auth_oidc/azure/run-driver-test.sh
@@ -6,7 +6,7 @@ set -o nounset
 # Check for inputs.
 if [ -z "${AZUREOIDC_DRIVERS_TAR_FILE:-}" ] || \
    [ -z "${AZUREOIDC_TEST_CMD:-}" ] || \
-   [ -z "${AZUREOIDC_DRIVERS_TOOLS:-}" ] then;
+   [ -z "${AZUREOIDC_DRIVERS_TOOLS:-}" ]; then
     echo "Please set the following required environment variables"
     echo " AZUREOIDC_DRIVERS_TAR_FILE"
     echo " AZUREOIDC_TEST_CMD"

--- a/.evergreen/auth_oidc/azure/test.py
+++ b/.evergreen/auth_oidc/azure/test.py
@@ -41,7 +41,7 @@ def callback(client_id, client_info, server_info):
             raise ValueError(msg)
     return dict(access_token=data['access_token'])
 
-props = dict(request_token_callback=partial(callback(os.environ['AZUREOIDC_TOKENCLIENT'])))
+props = dict(request_token_callback=partial(callback, os.environ['AZUREOIDC_TOKENCLIENT']))
 print('Testing MONGODB-OIDC on azure...')
 print('Testing resource 1...')
 c = MongoClient('mongodb://localhost:27017/?authMechanism=MONGODB-OIDC', authMechanismProperties=props)
@@ -50,7 +50,7 @@ c.close()
 print('Testing resource 1... done.')
 
 print('Testing resource 2...')
-props = dict(request_token_callback=partial(callback(os.environ['AZUREOIDC_TOKENCLIENT2'])))
+props = dict(request_token_callback=partial(callback, os.environ['AZUREOIDC_TOKENCLIENT2']))
 c = MongoClient('mongodb://localhost:27017/?authMechanism=MONGODB-OIDC', authMechanismProperties=props)
 c.test.test.find_one({})
 c.close()

--- a/.evergreen/auth_oidc/azure/test.py
+++ b/.evergreen/auth_oidc/azure/test.py
@@ -1,5 +1,4 @@
 from pymongo import MongoClient
-from functools import partial
 import os
 import json
 from urllib.request import urlopen, Request
@@ -10,7 +9,7 @@ _AUTH_MAP["MONGODB-OIDC"] = _authenticate_oidc
 
 app_id = os.environ['AZUREOIDC_CLIENTID']
 
-def callback(client_id, client_info, server_info):
+def _inner_callback(client_id, client_info, server_info):
     url = "http://169.254.169.254/metadata/identity/oauth2/token"
     url += "?api-version=2018-02-01"
     url += f"&resource=api://{app_id}"
@@ -41,7 +40,13 @@ def callback(client_id, client_info, server_info):
             raise ValueError(msg)
     return dict(access_token=data['access_token'])
 
-props = dict(request_token_callback=partial(callback, os.environ['AZUREOIDC_TOKENCLIENT']))
+def callback1(client_info, server_info):
+    return _inner_callback(os.environ['AZUREOIDC_TOKENCLIENT'], client_info, server_info)
+
+def callback2(client_info, server_info):
+    return _inner_callback(os.environ['AZUREOIDC_TOKENCLIENT2'], client_info, server_info)
+
+props = dict(request_token_callback=callback1)
 print('Testing MONGODB-OIDC on azure...')
 print('Testing resource 1...')
 c = MongoClient('mongodb://localhost:27017/?authMechanism=MONGODB-OIDC', authMechanismProperties=props)
@@ -50,7 +55,7 @@ c.close()
 print('Testing resource 1... done.')
 
 print('Testing resource 2...')
-props = dict(request_token_callback=partial(callback, os.environ['AZUREOIDC_TOKENCLIENT2']))
+props = dict(request_token_callback=callback2)
 c = MongoClient('mongodb://localhost:27017/?authMechanism=MONGODB-OIDC', authMechanismProperties=props)
 c.test.test.find_one({})
 c.close()

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -800,7 +800,6 @@ tasks:
         - func: "run docker test"
 
     - name: "test-oidc"
-      tags: ["latest", "oidc"]
       commands:
         - func: "run oidc test"
 
@@ -1028,7 +1027,8 @@ buildvariants:
   display_name: OIDC
   run_on: ubuntu2004-small
   tasks:
-    - ".oidc"   # Run all tasks with the "oidc" tag
+    - "test-oidc"  
+    - "testazureoidc_task_group"
 
 - matrix_name: "tests-all"
   matrix_spec: {"os-fully-featured": "*", auth: "*", ssl: "*" }

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -990,7 +990,7 @@ task_groups:
           ${PREPARE_SHELL}
           # ensure HEAD points to current commit
           cd src
-          git checkout oidc-test-branch
+          git checkout -b oidc-test-branch
           git add .
           git commit -m "add files"
           export AZUREOIDC_VMNAME_PREFIX="DRIVERS_TOOLS"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1018,18 +1018,17 @@ buildvariants:
 
 # Tests relating to docker images
 - name: tests-docker-related
-  display_name: Docker Related
+  display_name: Docker
   run_on:
     - ubuntu2004-large
   tasks:
     - ".docker"  # Run all tasks with the "docker" tag
 
 - name: testazureoidc-variant
-  display_name: "Azure OIDC"
+  display_name: OIDC
   run_on: ubuntu2004-small
   tasks:
-    - name: testazureoidc_task_group
-      batchtime: 20160 # Use a batchtime of 14 days as suggested by the CSFLE test README
+    - ".oidc"   # Run all tasks with the "oidc" tag
 
 - matrix_name: "tests-all"
   matrix_spec: {"os-fully-featured": "*", auth: "*", ssl: "*" }

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -800,12 +800,12 @@ tasks:
         - func: "run docker test"
 
     - name: "test-oidc"
-      tags: ["latest", "docker"]
+      tags: ["latest", "oidc"]
       commands:
         - func: "run oidc test"
 
-    - name: "oidc-auth-test-azure"
-      tags: ["latest", "azure"]
+    - name: "test-oidc-azure"
+      tags: ["latest", "oidc"]
       commands:
         - func: "run oidc azure test"
 
@@ -988,6 +988,9 @@ task_groups:
         script: |-
           set -o errexit
           ${PREPARE_SHELL}
+          # ensure HEAD points to current commit
+          git add .
+          git commit -a "commit local changes"
           export AZUREOIDC_VMNAME_PREFIX="DRIVERS_TOOLS"
           $DRIVERS_TOOLS/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
     teardown_group:
@@ -1000,7 +1003,7 @@ task_groups:
     setup_group_can_fail_task: true
     setup_group_timeout_secs: 1800
     tasks:
-    - oidc-auth-test-azure
+    - test-oidc-azure
 
 buildvariants:
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -395,17 +395,17 @@ functions:
           cd ${PROJECT_DIRECTORY}
           make test
 
-  "oidc-auth-test-azure":
+  "run oidc azure test":
     - command: shell.exec
-      type: test
       params:
-        working_dir: "src"
-        script: |
+        shell: bash
+        script: |-
+          set -o errexit
           ${PREPARE_SHELL}
-          set -ex
-          export AZUREOIDC_DRIVERS_TAR_FILE=/tmp/drivers_tools.tgz
+          cd src
+          export AZUREOIDC_DRIVERS_TAR_FILE=/tmp/mongo-python-driver.tgz
           git archive -o $AZUREOIDC_DRIVERS_TAR_FILE HEAD
-          export AZUREOIDC_TEST_CMD="source ./env.sh && echo 'hello'"
+          export AZUREOIDC_TEST_CMD="source ./env.sh && OIDC_PROVIDER_NAME=azure ./.evergreen/run-mongodb-oidc-test.sh"
           bash $DRIVERS_TOOLS/.evergreen/auth_oidc/azure/run-driver-test.sh
 
   "cleanup":
@@ -803,6 +803,11 @@ tasks:
       tags: ["latest", "docker"]
       commands:
         - func: "run oidc test"
+
+    - name: "oidc-auth-test-azure"
+      tags: ["latest", "azure"]
+      commands:
+        - func: "run oidc azure test"
 
 # }}}
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -989,7 +989,7 @@ task_groups:
           set -o errexit
           ${PREPARE_SHELL}
           # ensure HEAD points to current commit
-          cd src
+          cd $DRIVERS_TOOLS
           git add .
           git commit -m "add files"
           export AZUREOIDC_VMNAME_PREFIX="DRIVERS_TOOLS"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -395,6 +395,19 @@ functions:
           cd ${PROJECT_DIRECTORY}
           make test
 
+  "oidc-auth-test-azure":
+    - command: shell.exec
+      type: test
+      params:
+        working_dir: "src"
+        script: |
+          ${PREPARE_SHELL}
+          set -ex
+          export AZUREOIDC_DRIVERS_TAR_FILE=/tmp/drivers_tools.tgz
+          git archive -o $AZUREOIDC_DRIVERS_TAR_FILE HEAD
+          export AZUREOIDC_TEST_CMD="source ./env.sh && echo 'hello'"
+          bash $DRIVERS_TOOLS/.evergreen/auth_oidc/azure/run-driver-test.sh
+
   "cleanup":
     - command: shell.exec
       params:
@@ -960,6 +973,30 @@ task_groups:
     tasks:
       - ".serverless"
 
+  - name: testazureoidc_task_group
+    setup_group:
+    - func: fetch source
+    - func: prepare resources
+    - command: shell.exec
+      params:
+        shell: bash
+        script: |-
+          set -o errexit
+          ${PREPARE_SHELL}
+          export AZUREOIDC_VMNAME_PREFIX="DRIVERS_TOOLS"
+          $DRIVERS_TOOLS/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
+    teardown_group:
+    - command: shell.exec
+      params:
+        shell: bash
+        script: |-
+          ${PREPARE_SHELL}
+          $DRIVERS_TOOLS/.evergreen/auth_oidc/azure/delete-vm.sh
+    setup_group_can_fail_task: true
+    setup_group_timeout_secs: 1800
+    tasks:
+    - oidc-auth-test-azure
+
 buildvariants:
 
 # Test packaging and other release related routines
@@ -977,6 +1014,13 @@ buildvariants:
     - ubuntu2004-large
   tasks:
     - ".docker"  # Run all tasks with the "docker" tag
+
+- name: testazureoidc-variant
+  display_name: "Azure OIDC"
+  run_on: ubuntu2004-small
+  tasks:
+    - name: testazureoidc_task_group
+      batchtime: 20160 # Use a batchtime of 14 days as suggested by the CSFLE test README
 
 - matrix_name: "tests-all"
   matrix_spec: {"os-fully-featured": "*", auth: "*", ssl: "*" }

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -804,11 +804,6 @@ tasks:
       commands:
         - func: "run oidc test"
 
-    - name: "test-oidc-azure"
-      tags: ["latest", "oidc"]
-      commands:
-        - func: "run oidc azure test"
-
 # }}}
 
 
@@ -979,6 +974,7 @@ task_groups:
       - ".serverless"
 
   - name: testazureoidc_task_group
+    tags: ["latest", "oidc"]
     setup_group:
     - func: fetch source
     - func: prepare resources

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -991,7 +991,7 @@ task_groups:
           # ensure HEAD points to current commit
           cd src
           git add .
-          git commit -a "commit local changes"
+          git commit -m "commit local changes"
           export AZUREOIDC_VMNAME_PREFIX="DRIVERS_TOOLS"
           $DRIVERS_TOOLS/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
     teardown_group:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -395,7 +395,7 @@ functions:
           cd ${PROJECT_DIRECTORY}
           make test
 
-  "run oidc azure test":
+  "test-oidc-azure":
     - command: shell.exec
       params:
         shell: bash

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -989,6 +989,7 @@ task_groups:
           set -o errexit
           ${PREPARE_SHELL}
           # ensure HEAD points to current commit
+          cd src
           git add .
           git commit -a "commit local changes"
           export AZUREOIDC_VMNAME_PREFIX="DRIVERS_TOOLS"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -990,8 +990,9 @@ task_groups:
           ${PREPARE_SHELL}
           # ensure HEAD points to current commit
           cd src
+          git checkout oidc-test-branch
           git add .
-          git commit -m "commit local changes"
+          git commit -m "add files"
           export AZUREOIDC_VMNAME_PREFIX="DRIVERS_TOOLS"
           $DRIVERS_TOOLS/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
     teardown_group:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -990,7 +990,6 @@ task_groups:
           ${PREPARE_SHELL}
           # ensure HEAD points to current commit
           cd src
-          git checkout -b oidc-test-branch
           git add .
           git commit -m "add files"
           export AZUREOIDC_VMNAME_PREFIX="DRIVERS_TOOLS"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1017,14 +1017,14 @@ buildvariants:
     - ".releng" # Run all tasks with the "releng" tag
 
 # Tests relating to docker images
-- name: tests-docker-related
+- name: tests-docker
   display_name: Docker
   run_on:
     - ubuntu2004-large
   tasks:
     - ".docker"  # Run all tasks with the "docker" tag
 
-- name: testazureoidc-variant
+- name: tests-oidc
   display_name: OIDC
   run_on: ubuntu2004-small
   tasks:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -800,6 +800,7 @@ tasks:
         - func: "run docker test"
 
     - name: "test-oidc"
+      tags: ["latest", "oidc"]
       commands:
         - func: "run oidc test"
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -402,7 +402,7 @@ functions:
         script: |-
           set -o errexit
           ${PREPARE_SHELL}
-          cd src
+          cd $DRIVERS_TOOLS
           export AZUREOIDC_DRIVERS_TAR_FILE=/tmp/drivers-tools.tgz
           git archive -o $AZUREOIDC_DRIVERS_TAR_FILE HEAD
           export AZUREOIDC_TEST_CMD="source ./env.sh && echo 'hello'"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -403,9 +403,9 @@ functions:
           set -o errexit
           ${PREPARE_SHELL}
           cd src
-          export AZUREOIDC_DRIVERS_TAR_FILE=/tmp/mongo-python-driver.tgz
+          export AZUREOIDC_DRIVERS_TAR_FILE=/tmp/drivers-tools.tgz
           git archive -o $AZUREOIDC_DRIVERS_TAR_FILE HEAD
-          export AZUREOIDC_TEST_CMD="source ./env.sh && OIDC_PROVIDER_NAME=azure ./.evergreen/run-mongodb-oidc-test.sh"
+          export AZUREOIDC_TEST_CMD="source ./env.sh && echo 'hello'"
           bash $DRIVERS_TOOLS/.evergreen/auth_oidc/azure/run-driver-test.sh
 
   "cleanup":

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -395,7 +395,7 @@ functions:
           cd ${PROJECT_DIRECTORY}
           make test
 
-  "test-oidc-azure":
+  "run oidc azure test":
     - command: shell.exec
       params:
         shell: bash
@@ -803,6 +803,10 @@ tasks:
       tags: ["latest", "oidc"]
       commands:
         - func: "run oidc test"
+
+    - name: "test-oidc-azure"
+      commands:
+        - func: "run oidc azure test"
 
 # }}}
 

--- a/.evergreen/csfle/azurekms/create-vm.sh
+++ b/.evergreen/csfle/azurekms/create-vm.sh
@@ -39,6 +39,10 @@ az vm create \
     --assign-identity $AZUREKMS_IDENTITY \
     >/dev/null
 
-SHUTDOWN_TIME=$(TZ="-2" date +"%H%M")  # force shut down in one hour.
+if [ $(uname -s) = "Darwin" ]; then
+    SHUTDOWN_TIME=$(date -u -v2H +"%H%M")
+else
+    SHUTDOWN_TIME=$(date -u -d "$(date) + 1 hours" +"%H%M")
+fi
 az vm auto-shutdown -g $AZUREKMS_RESOURCEGROUP -n $AZUREKMS_VMNAME --time $SHUTDOWN_TIME
 echo "Creating a Virtual Machine ($AZUREKMS_VMNAME) ... end"

--- a/.evergreen/csfle/azurekms/create-vm.sh
+++ b/.evergreen/csfle/azurekms/create-vm.sh
@@ -38,4 +38,7 @@ az vm create \
     --nsg "$AZUREKMS_VMNAME-NSG" \
     --assign-identity $AZUREKMS_IDENTITY \
     >/dev/null
+
+SHUTDOWN_TIME=$(TZ="-1" date +"%H%M")  # force shut down in one hour.
+az vm auto-shutdown -g $AZUREKMS_RESOURCEGROUP -n $AZUREKMS_VMNAME --time $SHUTDOWN_TIME
 echo "Creating a Virtual Machine ($AZUREKMS_VMNAME) ... end"

--- a/.evergreen/csfle/azurekms/create-vm.sh
+++ b/.evergreen/csfle/azurekms/create-vm.sh
@@ -39,6 +39,6 @@ az vm create \
     --assign-identity $AZUREKMS_IDENTITY \
     >/dev/null
 
-SHUTDOWN_TIME=$(TZ="-1" date +"%H%M")  # force shut down in one hour.
+SHUTDOWN_TIME=$(TZ="-2" date +"%H%M")  # force shut down in one hour.
 az vm auto-shutdown -g $AZUREKMS_RESOURCEGROUP -n $AZUREKMS_VMNAME --time $SHUTDOWN_TIME
 echo "Creating a Virtual Machine ($AZUREKMS_VMNAME) ... end"

--- a/.evergreen/csfle/azurekms/create-vm.sh
+++ b/.evergreen/csfle/azurekms/create-vm.sh
@@ -40,7 +40,7 @@ az vm create \
     >/dev/null
 
 if [ $(uname -s) = "Darwin" ]; then
-    SHUTDOWN_TIME=$(date -u -v2H +"%H%M")
+    SHUTDOWN_TIME=$(date -u -v+1H +"%H%M")
 else
     SHUTDOWN_TIME=$(date -u -d "$(date) + 1 hours" +"%H%M")
 fi

--- a/.evergreen/csfle/azurekms/remote-scripts/setup-azure-vm.sh
+++ b/.evergreen/csfle/azurekms/remote-scripts/setup-azure-vm.sh
@@ -2,19 +2,18 @@
 set -o errexit
 set -o pipefail
 # Do not error on unset variables. run-orchestration.sh accesses unset variables.
-export DEBIAN_FRONTEND=noninteractive
-sudo apt-get update
+DEBIAN_FRONTEND=noninteractive sudo apt-get update
 
 echo "Install jq ... begin"
-sudo apt-get -y -o DPkg::Lock::Timeout=-1 install jq
+DEBIAN_FRONTEND=noninteractive sudo apt-get -y -o DPkg::Lock::Timeout=-1 install jq
 echo "Install jq ... end"
 
 echo "Installing MongoDB dependencies ... begin"
 # Dependencies for mongod: https://www.mongodb.com/docs/manual/tutorial/install-mongodb-enterprise-on-debian-tarball/
-sudo apt-get -y -o DPkg::Lock::Timeout=-1 install libcurl4 libgssapi-krb5-2 libldap-2.4-2 libwrap0 libsasl2-2 libsasl2-modules libsasl2-modules-gssapi-mit snmp openssl liblzma5
+DEBIAN_FRONTEND=noninteractive sudo apt-get -y -o DPkg::Lock::Timeout=-1 install libcurl4 libgssapi-krb5-2 libldap-2.4-2 libwrap0 libsasl2-2 libsasl2-modules libsasl2-modules-gssapi-mit snmp openssl liblzma5
 # Dependencies for run-orchestration.sh
-sudo apt-get -y -o DPkg::Lock::Timeout=-1 install python3.9-venv
-sudo apt-get -y -o DPkg::Lock::Timeout=-1 install python3-pip
+DEBIAN_FRONTEND=noninteractive sudo apt-get -y -o DPkg::Lock::Timeout=-1 install python3.9-venv
+DEBIAN_FRONTEND=noninteractive sudo apt-get -y -o DPkg::Lock::Timeout=-1 install python3-pip
 # Install git.
-sudo apt-get -y -o DPkg::Lock::Timeout=-1 install git
+DEBIAN_FRONTEND=noninteractive sudo apt-get -y -o DPkg::Lock::Timeout=-1 install git
 echo "Installing MongoDB dependencies ... end"

--- a/.evergreen/csfle/azurekms/remote-scripts/setup-azure-vm.sh
+++ b/.evergreen/csfle/azurekms/remote-scripts/setup-azure-vm.sh
@@ -2,18 +2,18 @@
 set -o errexit
 set -o pipefail
 # Do not error on unset variables. run-orchestration.sh accesses unset variables.
-DEBIAN_FRONTEND=noninteractive sudo apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get update
 
 echo "Install jq ... begin"
-DEBIAN_FRONTEND=noninteractive sudo apt-get -y -o DPkg::Lock::Timeout=-1 install jq
+sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o DPkg::Lock::Timeout=-1 install jq
 echo "Install jq ... end"
 
 echo "Installing MongoDB dependencies ... begin"
 # Dependencies for mongod: https://www.mongodb.com/docs/manual/tutorial/install-mongodb-enterprise-on-debian-tarball/
-DEBIAN_FRONTEND=noninteractive sudo apt-get -y -o DPkg::Lock::Timeout=-1 install libcurl4 libgssapi-krb5-2 libldap-2.4-2 libwrap0 libsasl2-2 libsasl2-modules libsasl2-modules-gssapi-mit snmp openssl liblzma5
+sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o DPkg::Lock::Timeout=-1 install libcurl4 libgssapi-krb5-2 libldap-2.4-2 libwrap0 libsasl2-2 libsasl2-modules libsasl2-modules-gssapi-mit snmp openssl liblzma5
 # Dependencies for run-orchestration.sh
-DEBIAN_FRONTEND=noninteractive sudo apt-get -y -o DPkg::Lock::Timeout=-1 install python3.9-venv
-DEBIAN_FRONTEND=noninteractive sudo apt-get -y -o DPkg::Lock::Timeout=-1 install python3-pip
+sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o DPkg::Lock::Timeout=-1 install python3.9-venv
+sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o DPkg::Lock::Timeout=-1 install python3-pip
 # Install git.
-DEBIAN_FRONTEND=noninteractive sudo apt-get -y -o DPkg::Lock::Timeout=-1 install git
+sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o DPkg::Lock::Timeout=-1 install git
 echo "Installing MongoDB dependencies ... end"

--- a/.evergreen/csfle/azurekms/remote-scripts/setup-azure-vm.sh
+++ b/.evergreen/csfle/azurekms/remote-scripts/setup-azure-vm.sh
@@ -2,6 +2,7 @@
 set -o errexit
 set -o pipefail
 # Do not error on unset variables. run-orchestration.sh accesses unset variables.
+export DEBIAN_FRONTEND=noninteractive
 sudo apt-get update
 
 echo "Install jq ... begin"


### PR DESCRIPTION
Tested with https://github.com/mongodb/mongo-python-driver/pull/1443 

- [x] Passing build in Python PR
	`======================== 15 passed, 21 skipped in 3.69s ========================`
- [x] Adjust EVG tasks so OIDC is grouped and Docker test is a new top level test
- [x] Update Azure setup wiki and update link in readme
- [x] Set up VMs to automatically shut down as a failsafe
- [x] See if we can have a default client id on the VM and if so, add a test for it - no, client_id is [required](https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/how-to-use-vm-token#get-a-token-using-http) when there is more than on managed id.