### PR TITLE
GODRIVER-3061 restore `CRYPT_SHARED_LIB_PATH` to `mo-orchestration.yml`

### DIFF
--- a/.evergreen/run-orchestration.sh
+++ b/.evergreen/run-orchestration.sh
@@ -128,7 +128,7 @@ fi
 cat tmp.json
 
 URI=$(${PYTHON:?} -c 'import json; j=json.load(open("tmp.json")); print(j["mongodb_auth_uri" if "mongodb_auth_uri" in j else "mongodb_uri"])' | tr -d '\r')
-echo 'MONGODB_URI: "'$URI'"' > mo-expansion.yml
+echo 'MONGODB_URI: "'$URI'"' >> mo-expansion.yml
 echo $URI > $DRIVERS_TOOLS/uri.txt
 printf "\nCluster URI: %s\n" "$URI"
 


### PR DESCRIPTION
# Summary

Restore `CRYPT_SHARED_LIB_PATH` to `mo-orchestration.yml`

# Background & Motivation

https://github.com/mongodb-labs/drivers-evergreen-tools/pull/378 appears to cause task failures in the C++ driver project due to a missing `CRYPT_SHARED_LIB_PATH` environment variable. [Example](https://spruce.mongodb.com/task/cxx_driver_integration_ubuntu1804_4.2_single_compile_and_test_with_shared_libs_patch_86d4a2b25287a1f75c26cf3bdc9fb7bd0086f4a9_65809d8ea4cf470922eaee32_23_12_18_19_29_20/logs?execution=0):

```
[2023/12/18 14:35:10.819] .evergreen/test.sh: line 243: CRYPT_SHARED_LIB_PATH: parameter null or not set
```

The `mo-orchestration.yml` file is overwritten in `run-orchestration.sh`, removing the previously appended `CRYPT_SHARED_LIB_PATH`.

This PR has been tested with the C++ driver: https://spruce.mongodb.com/version/6580aea9d6d80a06bc78a9cc/


