### PR TITLE
 DRIVERS-2416 Azure OIDC updates

### DIFF
--- a/.evergreen/auth_aws/setup_secrets.sh
+++ b/.evergreen/auth_aws/setup_secrets.sh
@@ -10,7 +10,7 @@ pushd $SCRIPT_DIR
 
 . ./activate-authawsvenv.sh
 set -x
-echo "Getting secrets:" "$@"
+echo "Getting AWS secrets:" "$@"
 python ./setup_secrets.py "$@"
 mv secrets-export.sh $CURRENT
 popd

--- a/.evergreen/auth_aws/setup_secrets.sh
+++ b/.evergreen/auth_aws/setup_secrets.sh
@@ -10,7 +10,7 @@ pushd $SCRIPT_DIR
 
 . ./activate-authawsvenv.sh
 set -x
-echo "Getting AWS secrets:" "$@"
+echo "Getting secrets:" "$@"
 python ./setup_secrets.py "$@"
 mv secrets-export.sh $CURRENT
 popd

--- a/.evergreen/auth_aws/setup_secrets.sh
+++ b/.evergreen/auth_aws/setup_secrets.sh
@@ -11,5 +11,9 @@ pushd $SCRIPT_DIR
 popd
 set -x
 echo "Getting secrets:" "$@"
-python $SCRIPT_DIR/setup_secrets.py "$@"
+if [ "Windows_NT" = "$OS" ]; then
+    $SCRIPT_DIR/authawsvenv/Scripts/python.exe  $SCRIPT_DIR/setup_secrets.py "$@"
+else
+    python $SCRIPT_DIR/setup_secrets.py "$@"
+fi
 echo "Got secrets"

--- a/.evergreen/auth_aws/setup_secrets.sh
+++ b/.evergreen/auth_aws/setup_secrets.sh
@@ -4,16 +4,14 @@
 # for details on usage.
 set -eu
 
+CURRENT=$(pwd)
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 pushd $SCRIPT_DIR
 
 . ./activate-authawsvenv.sh
-popd
 set -x
 echo "Getting secrets:" "$@"
-if [ "Windows_NT" = "$OS" ]; then
-    $SCRIPT_DIR/authawsvenv/Scripts/python.exe  $SCRIPT_DIR/setup_secrets.py "$@"
-else
-    python $SCRIPT_DIR/setup_secrets.py "$@"
-fi
+python ./setup_secrets.py "$@"
+mv secrets-export.sh $CURRENT
+popd
 echo "Got secrets"

--- a/.evergreen/auth_aws/setup_secrets.sh
+++ b/.evergreen/auth_aws/setup_secrets.sh
@@ -4,12 +4,12 @@
 # for details on usage.
 set -eu
 
-HERE=$(dirname $0)
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+pushd $SCRIPT_DIR
 
-pushd $HERE
 . ./activate-authawsvenv.sh
 popd
 set -x
 echo "Getting secrets:" "$@"
-python $HERE/setup_secrets.py "$@"
+python $SCRIPT_DIR/setup_secrets.py "$@"
 echo "Got secrets"

--- a/.evergreen/auth_oidc/azure/README.md
+++ b/.evergreen/auth_oidc/azure/README.md
@@ -55,25 +55,13 @@ export AZUREOIDC_TEST_CMD="source ./env.sh && OIDC_PROVIDER_NAME=azure ./.evergr
 bash $DRIVERS_TOOLS/.evergreen/auth_oidc/azure/run-driver-test.sh
 ```
 
-In your tests, you can use the environment variables in `env.sh` to define the `TOKEN_AUDIENCE` and `TOKEN_CLIENT_ID` 
-auth mechanism properties, e.g.
+In your tests, you can use the environment variables in `env.sh` to define the `username` and `TOKEN_AUDIENCE` 
+auth mechanism property, e.g.
 
 ```python
-TOKEN_AUDIENCE="api://" + os.environ["AZUREOIDC_CLIENTID"]
-TOKEN_CLIENT_ID=os.environ["AZUREOIDC_TOKENCLIENT"]  # For first user
-TOKEN_CLIENT_ID=os.environ["AZUREOIDC_TOKENCLIENT2"]  # For second user
+username=os.environ["AZUREOIDC_USERNAME"]
+TOKEN_AUDIENCE=os.environ["AZUREOIDC_AUDIENCE"]
 ```
-
-Note: If you are creating a uri, you will have to escape `TOKEN_AUDIENCE` value, e.g.
-
-```bash
-MONGODB_URI="${MONGODB_URI}/?authMechanism=MONGODB-OIDC"
-MONGODB_URI="${MONGODB_URI}&authMechanismProperties=PROVIDER_NAME:azure"
-MONGODB_URI="${MONGODB_URI},TOKEN_AUDIENCE:api%3A%2F%2F${AZUREOIDC_CLIENTID}"
-```
-
-Note: since we will be testing with two different clients, the `TOKEN_CLIENT_ID` will need to be provided
-as an argument to `MongoClient` in the prose tests.
 
 Finally, we tear down the vm:
 
@@ -87,9 +75,9 @@ Below is an explanantion of the environment variables stored in the Azure key va
 
 - AZUREOIDC_AUTHPREFIX - The auth prefix used for DB user and role names.
 - AZUREOIDC_AUTHCLAIM - The object ID of the Azure Group, used in the DB role name.
-- AZUREOIDC_CLIENTID - The client ID of the Azure App registration, used for the `TOKEN_AUDIENCE` auth mechanism property.
-- AZUREOIDC_TOKENCLIENT - The client ID of the first Azure Managed Identity, used for the `TOKEN_CLIENT_ID` auth mechanism property.
-- AZUREOIDC_TOKENCLIENT2 - The client ID of the second Azure Managed Identity, used for the `TOKEN_CLIENT_ID` auth mechanism property.
+- AZUREOIDC_USERNAME - The Object (principal) ID of the Azure Manager Identity, used for the `username`.
+- AZUREOIDC_AUDIENCE - The escaped Application ID URI to use in the `TOKEN_AUDIENCE` auth mechanism property.
+- AZUREOIDC_CLIENTID - The client ID of the Azure App registration, used to generate the unescaped Application ID URI.
 - AZUREOIDC_TENANTID - The tenant ID of the Azure App registration, used to derive the `issuer` URI.
-- AZUREKMS_IDENTITY - A space separated string with the two Resource IDs of the managed identities (`/subscriptions/... /subscriptions/...`).  Used to assign the identities to the VM.
+- AZUREKMS_IDENTITY - A space separated string with the Resource ID of the managed identity (`/subscriptions/...`).  Used to assign the identity to the VM.
 - AZUREOIDC_RESOURCEGROUP - The name of the Azure Resource Group, used when accessing the VM through the CLI.

--- a/.evergreen/auth_oidc/azure/handle_secrets.py
+++ b/.evergreen/auth_oidc/azure/handle_secrets.py
@@ -39,7 +39,7 @@ def main():
         fid.write(f'export AZUREOIDC_CLIENTID={client_id}\n')
         fid.write(f'export AZUREOIDC_TENANTID={tenant_id}\n')
         fid.write(f'export AZUREOIDC_AUTHPREFIX={secrets["AUTHPREFIX"]}\n')
-        fid.write(f'export AZUREKMS_IDENTITY="{secrets["IDENTITY"]} {secrets["IDENTITY2"]}"\n')
+        fid.write(f'export AZUREKMS_IDENTITY="{secrets["IDENTITY"]}"\n')
 
     if os.path.exists(private_key_file):
         os.remove(private_key_file)

--- a/.evergreen/auth_oidc/azure/handle_secrets.py
+++ b/.evergreen/auth_oidc/azure/handle_secrets.py
@@ -26,7 +26,7 @@ def main():
 
     secrets = dict()
     for secret in ['RESOURCEGROUP', 'PUBLICKEY', 'PRIVATEKEY', 'TOKENCLIENT', 'AUTHCLAIM', 'AUTHPREFIX', 'IDENTITY',
-                   'TOKENCLIENT2', 'IDENTITY2']:
+                   'TOKENCLIENT2', 'IDENTITY2', 'USERNAME', 'AUDIENCE']:
         retrieved = client.get_secret(secret)
         secrets[secret] = retrieved.value
 

--- a/.evergreen/auth_oidc/azure/handle_secrets.py
+++ b/.evergreen/auth_oidc/azure/handle_secrets.py
@@ -40,8 +40,8 @@ def main():
         fid.write(f'export AZUREOIDC_TENANTID={tenant_id}\n')
         fid.write(f'export AZUREOIDC_AUTHPREFIX={secrets["AUTHPREFIX"]}\n')
         fid.write(f'export AZUREKMS_IDENTITY="{secrets["IDENTITY"]}"\n')
-        fid.write(f'export AZUREKMS_USERNAME="{secrets["USERNAME"]}"\n')
-        fid.write(f'export AZUREKMS_AUDIENCE="{secrets["AUDIENCE"]}"\n')
+        fid.write(f'export AZUREOIDC_USERNAME="{secrets["USERNAME"]}"\n')
+        fid.write(f'export AZUREOIDC_AUDIENCE="{secrets["AUDIENCE"]}"\n')
 
     if os.path.exists(private_key_file):
         os.remove(private_key_file)

--- a/.evergreen/auth_oidc/azure/handle_secrets.py
+++ b/.evergreen/auth_oidc/azure/handle_secrets.py
@@ -40,6 +40,8 @@ def main():
         fid.write(f'export AZUREOIDC_TENANTID={tenant_id}\n')
         fid.write(f'export AZUREOIDC_AUTHPREFIX={secrets["AUTHPREFIX"]}\n')
         fid.write(f'export AZUREKMS_IDENTITY="{secrets["IDENTITY"]}"\n')
+        fid.write(f'export AZUREKMS_USERNAME="{secrets["USERNAME"]}"\n')
+        fid.write(f'export AZUREKMS_AUDIENCE="{secrets["AUDIENCE"]}"\n')
 
     if os.path.exists(private_key_file):
         os.remove(private_key_file)

--- a/.evergreen/auth_oidc/azure/test.py
+++ b/.evergreen/auth_oidc/azure/test.py
@@ -8,12 +8,13 @@ from pymongo.auth import _AUTH_MAP, _authenticate_oidc
 _AUTH_MAP["MONGODB-OIDC"] = _authenticate_oidc
 
 app_id = os.environ['AZUREOIDC_CLIENTID']
+object_id = os.environ['AZUREOIDC_USERNAME']
 
-def _inner_callback(client_id, client_info, server_info):
+def callback(client_info, server_info):
     url = "http://169.254.169.254/metadata/identity/oauth2/token"
     url += "?api-version=2018-02-01"
     url += f"&resource=api://{app_id}"
-    url += f"&client_id={client_id}"
+    url += f"&object_id={object_id}"
     headers = { "Metadata": "true", "Accept": "application/json" }
     request = Request(url, headers=headers)
     try:
@@ -40,25 +41,10 @@ def _inner_callback(client_id, client_info, server_info):
             raise ValueError(msg)
     return dict(access_token=data['access_token'])
 
-def callback1(client_info, server_info):
-    return _inner_callback(os.environ['AZUREOIDC_TOKENCLIENT'], client_info, server_info)
-
-def callback2(client_info, server_info):
-    return _inner_callback(os.environ['AZUREOIDC_TOKENCLIENT2'], client_info, server_info)
-
-props = dict(request_token_callback=callback1)
+props = dict(request_token_callback=callback)
 print('Testing MONGODB-OIDC on azure...')
-print('Testing resource 1...')
 c = MongoClient('mongodb://localhost:27017/?authMechanism=MONGODB-OIDC', authMechanismProperties=props)
 c.test.test.insert_one({})
 c.close()
-print('Testing resource 1... done.')
-
-print('Testing resource 2...')
-props = dict(request_token_callback=callback2)
-c = MongoClient('mongodb://localhost:27017/?authMechanism=MONGODB-OIDC', authMechanismProperties=props)
-c.test.test.find_one({})
-c.close()
-print('Testing resource 2... done.')
 print('Testing MONGODB-OIDC on azure... done.')
 print('Self test complete!')

--- a/.evergreen/auth_oidc/oidc_get_tokens.sh
+++ b/.evergreen/auth_oidc/oidc_get_tokens.sh
@@ -3,8 +3,8 @@
 # Get the set of OIDC tokens in the OIDC_TOKEN_DIR.
 #
 set -ex
-HERE=$(dirname $0)
-pushd $HERE
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+pushd $SCRIPT_DIR
 
 if [ -z "$OIDC_TOKEN_DIR" ]; then
     if [ "Windows_NT" = "$OS" ]; then
@@ -17,7 +17,7 @@ mkdir -p $OIDC_TOKEN_DIR
 . ./activate-authoidcvenv.sh
 
 if [ ! -f "./secrets-export.sh" ]; then
-    AUTH_AWS="$HERE/../auth_aws"
+    AUTH_AWS="$SCRIPT_DIR/../auth_aws"
     set -x
     echo "Getting oidc secrets"
     python $AUTH_AWS/setup_secrets.py drivers/oidc
@@ -26,3 +26,4 @@ fi
 
 source ./secrets-export.sh
 python oidc_get_tokens.py
+popd

--- a/.evergreen/auth_oidc/oidc_get_tokens.sh
+++ b/.evergreen/auth_oidc/oidc_get_tokens.sh
@@ -20,7 +20,10 @@ if [ ! -f "./secrets-export.sh" ]; then
     AUTH_AWS="$SCRIPT_DIR/../auth_aws"
     set -x
     echo "Getting oidc secrets"
-    python $AUTH_AWS/setup_secrets.py drivers/oidc
+    pushd $AUTH_AWS
+    python ./setup_secrets.py drivers/oidc
+    mv secrets-export.sh $SCRIPT_DIR
+    popd
     echo "Got secrets"
 fi
 

--- a/.evergreen/auth_oidc/oidc_write_orchestration.py
+++ b/.evergreen/auth_oidc/oidc_write_orchestration.py
@@ -13,7 +13,7 @@ from utils import get_secrets, MOCK_ENDPOINT, DEFAULT_CLIENT
 
 
 def azure():
-    client_id = os.environ['AZUREOIDC_TOKENCLIENT']
+    client_id = os.environ['AZUREOIDC_USERNAME']
     tenant_id = os.environ['AZUREOIDC_TENANTID']
     app_id = os.environ['AZUREOIDC_CLIENTID']
     auth_name_prefix = os.environ['AZUREOIDC_AUTHPREFIX']
@@ -43,7 +43,7 @@ def azure():
             "port": 27017,
             "setParameter": {
                 "enableTestCommands": 1,
-                "authenticationMechanisms": "SCRAM-SHA-1,SCRAM-SHA-256,MONGODB-OIDC",
+                "authenticationMechanisms": "SCRAM-SHA-256,MONGODB-OIDC",
                 "oidcIdentityProviders": providers
             }
         }

--- a/.evergreen/auth_oidc/oidc_write_orchestration.py
+++ b/.evergreen/auth_oidc/oidc_write_orchestration.py
@@ -43,7 +43,7 @@ def azure():
             "port": 27017,
             "setParameter": {
                 "enableTestCommands": 1,
-                "authenticationMechanisms": "SCRAM-SHA-256,MONGODB-OIDC",
+                "authenticationMechanisms": "SCRAM-SHA-1,SCRAM-SHA-256,MONGODB-OIDC",
                 "oidcIdentityProviders": providers
             }
         }

--- a/.evergreen/auth_oidc/oidc_write_orchestration.py
+++ b/.evergreen/auth_oidc/oidc_write_orchestration.py
@@ -33,7 +33,7 @@ def azure():
     data = {
         "id": "oidc-repl0",
         "auth_key": "secret",
-        "login": "bob",
+        "login": client_id,
         "name": "mongod",
         "password": "pwd123",
         "procParams": {

--- a/.evergreen/auth_oidc/setup_oidc.js
+++ b/.evergreen/auth_oidc/setup_oidc.js
@@ -4,8 +4,9 @@
 (function() {
 "use strict";
 
+const adminUser = process.env['AZUREOIDC_USERNAME'] || 'bob';
 const admin = Mongo().getDB("admin");
-assert(admin.auth("bob", "pwd123"));
+assert(admin.auth(adminUser, "pwd123"));
 
 console.log("Setting up User");
 const authorizationPrefix = process.env['AZUREOIDC_AUTHPREFIX'] || 'test1';

--- a/.evergreen/auth_oidc/setup_oidc.js
+++ b/.evergreen/auth_oidc/setup_oidc.js
@@ -5,6 +5,7 @@
 "use strict";
 
 const adminUser = process.env['AZUREOIDC_USERNAME'] || 'bob';
+console.log("Setting up Admin User", adminUser);
 const admin = Mongo().getDB("admin");
 assert(admin.auth(adminUser, "pwd123"));
 


### PR DESCRIPTION
- Add only one managed identity to the VM
- Use the object id of the managed identity as the `username` instead of as an auth mechanism property

Tested with https://github.com/mongodb/mongo-python-driver/pull/1443