### PR TITLE
Normalize Script Path Usage

### DIFF
--- a/.evergreen/atlas/setup-atlas-cluster.sh
+++ b/.evergreen/atlas/setup-atlas-cluster.sh
@@ -36,7 +36,7 @@ for VARNAME in ${VARLIST[*]}; do
 done
 
 # Set up the common variables.
-DIR="$(dirname "${BASH_SOURCE[0]}")"
+DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 . $DIR/setup-variables.sh
 
 # The cluster server version.

--- a/.evergreen/atlas/setup-atlas-cluster.sh
+++ b/.evergreen/atlas/setup-atlas-cluster.sh
@@ -36,7 +36,7 @@ for VARNAME in ${VARLIST[*]}; do
 done
 
 # Set up the common variables.
-DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DIR=$(dirname ${BASH_SOURCE:-$0})
 . $DIR/../handle-paths.sh
 . $DIR/setup-variables.sh
 

--- a/.evergreen/atlas/setup-atlas-cluster.sh
+++ b/.evergreen/atlas/setup-atlas-cluster.sh
@@ -36,9 +36,9 @@ for VARNAME in ${VARLIST[*]}; do
 done
 
 # Set up the common variables.
-DIR=$(dirname ${BASH_SOURCE:-$0})
-. $DIR/../handle-paths.sh
-. $DIR/setup-variables.sh
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+. $SCRIPT_DIR/../handle-paths.sh
+. $SCRIPT_DIR/setup-variables.sh
 
 # The cluster server version.
 VERSION="${MONGODB_VERSION:-6.0}"

--- a/.evergreen/atlas/setup-atlas-cluster.sh
+++ b/.evergreen/atlas/setup-atlas-cluster.sh
@@ -37,6 +37,7 @@ done
 
 # Set up the common variables.
 DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+. $DIR/../handle-paths.sh
 . $DIR/setup-variables.sh
 
 # The cluster server version.

--- a/.evergreen/atlas/teardown-atlas-cluster.sh
+++ b/.evergreen/atlas/teardown-atlas-cluster.sh
@@ -29,7 +29,7 @@ for VARNAME in ${VARLIST[*]}; do
 done
 
 # Set up the common variables.
-DIR="$(dirname "${BASH_SOURCE[0]}")"
+DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 . $DIR/setup-variables.sh
 
 # Delete the cluster.

--- a/.evergreen/atlas/teardown-atlas-cluster.sh
+++ b/.evergreen/atlas/teardown-atlas-cluster.sh
@@ -29,9 +29,9 @@ for VARNAME in ${VARLIST[*]}; do
 done
 
 # Set up the common variables.
-DIR=$(dirname ${BASH_SOURCE:-$0})
-. $DIR/../handle-paths.sh
-. $DIR/setup-variables.sh
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+. $SCRIPT_DIR/../handle-paths.sh
+. $SCRIPT_DIR/setup-variables.sh
 
 # Delete the cluster.
 echo "Deleting Atlas Cluster..."

--- a/.evergreen/atlas/teardown-atlas-cluster.sh
+++ b/.evergreen/atlas/teardown-atlas-cluster.sh
@@ -29,7 +29,7 @@ for VARNAME in ${VARLIST[*]}; do
 done
 
 # Set up the common variables.
-DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DIR=$(dirname ${BASH_SOURCE:-$0})
 . $DIR/../handle-paths.sh
 . $DIR/setup-variables.sh
 

--- a/.evergreen/atlas/teardown-atlas-cluster.sh
+++ b/.evergreen/atlas/teardown-atlas-cluster.sh
@@ -30,6 +30,7 @@ done
 
 # Set up the common variables.
 DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+. $DIR/../handle-paths.sh
 . $DIR/setup-variables.sh
 
 # Delete the cluster.

--- a/.evergreen/atlas_data_lake/build-mongohouse-local.sh
+++ b/.evergreen/atlas_data_lake/build-mongohouse-local.sh
@@ -5,7 +5,7 @@
 set -o errexit  # Exit the script with error if any of the commands fail
 
 ORIG_DIR="$(pwd)"
-DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DIR=$(dirname ${BASH_SOURCE:-$0})
 . $DIR/../handle-paths.sh
 
 # Configure git to use the git protocol

--- a/.evergreen/atlas_data_lake/build-mongohouse-local.sh
+++ b/.evergreen/atlas_data_lake/build-mongohouse-local.sh
@@ -6,7 +6,7 @@ set -o errexit  # Exit the script with error if any of the commands fail
 
 ORIG_DIR="$(pwd)"
 DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-DRIVERS_TOOLS=$(dirname $(dirname $(dirname $DIR)))
+. $DIR/../handle-paths.sh
 
 # Configure git to use the git protocol
 git config --global url."git@github.com:".insteadof "https://github.com/"

--- a/.evergreen/atlas_data_lake/build-mongohouse-local.sh
+++ b/.evergreen/atlas_data_lake/build-mongohouse-local.sh
@@ -5,6 +5,8 @@
 set -o errexit  # Exit the script with error if any of the commands fail
 
 ORIG_DIR="$(pwd)"
+DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DRIVERS_TOOLS=$(dirname $(dirname $(dirname $DIR)))
 
 # Configure git to use the git protocol
 git config --global url."git@github.com:".insteadof "https://github.com/"

--- a/.evergreen/atlas_data_lake/build-mongohouse-local.sh
+++ b/.evergreen/atlas_data_lake/build-mongohouse-local.sh
@@ -5,8 +5,8 @@
 set -o errexit  # Exit the script with error if any of the commands fail
 
 ORIG_DIR="$(pwd)"
-DIR=$(dirname ${BASH_SOURCE:-$0})
-. $DIR/../handle-paths.sh
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+. $SCRIPT_DIR/../handle-paths.sh
 
 # Configure git to use the git protocol
 git config --global url."git@github.com:".insteadof "https://github.com/"

--- a/.evergreen/atlas_data_lake/pull-mongohouse-image.sh
+++ b/.evergreen/atlas_data_lake/pull-mongohouse-image.sh
@@ -4,7 +4,7 @@
 #
 set -eux
 
-DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DIR=$(dirname ${BASH_SOURCE:-$0})
 . $DIR/../handle-paths.sh
 REPO="904697982180.dkr.ecr.us-east-1.amazonaws.com/atlas-query-engine-test"
 pushd $DRIVERS_TOOLS/.evergreen/auth_aws

--- a/.evergreen/atlas_data_lake/pull-mongohouse-image.sh
+++ b/.evergreen/atlas_data_lake/pull-mongohouse-image.sh
@@ -4,7 +4,8 @@
 #
 set -eux
 
-DRIVERS_TOOLS=${DRIVERS_TOOLS:-$(readlink -f ../..)}
+DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DRIVERS_TOOLS=$(dirname $(dirname $DIR))
 REPO="904697982180.dkr.ecr.us-east-1.amazonaws.com/atlas-query-engine-test"
 pushd $DRIVERS_TOOLS/.evergreen/auth_aws
 bash setup_secrets.sh drivers/adl

--- a/.evergreen/atlas_data_lake/pull-mongohouse-image.sh
+++ b/.evergreen/atlas_data_lake/pull-mongohouse-image.sh
@@ -4,8 +4,8 @@
 #
 set -eux
 
-DIR=$(dirname ${BASH_SOURCE:-$0})
-. $DIR/../handle-paths.sh
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+. $SCRIPT_DIR/../handle-paths.sh
 REPO="904697982180.dkr.ecr.us-east-1.amazonaws.com/atlas-query-engine-test"
 pushd $DRIVERS_TOOLS/.evergreen/auth_aws
 bash setup_secrets.sh drivers/adl

--- a/.evergreen/atlas_data_lake/pull-mongohouse-image.sh
+++ b/.evergreen/atlas_data_lake/pull-mongohouse-image.sh
@@ -5,7 +5,7 @@
 set -eux
 
 DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-DRIVERS_TOOLS=$(dirname $(dirname $DIR))
+. $DIR/../handle-paths.sh
 REPO="904697982180.dkr.ecr.us-east-1.amazonaws.com/atlas-query-engine-test"
 pushd $DRIVERS_TOOLS/.evergreen/auth_aws
 bash setup_secrets.sh drivers/adl

--- a/.evergreen/atlas_data_lake/run-mongohouse-image.sh
+++ b/.evergreen/atlas_data_lake/run-mongohouse-image.sh
@@ -7,7 +7,7 @@
 set -eux
 
 DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-DRIVERS_TOOLS=$(dirname $(dirname $DIR))
+. $DIR/../handle-paths.sh
 IMAGE=904697982180.dkr.ecr.us-east-1.amazonaws.com/atlas-query-engine-test
 USE_TTY=""
 test -t 1 && USE_TTY="-t"

--- a/.evergreen/atlas_data_lake/run-mongohouse-image.sh
+++ b/.evergreen/atlas_data_lake/run-mongohouse-image.sh
@@ -6,7 +6,8 @@
 # on Evergreen to terminate processes and clean up when tasks end.
 set -eux
 
-DRIVERS_TOOLS=${DRIVERS_TOOLS:-$(readlink -f ../..)}
+DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DRIVERS_TOOLS=$(dirname $(dirname $DIR))
 IMAGE=904697982180.dkr.ecr.us-east-1.amazonaws.com/atlas-query-engine-test
 USE_TTY=""
 test -t 1 && USE_TTY="-t"

--- a/.evergreen/atlas_data_lake/run-mongohouse-image.sh
+++ b/.evergreen/atlas_data_lake/run-mongohouse-image.sh
@@ -6,8 +6,8 @@
 # on Evergreen to terminate processes and clean up when tasks end.
 set -eux
 
-DIR=$(dirname ${BASH_SOURCE:-$0})
-. $DIR/../handle-paths.sh
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+. $SCRIPT_DIR/../handle-paths.sh
 IMAGE=904697982180.dkr.ecr.us-east-1.amazonaws.com/atlas-query-engine-test
 USE_TTY=""
 test -t 1 && USE_TTY="-t"

--- a/.evergreen/atlas_data_lake/run-mongohouse-image.sh
+++ b/.evergreen/atlas_data_lake/run-mongohouse-image.sh
@@ -6,7 +6,7 @@
 # on Evergreen to terminate processes and clean up when tasks end.
 set -eux
 
-DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DIR=$(dirname ${BASH_SOURCE:-$0})
 . $DIR/../handle-paths.sh
 IMAGE=904697982180.dkr.ecr.us-east-1.amazonaws.com/atlas-query-engine-test
 USE_TTY=""

--- a/.evergreen/atlas_data_lake/run-mongohouse-local.sh
+++ b/.evergreen/atlas_data_lake/run-mongohouse-local.sh
@@ -12,5 +12,5 @@ else
   export MONGOHOUSE_MQLRUN=`pwd`/artifacts/mqlrun
 fi;
 DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-DRIVERS_TOOLS=$(dirname $(dirname $(dirname $DIR)))
+. $DIR/../handle-paths.sh
 ./artifacts/mongohoused --config ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake/config.yml

--- a/.evergreen/atlas_data_lake/run-mongohouse-local.sh
+++ b/.evergreen/atlas_data_lake/run-mongohouse-local.sh
@@ -11,4 +11,6 @@ if [ "Windows_NT" = "$OS" ]; then
 else
   export MONGOHOUSE_MQLRUN=`pwd`/artifacts/mqlrun
 fi;
+DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DRIVERS_TOOLS=$(dirname $(dirname $(dirname $DIR)))
 ./artifacts/mongohoused --config ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake/config.yml

--- a/.evergreen/atlas_data_lake/run-mongohouse-local.sh
+++ b/.evergreen/atlas_data_lake/run-mongohouse-local.sh
@@ -11,6 +11,6 @@ if [ "Windows_NT" = "$OS" ]; then
 else
   export MONGOHOUSE_MQLRUN=`pwd`/artifacts/mqlrun
 fi;
-DIR=$(dirname ${BASH_SOURCE:-$0})
-. $DIR/../handle-paths.sh
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+. $SCRIPT_DIR/../handle-paths.sh
 ./artifacts/mongohoused --config ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake/config.yml

--- a/.evergreen/atlas_data_lake/run-mongohouse-local.sh
+++ b/.evergreen/atlas_data_lake/run-mongohouse-local.sh
@@ -11,6 +11,6 @@ if [ "Windows_NT" = "$OS" ]; then
 else
   export MONGOHOUSE_MQLRUN=`pwd`/artifacts/mqlrun
 fi;
-DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DIR=$(dirname ${BASH_SOURCE:-$0})
 . $DIR/../handle-paths.sh
 ./artifacts/mongohoused --config ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake/config.yml

--- a/.evergreen/auth_aws/aws_setup.sh
+++ b/.evergreen/auth_aws/aws_setup.sh
@@ -10,6 +10,7 @@
 set -eux
 
 DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+. $DIR/../handle-paths.sh
 pushd $DIR
 
 # Ensure that secrets have already been set up.

--- a/.evergreen/auth_aws/aws_setup.sh
+++ b/.evergreen/auth_aws/aws_setup.sh
@@ -9,9 +9,9 @@
 # Assumes you have already set up secrets.
 set -eux
 
-DIR=$(dirname ${BASH_SOURCE:-$0})
-. $DIR/../handle-paths.sh
-pushd $DIR
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+. $SCRIPT_DIR/../handle-paths.sh
+pushd $SCRIPT_DIR
 
 # Ensure that secrets have already been set up.
 if [ ! -f "secrets-export.sh" ]; then 
@@ -74,7 +74,7 @@ case $1 in
 
     web-identity)
         export AWS_ROLE_ARN=$IAM_AUTH_ASSUME_WEB_ROLE_NAME
-        export AWS_WEB_IDENTITY_TOKEN_FILE="$DIR/$AWS_WEB_IDENTITY_TOKEN_FILE"
+        export AWS_WEB_IDENTITY_TOKEN_FILE="$SCRIPT_DIR/$AWS_WEB_IDENTITY_TOKEN_FILE"
         ;;
 
     regular)

--- a/.evergreen/auth_aws/aws_setup.sh
+++ b/.evergreen/auth_aws/aws_setup.sh
@@ -74,7 +74,7 @@ case $1 in
 
     web-identity)
         export AWS_ROLE_ARN=$IAM_AUTH_ASSUME_WEB_ROLE_NAME
-        export AWS_WEB_IDENTITY_TOKEN_FILE="$SCRIPT_DIR/$AWS_WEB_IDENTITY_TOKEN_FILE"
+        export AWS_WEB_IDENTITY_TOKEN_FILE="$DIR/$AWS_WEB_IDENTITY_TOKEN_FILE"
         ;;
 
     regular)

--- a/.evergreen/auth_aws/aws_setup.sh
+++ b/.evergreen/auth_aws/aws_setup.sh
@@ -9,7 +9,7 @@
 # Assumes you have already set up secrets.
 set -eux
 
-DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DIR=$(dirname ${BASH_SOURCE:-$0})
 . $DIR/../handle-paths.sh
 pushd $DIR
 

--- a/.evergreen/auth_aws/aws_setup.sh
+++ b/.evergreen/auth_aws/aws_setup.sh
@@ -9,8 +9,8 @@
 # Assumes you have already set up secrets.
 set -eux
 
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-pushd $SCRIPT_DIR
+DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+pushd $DIR
 
 # Ensure that secrets have already been set up.
 if [ ! -f "secrets-export.sh" ]; then 

--- a/.evergreen/auth_aws/setup_secrets.sh
+++ b/.evergreen/auth_aws/setup_secrets.sh
@@ -7,7 +7,9 @@ set -eu
 DIR=$(dirname ${BASH_SOURCE:-$0})
 . $DIR/../handle-paths.sh
 
+pushd $DIR
 . ./activate-authawsvenv.sh
+popd
 set -x
 echo "Getting secrets:" "$@"
 python $DIR/setup_secrets.py "$@"

--- a/.evergreen/auth_aws/setup_secrets.sh
+++ b/.evergreen/auth_aws/setup_secrets.sh
@@ -6,6 +6,7 @@ set -eu
 
 CURRENT=$(pwd)
 DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+. $DIR/../handle-paths.sh
 pushd $DIR
 
 . ./activate-authawsvenv.sh

--- a/.evergreen/auth_aws/setup_secrets.sh
+++ b/.evergreen/auth_aws/setup_secrets.sh
@@ -4,15 +4,11 @@
 # for details on usage.
 set -eu
 
-CURRENT=$(pwd)
 DIR=$(dirname ${BASH_SOURCE:-$0})
 . $DIR/../handle-paths.sh
-pushd $DIR
 
 . ./activate-authawsvenv.sh
 set -x
 echo "Getting secrets:" "$@"
-python ./setup_secrets.py "$@"
-mv -f secrets-export.sh $CURRENT
-popd
+python $DIR/setup_secrets.py "$@"
 echo "Got secrets"

--- a/.evergreen/auth_aws/setup_secrets.sh
+++ b/.evergreen/auth_aws/setup_secrets.sh
@@ -5,8 +5,8 @@
 set -eu
 
 CURRENT=$(pwd)
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-pushd $SCRIPT_DIR
+DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+pushd $DIR
 
 . ./activate-authawsvenv.sh
 set -x

--- a/.evergreen/auth_aws/setup_secrets.sh
+++ b/.evergreen/auth_aws/setup_secrets.sh
@@ -4,13 +4,13 @@
 # for details on usage.
 set -eu
 
-DIR=$(dirname ${BASH_SOURCE:-$0})
-. $DIR/../handle-paths.sh
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+. $SCRIPT_DIR/../handle-paths.sh
 
-pushd $DIR
+pushd $SCRIPT_DIR
 . ./activate-authawsvenv.sh
 popd
 set -x
 echo "Getting secrets:" "$@"
-python $DIR/setup_secrets.py "$@"
+python $SCRIPT_DIR/setup_secrets.py "$@"
 echo "Got secrets"

--- a/.evergreen/auth_aws/setup_secrets.sh
+++ b/.evergreen/auth_aws/setup_secrets.sh
@@ -5,7 +5,7 @@
 set -eu
 
 CURRENT=$(pwd)
-DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DIR=$(dirname ${BASH_SOURCE:-$0})
 . $DIR/../handle-paths.sh
 pushd $DIR
 

--- a/.evergreen/auth_aws/setup_secrets.sh
+++ b/.evergreen/auth_aws/setup_secrets.sh
@@ -13,6 +13,6 @@ pushd $DIR
 set -x
 echo "Getting secrets:" "$@"
 python ./setup_secrets.py "$@"
-mv secrets-export.sh $CURRENT
+mv -f secrets-export.sh $CURRENT
 popd
 echo "Got secrets"

--- a/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
+++ b/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
@@ -11,7 +11,7 @@ if [ -z "${AZUREOIDC_VMNAME_PREFIX:-}" ]; then
 fi
 
 DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-DRIVERS_TOOLS=$(dirname $(dirname $(dirname $DIR)))
+. $DIR/../../handle-paths.sh
 
 # Set defaults.
 BASE_PATH="$DRIVERS_TOOLS/.evergreen/auth_oidc"

--- a/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
+++ b/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
@@ -10,9 +10,11 @@ if [ -z "${AZUREOIDC_VMNAME_PREFIX:-}" ]; then
     exit 1
 fi
 
+DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DRIVERS_TOOLS=$(dirname $(dirname $(dirname $DIR)))
+
 # Set defaults.
-AZUREOIDC_DRIVERS_TOOLS=${AZUREOIDC_DRIVERS_TOOLS:-$DRIVERS_TOOLS}
-BASE_PATH="$AZUREOIDC_DRIVERS_TOOLS/.evergreen/auth_oidc"
+BASE_PATH="$DRIVERS_TOOLS/.evergreen/auth_oidc"
 export AZUREKMS_PUBLICKEYPATH="$BASE_PATH/azure/keyfile.pub"
 export AZUREKMS_PRIVATEKEYPATH="$BASE_PATH/azure/keyfile"
 export AZUREKMS_VMNAME_PREFIX=$AZUREOIDC_VMNAME_PREFIX
@@ -43,37 +45,37 @@ if [[ "$(printf "$ACTUAL_VERSION\n$EXPECTED_VERSION_NEWER\n" | sort -rV | head -
 fi
 
 # Login.
-"$AZUREOIDC_DRIVERS_TOOLS"/.evergreen/csfle/azurekms/login.sh
+"$DRIVERS_TOOLS"/.evergreen/csfle/azurekms/login.sh
 
 # Get the rest of the secrets from the Azure vault.
 python ./azure/handle_secrets.py
 source $AZUREOIDC_ENVPATH
 
 # Create VM.
-. "$AZUREOIDC_DRIVERS_TOOLS"/.evergreen/csfle/azurekms/create-vm.sh
+. "$DRIVERS_TOOLS"/.evergreen/csfle/azurekms/create-vm.sh
 export AZUREOIDC_VMNAME="$AZUREKMS_VMNAME"
 export AZUREKMS_VMNAME="$AZUREOIDC_VMNAME"
 
 # Update expansions and env viles.
 echo "AZUREOIDC_VMNAME: $AZUREOIDC_VMNAME" > testazureoidc-expansions.yml
 echo "export AZUREOIDC_VMNAME=${AZUREOIDC_VMNAME}" >> $AZUREOIDC_ENVPATH
-echo "export AZUREOIDC_DRIVERS_TOOLS=${AZUREOIDC_DRIVERS_TOOLS}" >> $AZUREOIDC_ENVPATH
+echo "export DRIVERS_TOOLS=${DRIVERS_TOOLS}" >> $AZUREOIDC_ENVPATH
 
 # Install dependencies.
-AZUREKMS_SRC="$AZUREOIDC_DRIVERS_TOOLS/.evergreen/csfle/azurekms/remote-scripts/setup-azure-vm.sh" \
+AZUREKMS_SRC="$DRIVERS_TOOLS/.evergreen/csfle/azurekms/remote-scripts/setup-azure-vm.sh" \
 AZUREKMS_DST="./" \
-    "$AZUREOIDC_DRIVERS_TOOLS"/.evergreen/csfle/azurekms/copy-file.sh
+    "$DRIVERS_TOOLS"/.evergreen/csfle/azurekms/copy-file.sh
 AZUREKMS_CMD="./setup-azure-vm.sh" \
-    "$AZUREOIDC_DRIVERS_TOOLS"/.evergreen/csfle/azurekms/run-command.sh
+    "$DRIVERS_TOOLS"/.evergreen/csfle/azurekms/run-command.sh
 
 # Write the env variables file
 AZUREKMS_SRC=$AZUREOIDC_ENVPATH \
 AZUREKMS_DST="./" \
-    "$AZUREOIDC_DRIVERS_TOOLS"/.evergreen/csfle/azurekms/copy-file.sh
+    "$DRIVERS_TOOLS"/.evergreen/csfle/azurekms/copy-file.sh
 
 # Push Drivers Evergreen Tools onto the VM
 TARFILE=/tmp/drivers-evergreen-tools.tgz
-pushd $AZUREOIDC_DRIVERS_TOOLS
+pushd $DRIVERS_TOOLS
 git archive --format=tar.gz -o $TARFILE --prefix=drivers-evergreen-tools/ HEAD
 TARFILE_BASE=$(basename ${TARFILE})
 AZUREKMS_SRC=${TARFILE} \
@@ -88,8 +90,8 @@ popd
 
 # Start mongodb.
 AZUREKMS_CMD="./drivers-evergreen-tools/.evergreen/auth_oidc/azure/start-mongodb.sh" \
-    "$AZUREOIDC_DRIVERS_TOOLS"/.evergreen/csfle/azurekms/run-command.sh
+    "$DRIVERS_TOOLS"/.evergreen/csfle/azurekms/run-command.sh
 
 # Run the self-test
 AZUREKMS_CMD="./drivers-evergreen-tools/.evergreen/auth_oidc/azure/run-test.sh" \
-    "$AZUREOIDC_DRIVERS_TOOLS"/.evergreen/csfle/azurekms/run-command.sh
+    "$DRIVERS_TOOLS"/.evergreen/csfle/azurekms/run-command.sh

--- a/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
+++ b/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
@@ -10,8 +10,8 @@ if [ -z "${AZUREOIDC_VMNAME_PREFIX:-}" ]; then
     exit 1
 fi
 
-DIR=$(dirname ${BASH_SOURCE:-$0})
-. $DIR/../../handle-paths.sh
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+. $SCRIPT_DIR/../../handle-paths.sh
 
 # Set defaults.
 BASE_PATH="$DRIVERS_TOOLS/.evergreen/auth_oidc"

--- a/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
+++ b/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
@@ -10,7 +10,7 @@ if [ -z "${AZUREOIDC_VMNAME_PREFIX:-}" ]; then
     exit 1
 fi
 
-DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DIR=$(dirname ${BASH_SOURCE:-$0})
 . $DIR/../../handle-paths.sh
 
 # Set defaults.

--- a/.evergreen/auth_oidc/azure/delete-vm.sh
+++ b/.evergreen/auth_oidc/azure/delete-vm.sh
@@ -4,9 +4,9 @@ set -o pipefail
 set -o nounset
 
 # Read in the env variables.
-DIR=$(dirname ${BASH_SOURCE:-$0})
-. $DIR/../../handle-paths.sh
-source $DIR/env.sh
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+. $SCRIPT_DIR/../../handle-paths.sh
+source $SCRIPT_DIR/env.sh
 
 export AZUREKMS_VMNAME=$AZUREOIDC_VMNAME
 export AZUREKMS_RESOURCEGROUP=$AZUREOIDC_RESOURCEGROUP

--- a/.evergreen/auth_oidc/azure/delete-vm.sh
+++ b/.evergreen/auth_oidc/azure/delete-vm.sh
@@ -5,9 +5,10 @@ set -o nounset
 
 # Read in the env variables.
 DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+. $DIR/../../handle-paths.sh
 source $DIR/env.sh
 
 export AZUREKMS_VMNAME=$AZUREOIDC_VMNAME
 export AZUREKMS_RESOURCEGROUP=$AZUREOIDC_RESOURCEGROUP
 
-"$AZUREOIDC_DRIVERS_TOOLS"/.evergreen/csfle/azurekms/delete-vm.sh
+"$DRIVERS_TOOLS"/.evergreen/csfle/azurekms/delete-vm.sh

--- a/.evergreen/auth_oidc/azure/delete-vm.sh
+++ b/.evergreen/auth_oidc/azure/delete-vm.sh
@@ -4,7 +4,7 @@ set -o pipefail
 set -o nounset
 
 # Read in the env variables.
-DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DIR=$(dirname ${BASH_SOURCE:-$0})
 . $DIR/../../handle-paths.sh
 source $DIR/env.sh
 

--- a/.evergreen/auth_oidc/azure/delete-vm.sh
+++ b/.evergreen/auth_oidc/azure/delete-vm.sh
@@ -4,7 +4,7 @@ set -o pipefail
 set -o nounset
 
 # Read in the env variables.
-DIR=$(dirname $0)
+DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source $DIR/env.sh
 
 export AZUREKMS_VMNAME=$AZUREOIDC_VMNAME

--- a/.evergreen/auth_oidc/azure/run-driver-test.sh
+++ b/.evergreen/auth_oidc/azure/run-driver-test.sh
@@ -3,8 +3,9 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-AZURE_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-pushd $AZURE_DIR
+DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+. $DIR/../../handle-paths.sh
+pushd $DIR
 
 # Check for inputs.
 if [ -z "${AZUREOIDC_DRIVERS_TAR_FILE:-}" ] || \
@@ -21,19 +22,19 @@ source ./env.sh
 # Set up variables.
 export AZUREKMS_RESOURCEGROUP=$AZUREOIDC_RESOURCEGROUP
 export AZUREKMS_VMNAME=$AZUREOIDC_VMNAME
-export AZUREKMS_PRIVATEKEYPATH=$AZURE_DIR/keyfile
+export AZUREKMS_PRIVATEKEYPATH=$DIR/keyfile
 
 # Set up the remote driver checkout.
 DRIVER_TARFILE_BASE=$(basename ${AZUREOIDC_DRIVERS_TAR_FILE})
 AZUREKMS_SRC=${AZUREOIDC_DRIVERS_TAR_FILE} \
 AZUREKMS_DST="~/" \
-  $AZURE_DIR/../../csfle/azurekms/copy-file.sh
+  $DIR/../../csfle/azurekms/copy-file.sh
 echo "Copying files ... end"
 echo "Untarring file ... begin"
 AZUREKMS_CMD="tar xf ${DRIVER_TARFILE_BASE}" \
-  $AZURE_DIR/../../csfle/azurekms/run-command.sh
+  $DIR/../../csfle/azurekms/run-command.sh
 echo "Untarring file ... end"
 
 # Run the driver test.
 AZUREKMS_CMD="${AZUREOIDC_TEST_CMD}" \
-    $AZURE_DIR/../../csfle/azurekms/run-command.sh
+    $DIR/../../csfle/azurekms/run-command.sh

--- a/.evergreen/auth_oidc/azure/run-driver-test.sh
+++ b/.evergreen/auth_oidc/azure/run-driver-test.sh
@@ -3,7 +3,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DIR=$(dirname ${BASH_SOURCE:-$0})
 . $DIR/../../handle-paths.sh
 pushd $DIR
 

--- a/.evergreen/auth_oidc/azure/run-driver-test.sh
+++ b/.evergreen/auth_oidc/azure/run-driver-test.sh
@@ -3,9 +3,9 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-DIR=$(dirname ${BASH_SOURCE:-$0})
-. $DIR/../../handle-paths.sh
-pushd $DIR
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+. $SCRIPT_DIR/../../handle-paths.sh
+pushd $SCRIPT_DIR
 
 # Check for inputs.
 if [ -z "${AZUREOIDC_DRIVERS_TAR_FILE:-}" ] || \
@@ -22,19 +22,19 @@ source ./env.sh
 # Set up variables.
 export AZUREKMS_RESOURCEGROUP=$AZUREOIDC_RESOURCEGROUP
 export AZUREKMS_VMNAME=$AZUREOIDC_VMNAME
-export AZUREKMS_PRIVATEKEYPATH=$DIR/keyfile
+export AZUREKMS_PRIVATEKEYPATH=$SCRIPT_DIR/keyfile
 
 # Set up the remote driver checkout.
 DRIVER_TARFILE_BASE=$(basename ${AZUREOIDC_DRIVERS_TAR_FILE})
 AZUREKMS_SRC=${AZUREOIDC_DRIVERS_TAR_FILE} \
 AZUREKMS_DST="~/" \
-  $DIR/../../csfle/azurekms/copy-file.sh
+  $SCRIPT_DIR/../../csfle/azurekms/copy-file.sh
 echo "Copying files ... end"
 echo "Untarring file ... begin"
 AZUREKMS_CMD="tar xf ${DRIVER_TARFILE_BASE}" \
-  $DIR/../../csfle/azurekms/run-command.sh
+  $SCRIPT_DIR/../../csfle/azurekms/run-command.sh
 echo "Untarring file ... end"
 
 # Run the driver test.
 AZUREKMS_CMD="${AZUREOIDC_TEST_CMD}" \
-    $DIR/../../csfle/azurekms/run-command.sh
+    $SCRIPT_DIR/../../csfle/azurekms/run-command.sh

--- a/.evergreen/auth_oidc/oidc_get_tokens.sh
+++ b/.evergreen/auth_oidc/oidc_get_tokens.sh
@@ -4,6 +4,7 @@
 #
 set -ex
 DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+. $DIR/../handle-paths.sh
 pushd $DIR
 
 if [ -z "$OIDC_TOKEN_DIR" ]; then

--- a/.evergreen/auth_oidc/oidc_get_tokens.sh
+++ b/.evergreen/auth_oidc/oidc_get_tokens.sh
@@ -3,7 +3,7 @@
 # Get the set of OIDC tokens in the OIDC_TOKEN_DIR.
 #
 set -ex
-DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DIR=$(dirname ${BASH_SOURCE:-$0})
 . $DIR/../handle-paths.sh
 pushd $DIR
 

--- a/.evergreen/auth_oidc/oidc_get_tokens.sh
+++ b/.evergreen/auth_oidc/oidc_get_tokens.sh
@@ -3,9 +3,8 @@
 # Get the set of OIDC tokens in the OIDC_TOKEN_DIR.
 #
 set -ex
-DIR=$(dirname ${BASH_SOURCE:-$0})
-. $DIR/../handle-paths.sh
-pushd $DIR
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+. $SCRIPT_DIR/../handle-paths.sh
 
 if [ -z "$OIDC_TOKEN_DIR" ]; then
     export OIDC_TOKEN_DIR=/tmp/tokens
@@ -15,19 +14,17 @@ if [ "Windows_NT" = "$OS" ]; then
 fi
 mkdir -p $OIDC_TOKEN_DIR
 
+pushd $SCRIPT_DIR
 . ./activate-authoidcvenv.sh
+popd
 
 if [ ! -f "./secrets-export.sh" ]; then
-    AUTH_AWS="$DIR/../auth_aws"
     set -x
     echo "Getting oidc secrets"
-    pushd $AUTH_AWS
-    python ./setup_secrets.py drivers/oidc
-    mv secrets-export.sh $DIR
+    python $SCRIPT_DIR/../auth_aws/setup_secrets.py drivers/oidc
     popd
     echo "Got secrets"
 fi
 
 source ./secrets-export.sh
-python oidc_get_tokens.py
-popd
+python $SCRIPT_DIR/oidc_get_tokens.py

--- a/.evergreen/auth_oidc/oidc_get_tokens.sh
+++ b/.evergreen/auth_oidc/oidc_get_tokens.sh
@@ -22,7 +22,6 @@ if [ ! -f "./secrets-export.sh" ]; then
     set -x
     echo "Getting oidc secrets"
     python $SCRIPT_DIR/../auth_aws/setup_secrets.py drivers/oidc
-    popd
     echo "Got secrets"
 fi
 

--- a/.evergreen/auth_oidc/oidc_get_tokens.sh
+++ b/.evergreen/auth_oidc/oidc_get_tokens.sh
@@ -3,26 +3,26 @@
 # Get the set of OIDC tokens in the OIDC_TOKEN_DIR.
 #
 set -ex
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-pushd $SCRIPT_DIR
+DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+pushd $DIR
 
 if [ -z "$OIDC_TOKEN_DIR" ]; then
-    if [ "Windows_NT" = "$OS" ]; then
-        export OIDC_TOKEN_DIR=C:/Temp/tokens
-    else
-        export OIDC_TOKEN_DIR=/tmp/tokens
-    fi
+    export OIDC_TOKEN_DIR=/tmp/tokens
+fi
+if [ "Windows_NT" = "$OS" ]; then
+    export OIDC_TOKEN_DIR=$(cygpath -m $OIDC_TOKEN_DIR)
 fi
 mkdir -p $OIDC_TOKEN_DIR
+
 . ./activate-authoidcvenv.sh
 
 if [ ! -f "./secrets-export.sh" ]; then
-    AUTH_AWS="$SCRIPT_DIR/../auth_aws"
+    AUTH_AWS="$DIR/../auth_aws"
     set -x
     echo "Getting oidc secrets"
     pushd $AUTH_AWS
     python ./setup_secrets.py drivers/oidc
-    mv secrets-export.sh $SCRIPT_DIR
+    mv secrets-export.sh $DIR
     popd
     echo "Got secrets"
 fi

--- a/.evergreen/auth_oidc/start_local_server.sh
+++ b/.evergreen/auth_oidc/start_local_server.sh
@@ -6,7 +6,8 @@
 #
 set -eux
 
-DRIVERS_TOOLS=${DRIVERS_TOOLS:-$(readlink -f ../..)}
+DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DRIVERS_TOOLS=$(dirname $(dirname $DIR))
 ENTRYPOINT=${ENTRYPOINT:-/root/docker_entry.sh}
 USE_TTY=""
 VOL="-v ${DRIVERS_TOOLS}:/root/drivers-evergreen-tools"

--- a/.evergreen/auth_oidc/start_local_server.sh
+++ b/.evergreen/auth_oidc/start_local_server.sh
@@ -6,7 +6,7 @@
 #
 set -eux
 
-DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DIR=$(dirname ${BASH_SOURCE:-$0})
 . $DIR/../handle-paths.sh
 ENTRYPOINT=${ENTRYPOINT:-/root/docker_entry.sh}
 USE_TTY=""

--- a/.evergreen/auth_oidc/start_local_server.sh
+++ b/.evergreen/auth_oidc/start_local_server.sh
@@ -6,8 +6,8 @@
 #
 set -eux
 
-DIR=$(dirname ${BASH_SOURCE:-$0})
-. $DIR/../handle-paths.sh
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+. $SCRIPT_DIR/../handle-paths.sh
 ENTRYPOINT=${ENTRYPOINT:-/root/docker_entry.sh}
 USE_TTY=""
 VOL="-v ${DRIVERS_TOOLS}:/root/drivers-evergreen-tools"

--- a/.evergreen/auth_oidc/start_local_server.sh
+++ b/.evergreen/auth_oidc/start_local_server.sh
@@ -7,7 +7,7 @@
 set -eux
 
 DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-DRIVERS_TOOLS=$(dirname $(dirname $DIR))
+. $DIR/../handle-paths.sh
 ENTRYPOINT=${ENTRYPOINT:-/root/docker_entry.sh}
 USE_TTY=""
 VOL="-v ${DRIVERS_TOOLS}:/root/drivers-evergreen-tools"

--- a/.evergreen/aws_lambda/run-deployed-lambda-aws-tests.sh
+++ b/.evergreen/aws_lambda/run-deployed-lambda-aws-tests.sh
@@ -30,7 +30,7 @@ for VARNAME in ${VARLIST[*]}; do
 done
 
 # Set up the common variables
-DIR="$(dirname $(dirname "${BASH_SOURCE[0]}"))"
+DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 . $DIR/atlas/setup-variables.sh
 
 # Restarts the cluster's primary node.

--- a/.evergreen/aws_lambda/run-deployed-lambda-aws-tests.sh
+++ b/.evergreen/aws_lambda/run-deployed-lambda-aws-tests.sh
@@ -30,7 +30,7 @@ for VARNAME in ${VARLIST[*]}; do
 done
 
 # Set up the common variables
-DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DIR=$(dirname ${BASH_SOURCE:-$0})
 . $DIR/../handle-paths.sh
 . $DIR/atlas/setup-variables.sh
 

--- a/.evergreen/aws_lambda/run-deployed-lambda-aws-tests.sh
+++ b/.evergreen/aws_lambda/run-deployed-lambda-aws-tests.sh
@@ -31,6 +31,7 @@ done
 
 # Set up the common variables
 DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+. $DIR/../handle-paths.sh
 . $DIR/atlas/setup-variables.sh
 
 # Restarts the cluster's primary node.

--- a/.evergreen/aws_lambda/run-deployed-lambda-aws-tests.sh
+++ b/.evergreen/aws_lambda/run-deployed-lambda-aws-tests.sh
@@ -32,7 +32,7 @@ done
 # Set up the common variables
 DIR=$(dirname ${BASH_SOURCE:-$0})
 . $DIR/../handle-paths.sh
-. $DIR/atlas/setup-variables.sh
+. $DIR/../atlas/setup-variables.sh
 
 # Restarts the cluster's primary node.
 restart_cluster_primary ()

--- a/.evergreen/aws_lambda/run-deployed-lambda-aws-tests.sh
+++ b/.evergreen/aws_lambda/run-deployed-lambda-aws-tests.sh
@@ -30,9 +30,9 @@ for VARNAME in ${VARLIST[*]}; do
 done
 
 # Set up the common variables
-DIR=$(dirname ${BASH_SOURCE:-$0})
-. $DIR/../handle-paths.sh
-. $DIR/../atlas/setup-variables.sh
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+. $SCRIPT_DIR/../handle-paths.sh
+. $SCRIPT_DIR/../atlas/setup-variables.sh
 
 # Restarts the cluster's primary node.
 restart_cluster_primary ()

--- a/.evergreen/compile.sh
+++ b/.evergreen/compile.sh
@@ -2,7 +2,7 @@
 set -o errexit  # Exit the script with error if any of the commands fail
 
 
-DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DIR=$(dirname ${BASH_SOURCE:-$0})
 . $DIR/handle-paths.sh
 
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')

--- a/.evergreen/compile.sh
+++ b/.evergreen/compile.sh
@@ -2,15 +2,15 @@
 set -o errexit  # Exit the script with error if any of the commands fail
 
 
-DIR=$(dirname ${BASH_SOURCE:-$0})
-. $DIR/handle-paths.sh
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+. $SCRIPT_DIR/handle-paths.sh
 
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 BUILDTOOL=${BUILDTOOL:-autotools}
 
 case "$OS" in
    cygwin*)
-      sh $DIR/compile-windows.sh
+      sh $SCRIPT_DIR/compile-windows.sh
    ;;
 
    *)
@@ -19,10 +19,10 @@ case "$OS" in
       # this would be a good place to call the different scripts
       case "$BUILDTOOL" in
          cmake)
-            sh $DIR/compile-unix-cmake.sh
+            sh $SCRIPT_DIR/compile-unix-cmake.sh
          ;;
          autotools)
-            sh $DIR/compile-unix.sh
+            sh $SCRIPT_DIR/compile-unix.sh
          ;;
       esac
    ;;

--- a/.evergreen/compile.sh
+++ b/.evergreen/compile.sh
@@ -3,6 +3,7 @@ set -o errexit  # Exit the script with error if any of the commands fail
 
 
 DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+. $DIR/handle-paths.sh
 
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 BUILDTOOL=${BUILDTOOL:-autotools}

--- a/.evergreen/compile.sh
+++ b/.evergreen/compile.sh
@@ -2,7 +2,7 @@
 set -o errexit  # Exit the script with error if any of the commands fail
 
 
-DIR=$(dirname $0)
+DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 BUILDTOOL=${BUILDTOOL:-autotools}
@@ -26,4 +26,3 @@ case "$OS" in
       esac
    ;;
 esac
-

--- a/.evergreen/csfle/azurekms/create-and-setup-vm.sh
+++ b/.evergreen/csfle/azurekms/create-and-setup-vm.sh
@@ -3,7 +3,8 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-AZUREKMS_DRIVERS_TOOLS=${AZUREKMS_DRIVERS_TOOLS:-$DRIVERS_TOOLS}
+DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DRIVERS_TOOLS=$(dirname $(dirname $(dirname $DIR)))
 
 if [ -n "${AZUREKMS_PUBLICKEY:-}" ]; then
     echo "${AZUREKMS_PUBLICKEY}" > /tmp/testazurekms_publickey
@@ -48,9 +49,9 @@ if [[ "$(printf "$ACTUAL_VERSION\n$EXPECTED_VERSION_NEWER\n" | sort -rV | head -
 fi
 
 # Login.
-"$AZUREKMS_DRIVERS_TOOLS"/.evergreen/csfle/azurekms/login.sh
+"$DRIVERS_TOOLS"/.evergreen/csfle/azurekms/login.sh
 # Create VM.
-. "$AZUREKMS_DRIVERS_TOOLS"/.evergreen/csfle/azurekms/create-vm.sh
+. "$DRIVERS_TOOLS"/.evergreen/csfle/azurekms/create-vm.sh
 export AZUREKMS_VMNAME="$AZUREKMS_VMNAME"
 # Store items needed for teardown.
 cat <<EOT > testazurekms-expansions.yml
@@ -59,16 +60,16 @@ AZUREKMS_RESOURCEGROUP: $AZUREKMS_RESOURCEGROUP
 AZUREKMS_SCOPE: $AZUREKMS_SCOPE
 EOT
 # Assign role.
-"$AZUREKMS_DRIVERS_TOOLS"/.evergreen/csfle/azurekms/assign-role.sh
+"$DRIVERS_TOOLS"/.evergreen/csfle/azurekms/assign-role.sh
 # Install dependencies.
-AZUREKMS_SRC="$AZUREKMS_DRIVERS_TOOLS/.evergreen/csfle/azurekms/remote-scripts/setup-azure-vm.sh" \
+AZUREKMS_SRC="$DRIVERS_TOOLS/.evergreen/csfle/azurekms/remote-scripts/setup-azure-vm.sh" \
 AZUREKMS_DST="./" \
-    "$AZUREKMS_DRIVERS_TOOLS"/.evergreen/csfle/azurekms/copy-file.sh
+    "$DRIVERS_TOOLS"/.evergreen/csfle/azurekms/copy-file.sh
 AZUREKMS_CMD="./setup-azure-vm.sh" \
-    "$AZUREKMS_DRIVERS_TOOLS"/.evergreen/csfle/azurekms/run-command.sh
+    "$DRIVERS_TOOLS"/.evergreen/csfle/azurekms/run-command.sh
 # Start mongodb.
-AZUREKMS_SRC="$AZUREKMS_DRIVERS_TOOLS/.evergreen/csfle/azurekms/remote-scripts/start-mongodb.sh" \
+AZUREKMS_SRC="$DRIVERS_TOOLS/.evergreen/csfle/azurekms/remote-scripts/start-mongodb.sh" \
 AZUREKMS_DST="./" \
-    "$AZUREKMS_DRIVERS_TOOLS"/.evergreen/csfle/azurekms/copy-file.sh
+    "$DRIVERS_TOOLS"/.evergreen/csfle/azurekms/copy-file.sh
 AZUREKMS_CMD="./start-mongodb.sh" \
-    "$AZUREKMS_DRIVERS_TOOLS"/.evergreen/csfle/azurekms/run-command.sh
+    "$DRIVERS_TOOLS"/.evergreen/csfle/azurekms/run-command.sh

--- a/.evergreen/csfle/azurekms/create-and-setup-vm.sh
+++ b/.evergreen/csfle/azurekms/create-and-setup-vm.sh
@@ -3,8 +3,8 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-DIR=$(dirname ${BASH_SOURCE:-$0})
-. $DIR/../../handle-paths.sh
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+. $SCRIPT_DIR/../../handle-paths.sh
 
 if [ -n "${AZUREKMS_PUBLICKEY:-}" ]; then
     echo "${AZUREKMS_PUBLICKEY}" > /tmp/testazurekms_publickey

--- a/.evergreen/csfle/azurekms/create-and-setup-vm.sh
+++ b/.evergreen/csfle/azurekms/create-and-setup-vm.sh
@@ -4,7 +4,7 @@ set -o pipefail
 set -o nounset
 
 DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-DRIVERS_TOOLS=$(dirname $(dirname $(dirname $DIR)))
+. $DIR/../../handle-paths.sh
 
 if [ -n "${AZUREKMS_PUBLICKEY:-}" ]; then
     echo "${AZUREKMS_PUBLICKEY}" > /tmp/testazurekms_publickey

--- a/.evergreen/csfle/azurekms/create-and-setup-vm.sh
+++ b/.evergreen/csfle/azurekms/create-and-setup-vm.sh
@@ -3,7 +3,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DIR=$(dirname ${BASH_SOURCE:-$0})
 . $DIR/../../handle-paths.sh
 
 if [ -n "${AZUREKMS_PUBLICKEY:-}" ]; then

--- a/.evergreen/csfle/gcpkms/create-and-setup-instance.sh
+++ b/.evergreen/csfle/gcpkms/create-and-setup-instance.sh
@@ -3,7 +3,7 @@
 set -o errexit # Exit on first command error.
 
 DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-DRIVERS_TOOLS=$(dirname $(dirname $(dirname $DIR)))
+. $DIR/../../handle-paths.sh
 
 if [ -z "$GCPKMS_KEYFILE" -o -z "$GCPKMS_SERVICEACCOUNT" ]; then
     echo "Please set the following required environment variables"

--- a/.evergreen/csfle/gcpkms/create-and-setup-instance.sh
+++ b/.evergreen/csfle/gcpkms/create-and-setup-instance.sh
@@ -1,10 +1,13 @@
 # Create and setup a GCE instance.
 # On success, creates testgcpkms-expansions.yml expansions 
 set -o errexit # Exit on first command error.
-if [ -z "$GCPKMS_KEYFILE" -o -z "$GCPKMS_DRIVERS_TOOLS" -o -z "$GCPKMS_SERVICEACCOUNT" ]; then
+
+DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DRIVERS_TOOLS=$(dirname $(dirname $(dirname $DIR)))
+
+if [ -z "$GCPKMS_KEYFILE" -o -z "$GCPKMS_SERVICEACCOUNT" ]; then
     echo "Please set the following required environment variables"
     echo " GCPKMS_KEYFILE to the JSON file for the service account"
-    echo " GCPKMS_DRIVERS_TOOLS to the path of the drivers-evergreen-tools directory"
     echo " GCPKMS_SERVICEACCOUNT to a GCP service account used to create and attach to the GCE instance"
     exit 1
 fi
@@ -19,14 +22,14 @@ export GCPKMS_DISKSIZE=${GCPKMS_DISKSIZE:-"20gb"}
 
 # download-gcloud.sh sets GCPKMS_GCLOUD.
 echo "download-gcloud.sh ... begin"
-. $GCPKMS_DRIVERS_TOOLS/.evergreen/csfle/gcpkms/download-gcloud.sh
+. $DRIVERS_TOOLS/.evergreen/csfle/gcpkms/download-gcloud.sh
 echo "download-gcloud.sh ... end"
 
 $GCPKMS_GCLOUD auth activate-service-account --key-file $GCPKMS_KEYFILE
 
 # create-instance.sh sets INSTANCENAME.
 echo "create-instance.sh ... begin"
-. $GCPKMS_DRIVERS_TOOLS/.evergreen/csfle/gcpkms/create-instance.sh
+. $DRIVERS_TOOLS/.evergreen/csfle/gcpkms/create-instance.sh
 echo "create-instance.sh ... end"
 
 # Echo expansions required for delete-instance.sh. If the remaining setup fails, delete-instance.sh can still clean up resources.
@@ -61,6 +64,5 @@ $GCPKMS_GCLOUD compute os-login ssh-keys update --key-file ~/.ssh/google_compute
 echo "Adding expiration time to SSH key ... end"
 
 echo "setup-instance.sh ... begin"
-. $GCPKMS_DRIVERS_TOOLS/.evergreen/csfle/gcpkms/setup-instance.sh
+. $DRIVERS_TOOLS/.evergreen/csfle/gcpkms/setup-instance.sh
 echo "setup-instance.sh ... end"
-

--- a/.evergreen/csfle/gcpkms/create-and-setup-instance.sh
+++ b/.evergreen/csfle/gcpkms/create-and-setup-instance.sh
@@ -2,7 +2,7 @@
 # On success, creates testgcpkms-expansions.yml expansions 
 set -o errexit # Exit on first command error.
 
-DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DIR=$(dirname ${BASH_SOURCE:-$0})
 . $DIR/../../handle-paths.sh
 
 if [ -z "$GCPKMS_KEYFILE" -o -z "$GCPKMS_SERVICEACCOUNT" ]; then

--- a/.evergreen/csfle/gcpkms/create-and-setup-instance.sh
+++ b/.evergreen/csfle/gcpkms/create-and-setup-instance.sh
@@ -2,8 +2,8 @@
 # On success, creates testgcpkms-expansions.yml expansions 
 set -o errexit # Exit on first command error.
 
-DIR=$(dirname ${BASH_SOURCE:-$0})
-. $DIR/../../handle-paths.sh
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+. $SCRIPT_DIR/../../handle-paths.sh
 
 if [ -z "$GCPKMS_KEYFILE" -o -z "$GCPKMS_SERVICEACCOUNT" ]; then
     echo "Please set the following required environment variables"

--- a/.evergreen/csfle/gcpkms/create-instance.sh
+++ b/.evergreen/csfle/gcpkms/create-instance.sh
@@ -1,7 +1,6 @@
 # Create a GCE instance.
 set -o errexit # Exit on first command error.
-if [ -z "$GCPKMS_DRIVERS_TOOLS" -o \
-     -z "$GCPKMS_GCLOUD" -o \
+if [ -z "$GCPKMS_GCLOUD" -o \
      -z "$GCPKMS_PROJECT" -o \
      -z "$GCPKMS_ZONE" -o \
      -z "$GCPKMS_SERVICEACCOUNT" -o \
@@ -10,7 +9,6 @@ if [ -z "$GCPKMS_DRIVERS_TOOLS" -o \
      -z "$GCPKMS_MACHINETYPE" -o \
      -z "$GCPKMS_DISKSIZE" ]; then
     echo "Please set the following required environment variables"
-    echo " GCPKMS_DRIVERS_TOOLS to the path of the drivers-evergreen-tools directory"
     echo " GCPKMS_GCLOUD to the path of the gcloud binary"
     echo " GCPKMS_PROJECT to the GCP project"
     echo " GCPKMS_ZONE to the GCP zone"
@@ -22,6 +20,9 @@ if [ -z "$GCPKMS_DRIVERS_TOOLS" -o \
     exit 1
 fi
 GCPKMS_INSTANCENAME="instancename-$RANDOM"
+
+DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DRIVERS_TOOLS=$(dirname $(dirname $(dirname $DIR)))
 
 # Create GCE instance.
 echo "Creating GCE instance ($GCPKMS_INSTANCENAME) ... begin"
@@ -36,7 +37,7 @@ $GCPKMS_GCLOUD compute instances create $GCPKMS_INSTANCENAME \
     --service-account $GCPKMS_SERVICEACCOUNT \
     --image-project $GCPKMS_IMAGEPROJECT \
     --image-family $GCPKMS_IMAGEFAMILY \
-    --metadata-from-file=startup-script=$GCPKMS_DRIVERS_TOOLS/.evergreen/csfle/gcpkms/remote-scripts/startup.sh \
+    --metadata-from-file=startup-script=$DRIVERS_TOOLS/.evergreen/csfle/gcpkms/remote-scripts/startup.sh \
     --scopes https://www.googleapis.com/auth/cloudkms,https://www.googleapis.com/auth/compute \
     --metadata enable-oslogin=TRUE \
     --boot-disk-size $GCPKMS_DISKSIZE

--- a/.evergreen/csfle/gcpkms/create-instance.sh
+++ b/.evergreen/csfle/gcpkms/create-instance.sh
@@ -21,8 +21,8 @@ if [ -z "$GCPKMS_GCLOUD" -o \
 fi
 GCPKMS_INSTANCENAME="instancename-$RANDOM"
 
-DIR=$(dirname ${BASH_SOURCE:-$0})
-. $DIR/../../handle-paths.sh
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+. $SCRIPT_DIR/../../handle-paths.sh
 
 # Create GCE instance.
 echo "Creating GCE instance ($GCPKMS_INSTANCENAME) ... begin"

--- a/.evergreen/csfle/gcpkms/create-instance.sh
+++ b/.evergreen/csfle/gcpkms/create-instance.sh
@@ -21,7 +21,7 @@ if [ -z "$GCPKMS_GCLOUD" -o \
 fi
 GCPKMS_INSTANCENAME="instancename-$RANDOM"
 
-DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DIR=$(dirname ${BASH_SOURCE:-$0})
 . $DIR/../../handle-paths.sh
 
 # Create GCE instance.

--- a/.evergreen/csfle/gcpkms/create-instance.sh
+++ b/.evergreen/csfle/gcpkms/create-instance.sh
@@ -22,7 +22,7 @@ fi
 GCPKMS_INSTANCENAME="instancename-$RANDOM"
 
 DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-DRIVERS_TOOLS=$(dirname $(dirname $(dirname $DIR)))
+. $DIR/../../handle-paths.sh
 
 # Create GCE instance.
 echo "Creating GCE instance ($GCPKMS_INSTANCENAME) ... begin"

--- a/.evergreen/csfle/gcpkms/setup-instance.sh
+++ b/.evergreen/csfle/gcpkms/setup-instance.sh
@@ -1,8 +1,11 @@
 # Setup a GCE instance.
 set -o errexit # Exit on first command error.
-if [ -z "$GCPKMS_DRIVERS_TOOLS" -o -z "$GCPKMS_GCLOUD" -o -z "$GCPKMS_PROJECT" -o -z "$GCPKMS_ZONE" -o -z "$GCPKMS_INSTANCENAME" ]; then
+
+DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DRIVERS_TOOLS=$(dirname $(dirname $(dirname $DIR)))
+
+if [-z "$GCPKMS_GCLOUD" -o -z "$GCPKMS_PROJECT" -o -z "$GCPKMS_ZONE" -o -z "$GCPKMS_INSTANCENAME" ]; then
     echo "Please set the following required environment variables"
-    echo " GCPKMS_DRIVERS_TOOLS to the path of the drivers-evergreen-tools directory"
     echo " GCPKMS_GCLOUD to the path of the gcloud binary"
     echo " GCPKMS_PROJECT to the GCP project"
     echo " GCPKMS_ZONE to the GCP zone"
@@ -12,7 +15,7 @@ fi
 
 echo "Copying setup-gce-instance.sh to GCE instance ($GCPKMS_INSTANCENAME) ... begin"
 # Copy files to test. Use "-p" to preserve execute mode.
-$GCPKMS_GCLOUD compute scp $GCPKMS_DRIVERS_TOOLS/.evergreen/csfle/gcpkms/remote-scripts/setup-gce-instance.sh "$GCPKMS_INSTANCENAME":~ \
+$GCPKMS_GCLOUD compute scp $DRIVERS_TOOLS/.evergreen/csfle/gcpkms/remote-scripts/setup-gce-instance.sh "$GCPKMS_INSTANCENAME":~ \
     --zone $GCPKMS_ZONE \
     --project $GCPKMS_PROJECT \
     --scp-flag="-p"

--- a/.evergreen/csfle/gcpkms/setup-instance.sh
+++ b/.evergreen/csfle/gcpkms/setup-instance.sh
@@ -1,8 +1,8 @@
 # Setup a GCE instance.
 set -o errexit # Exit on first command error.
 
-DIR=$(dirname ${BASH_SOURCE:-$0})
-. $DIR/../../handle-paths.sh
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+. $SCRIPT_DIR/../../handle-paths.sh
 
 if [-z "$GCPKMS_GCLOUD" -o -z "$GCPKMS_PROJECT" -o -z "$GCPKMS_ZONE" -o -z "$GCPKMS_INSTANCENAME" ]; then
     echo "Please set the following required environment variables"

--- a/.evergreen/csfle/gcpkms/setup-instance.sh
+++ b/.evergreen/csfle/gcpkms/setup-instance.sh
@@ -1,7 +1,7 @@
 # Setup a GCE instance.
 set -o errexit # Exit on first command error.
 
-DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DIR=$(dirname ${BASH_SOURCE:-$0})
 . $DIR/../../handle-paths.sh
 
 if [-z "$GCPKMS_GCLOUD" -o -z "$GCPKMS_PROJECT" -o -z "$GCPKMS_ZONE" -o -z "$GCPKMS_INSTANCENAME" ]; then

--- a/.evergreen/csfle/gcpkms/setup-instance.sh
+++ b/.evergreen/csfle/gcpkms/setup-instance.sh
@@ -2,7 +2,7 @@
 set -o errexit # Exit on first command error.
 
 DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-DRIVERS_TOOLS=$(dirname $(dirname $(dirname $DIR)))
+. $DIR/../../handle-paths.sh
 
 if [-z "$GCPKMS_GCLOUD" -o -z "$GCPKMS_PROJECT" -o -z "$GCPKMS_ZONE" -o -z "$GCPKMS_INSTANCENAME" ]; then
     echo "Please set the following required environment variables"

--- a/.evergreen/docker/run-server.sh
+++ b/.evergreen/docker/run-server.sh
@@ -4,8 +4,8 @@
 #
 set -eu
 
-DIR=$(dirname ${BASH_SOURCE:-$0})
-. $DIR/../handle-paths.sh
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+. $SCRIPT_DIR/../handle-paths.sh
 NAME=drivers-evergreen-tools
 ENTRYPOINT=${ENTRYPOINT:-/root/local-entrypoint.sh}
 IMAGE=${TARGET_IMAGE:-ubuntu20.04}
@@ -16,7 +16,7 @@ docker build $PLATFORM -t $NAME $IMAGE
 pushd $DRIVERS_TOOLS
 
 # Remove existing mongodb files
-rm -rf $DIR/$IMAGE/mongodb
+rm -rf $SCRIPT_DIR/$IMAGE/mongodb
 
 # Handle environment variables.
 AUTH=${AUTH:-noauth}

--- a/.evergreen/docker/run-server.sh
+++ b/.evergreen/docker/run-server.sh
@@ -4,7 +4,7 @@
 #
 set -eu
 
-DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DIR=$(dirname ${BASH_SOURCE:-$0})
 . $DIR/../handle-paths.sh
 NAME=drivers-evergreen-tools
 ENTRYPOINT=${ENTRYPOINT:-/root/local-entrypoint.sh}

--- a/.evergreen/docker/run-server.sh
+++ b/.evergreen/docker/run-server.sh
@@ -13,7 +13,7 @@ PLATFORM=${DOCKER_PLATFORM:-}
 # e.g. --platform linux/amd64
 
 docker build $PLATFORM -t $NAME $IMAGE
-pushd $DRIVER_TOOLS
+pushd $DRIVERS_TOOLS
 
 # Remove existing mongodb files
 rm -rf $DIR/$IMAGE/mongodb

--- a/.evergreen/docker/run-server.sh
+++ b/.evergreen/docker/run-server.sh
@@ -5,7 +5,7 @@
 set -eu
 
 DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-DRIVERS_TOOLS=$(dirname $(dirname $DIR))
+. $DIR/../handle-paths.sh
 NAME=drivers-evergreen-tools
 ENTRYPOINT=${ENTRYPOINT:-/root/local-entrypoint.sh}
 IMAGE=${TARGET_IMAGE:-ubuntu20.04}

--- a/.evergreen/docker/run-server.sh
+++ b/.evergreen/docker/run-server.sh
@@ -4,7 +4,8 @@
 #
 set -eu
 
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DRIVERS_TOOLS=$(dirname $(dirname $DIR))
 NAME=drivers-evergreen-tools
 ENTRYPOINT=${ENTRYPOINT:-/root/local-entrypoint.sh}
 IMAGE=${TARGET_IMAGE:-ubuntu20.04}
@@ -12,10 +13,10 @@ PLATFORM=${DOCKER_PLATFORM:-}
 # e.g. --platform linux/amd64
 
 docker build $PLATFORM -t $NAME $IMAGE
-cd $SCRIPT_DIR/../..
+pushd $DRIVER_TOOLS
 
 # Remove existing mongodb files
-rm -rf $SCRIPT_DIR/$IMAGE/mongodb
+rm -rf $DIR/$IMAGE/mongodb
 
 # Handle environment variables.
 AUTH=${AUTH:-noauth}
@@ -59,3 +60,5 @@ ARGS+=" -v `pwd`:/root/drivers-evergreen-tools"
 
 # Launch server docker container.
 docker run $ARGS $NAME $ENTRYPOINT
+
+popd

--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -681,7 +681,7 @@ download_and_extract_package ()
       cd $MONGODB_BINARY_ROOT
    else
       DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-      DRIVERS_TOOLS=$(dirname $(dirname $DIR))
+      . $DIR/handle-paths.sh
       cd $DRIVERS_TOOLS
    fi
    echo "Installing server binaries..."
@@ -707,7 +707,7 @@ download_and_extract_mongosh ()
       cd $MONGODB_BINARY_ROOT
    else
       DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-      DRIVERS_TOOLS=$(dirname $(dirname $DIR))
+      . $DIR/handle-paths.sh
       cd $DRIVERS_TOOLS
    fi
    echo "Installing MongoDB shell..."
@@ -740,7 +740,7 @@ download_and_extract ()
    fi
 
    DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-   DRIVERS_TOOLS=$(dirname $(dirname $DIR))
+   . $DIR/handle-paths.sh
 
    if [ ! -z "${INSTALL_LEGACY_SHELL:-}" -a ! -e $DRIVERS_TOOLS/mongodb/bin/mongo -a ! -e $DRIVERS_TOOLS/mongodb/bin/mongo.exe ]; then
       # The legacy mongo shell is not included in server downloads of 6.0.0-rc6 or later. Refer: SERVER-64352.

--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -680,6 +680,8 @@ download_and_extract_package ()
    if [ -n "$MONGODB_BINARY_ROOT" ]; then
       cd $MONGODB_BINARY_ROOT
    else
+      DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+      DRIVERS_TOOLS=$(dirname $(dirname $DIR))
       cd $DRIVERS_TOOLS
    fi
    echo "Installing server binaries..."
@@ -704,6 +706,8 @@ download_and_extract_mongosh ()
    if [ -n "$MONGODB_BINARY_ROOT" ]; then
       cd $MONGODB_BINARY_ROOT
    else
+      DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+      DRIVERS_TOOLS=$(dirname $(dirname $DIR))
       cd $DRIVERS_TOOLS
    fi
    echo "Installing MongoDB shell..."
@@ -734,6 +738,9 @@ download_and_extract ()
    if [ "$MONGOSH_DOWNLOAD_URL" ]; then
       download_and_extract_mongosh "$MONGOSH_DOWNLOAD_URL" "$EXTRACT_MONGOSH"
    fi
+
+   DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+   DRIVERS_TOOLS=$(dirname $(dirname $DIR))
 
    if [ ! -z "${INSTALL_LEGACY_SHELL:-}" -a ! -e $DRIVERS_TOOLS/mongodb/bin/mongo -a ! -e $DRIVERS_TOOLS/mongodb/bin/mongo.exe ]; then
       # The legacy mongo shell is not included in server downloads of 6.0.0-rc6 or later. Refer: SERVER-64352.

--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -680,7 +680,7 @@ download_and_extract_package ()
    if [ -n "$MONGODB_BINARY_ROOT" ]; then
       cd $MONGODB_BINARY_ROOT
    else
-      SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+      SCRIPT_DIR=$(dirname ${BASH_SOURCE:-$0})
       . $SCRIPT_DIR/handle-paths.sh
       cd $DRIVERS_TOOLS
    fi
@@ -706,7 +706,7 @@ download_and_extract_mongosh ()
    if [ -n "$MONGODB_BINARY_ROOT" ]; then
       cd $MONGODB_BINARY_ROOT
    else
-      SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+      SCRIPT_DIR=$(dirname ${BASH_SOURCE:-$0})
       . $SCRIPT_DIR/handle-paths.sh
       cd $DRIVERS_TOOLS
    fi
@@ -739,7 +739,7 @@ download_and_extract ()
       download_and_extract_mongosh "$MONGOSH_DOWNLOAD_URL" "$EXTRACT_MONGOSH"
    fi
 
-   SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+   SCRIPT_DIR=$(dirname ${BASH_SOURCE:-$0})
    . $SCRIPT_DIR/handle-paths.sh
 
    if [ ! -z "${INSTALL_LEGACY_SHELL:-}" -a ! -e $DRIVERS_TOOLS/mongodb/bin/mongo -a ! -e $DRIVERS_TOOLS/mongodb/bin/mongo.exe ]; then

--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -680,8 +680,8 @@ download_and_extract_package ()
    if [ -n "$MONGODB_BINARY_ROOT" ]; then
       cd $MONGODB_BINARY_ROOT
    else
-      DIR=$(dirname ${BASH_SOURCE:-$0})
-      . $DIR/handle-paths.sh
+      SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+      . $SCRIPT_DIR/handle-paths.sh
       cd $DRIVERS_TOOLS
    fi
    echo "Installing server binaries..."
@@ -706,8 +706,8 @@ download_and_extract_mongosh ()
    if [ -n "$MONGODB_BINARY_ROOT" ]; then
       cd $MONGODB_BINARY_ROOT
    else
-      DIR=$(dirname ${BASH_SOURCE:-$0})
-      . $DIR/handle-paths.sh
+      SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+      . $SCRIPT_DIR/handle-paths.sh
       cd $DRIVERS_TOOLS
    fi
    echo "Installing MongoDB shell..."
@@ -739,8 +739,8 @@ download_and_extract ()
       download_and_extract_mongosh "$MONGOSH_DOWNLOAD_URL" "$EXTRACT_MONGOSH"
    fi
 
-   DIR=$(dirname ${BASH_SOURCE:-$0})
-   . $DIR/handle-paths.sh
+   SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+   . $SCRIPT_DIR/handle-paths.sh
 
    if [ ! -z "${INSTALL_LEGACY_SHELL:-}" -a ! -e $DRIVERS_TOOLS/mongodb/bin/mongo -a ! -e $DRIVERS_TOOLS/mongodb/bin/mongo.exe ]; then
       # The legacy mongo shell is not included in server downloads of 6.0.0-rc6 or later. Refer: SERVER-64352.

--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -680,7 +680,7 @@ download_and_extract_package ()
    if [ -n "$MONGODB_BINARY_ROOT" ]; then
       cd $MONGODB_BINARY_ROOT
    else
-      DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+      DIR=$(dirname ${BASH_SOURCE:-$0})
       . $DIR/handle-paths.sh
       cd $DRIVERS_TOOLS
    fi
@@ -706,7 +706,7 @@ download_and_extract_mongosh ()
    if [ -n "$MONGODB_BINARY_ROOT" ]; then
       cd $MONGODB_BINARY_ROOT
    else
-      DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+      DIR=$(dirname ${BASH_SOURCE:-$0})
       . $DIR/handle-paths.sh
       cd $DRIVERS_TOOLS
    fi
@@ -739,7 +739,7 @@ download_and_extract ()
       download_and_extract_mongosh "$MONGOSH_DOWNLOAD_URL" "$EXTRACT_MONGOSH"
    fi
 
-   DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+   DIR=$(dirname ${BASH_SOURCE:-$0})
    . $DIR/handle-paths.sh
 
    if [ ! -z "${INSTALL_LEGACY_SHELL:-}" -a ! -e $DRIVERS_TOOLS/mongodb/bin/mongo -a ! -e $DRIVERS_TOOLS/mongodb/bin/mongo.exe ]; then

--- a/.evergreen/github_app/create_or_modify_comment.sh
+++ b/.evergreen/github_app/create_or_modify_comment.sh
@@ -3,6 +3,7 @@ set -o errexit  # Exit the script with error if any of the commands fail
 set -x
 
 DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+. $DIR/../handle-paths.sh
 pushd $DIR
 
 # Bootstrap the secrets.

--- a/.evergreen/github_app/create_or_modify_comment.sh
+++ b/.evergreen/github_app/create_or_modify_comment.sh
@@ -2,17 +2,17 @@
 set -o errexit  # Exit the script with error if any of the commands fail
 set -x
 
-DIR=$(dirname ${BASH_SOURCE:-$0})
-. $DIR/../handle-paths.sh
-pushd $DIR
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+. $SCRIPT_DIR/../handle-paths.sh
+pushd $SCRIPT_DIR
 
 # Bootstrap the secrets.
-bash $DIR/../auth_aws/setup_secrets.sh drivers/comment-bot
+bash $SCRIPT_DIR/../auth_aws/setup_secrets.sh drivers/comment-bot
 source secrets-export.sh
 
 # Install node and activate it.
-bash $DIR/../install-node.sh
-source $DIR/../init-node-and-npm-env.sh
+bash $SCRIPT_DIR/../install-node.sh
+source $SCRIPT_DIR/../init-node-and-npm-env.sh
 
 # Install and run the app.
 set -x

--- a/.evergreen/github_app/create_or_modify_comment.sh
+++ b/.evergreen/github_app/create_or_modify_comment.sh
@@ -2,7 +2,7 @@
 set -o errexit  # Exit the script with error if any of the commands fail
 set -x
 
-DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DIR=$(dirname ${BASH_SOURCE:-$0})
 . $DIR/../handle-paths.sh
 pushd $DIR
 

--- a/.evergreen/github_app/create_or_modify_comment.sh
+++ b/.evergreen/github_app/create_or_modify_comment.sh
@@ -2,7 +2,7 @@
 set -o errexit  # Exit the script with error if any of the commands fail
 set -x
 
-DIR="$(dirname "${BASH_SOURCE[0]}")"
+DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 pushd $DIR
 
 # Bootstrap the secrets.

--- a/.evergreen/handle-paths.sh
+++ b/.evergreen/handle-paths.sh
@@ -6,6 +6,9 @@
 #
 # DIR=$(dirname ${BASH_SOURCE:-$0})
 # . $DIR/../handle-path.sh
+#
+# See https://stackoverflow.com/questions/35006457/choosing-between-0-and-bash-source/35006505#35006505
+# for more background.
 
 set -o errexit  # Exit the script with error if any of the commands fail
 

--- a/.evergreen/handle-paths.sh
+++ b/.evergreen/handle-paths.sh
@@ -1,18 +1,20 @@
 #!/bin/sh
 #
-# This script will handle the correct cross-platform paths for a script
-# directory and DRIVERS_TOOLS.  It is meant to be called as
-# ". $DIR/../handle-paths.sh", if called from one of the top level
-# folders in this directory.  It handles "DIR" and finds the correct
-# "DRIVERS_TOOLS".
+# This script will handle the correct cross-platform absolute
+# paths for a script directory and DRIVERS_TOOLS.  
+# It is meant to be invoked as follows:
 #
-# This script expects the following environment variables:
-#
-# DIR - the absolute directory of the source script, found using
-#   "$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+# DIR=$(dirname ${BASH_SOURCE:-$0})
+# . $DIR/../handle-path.sh
 
 set -o errexit  # Exit the script with error if any of the commands fail
 
+if [ -z "$DIR" ]; then 
+  echo "Please set $DIR first"
+  exit 1
+fi
+
+DIR="$( cd -- "$DIR" &> /dev/null && pwd )"
 if [ "Windows_NT" = "${OS:-}" ]; then # Magic variable in cygwin
   DIR=$(cygdrive -m $DIR)
 fi

--- a/.evergreen/handle-paths.sh
+++ b/.evergreen/handle-paths.sh
@@ -19,7 +19,7 @@ then
     DIR=$(realpath $DIR)
 else 
   DIR="$( cd -- "$DIR" &> /dev/null && pwd )"
-fi
+
 if [ "Windows_NT" = "${OS:-}" ]; then # Magic variable in cygwin
   DIR=$(cygpath -m $DIR)
 fi
@@ -27,11 +27,12 @@ fi
 # Find the DRIVERS_TOOLS by walking up the folder tree until there
 # is a .evergreen folder in the same directory.
 if [ -z "${DRIVERS_TOOLS:-}" ]; then
-  DRIVER_TOOLS=$(dirname $DIR)
+  DRIVERS_TOOLS=$(dirname $DIR)
   while 1
   do
     if [ -d "$DRIVERS_TOOLS/.evergreen" ]; then 
       break 
     fi
+    DRIVERS_TOOLS=$(dirname $DRIVERS_TOOLS)
   done
 fi

--- a/.evergreen/handle-paths.sh
+++ b/.evergreen/handle-paths.sh
@@ -28,7 +28,7 @@ fi
 # is a .evergreen folder in the same directory.
 if [ -z "${DRIVERS_TOOLS:-}" ]; then
   DRIVERS_TOOLS=$(dirname $SCRIPT_DIR)
-  while 1
+  while true
   do
     if [ -d "$DRIVERS_TOOLS/.evergreen" ]; then 
       break 

--- a/.evergreen/handle-paths.sh
+++ b/.evergreen/handle-paths.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+#
+# This script will handle the correct cross-platform paths for a script
+# directory and DRIVERS_TOOLS.  It is meant to be called as
+# ". $DIR/../handle-paths.sh", if called from one of the top level
+# folders in this directory.  It handles "DIR" and finds the correct
+# "DRIVERS_TOOLS".
+#
+# This script expects the following environment variables:
+#
+# DIR - the absolute directory of the source script, found using
+#   "$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+set -o errexit  # Exit the script with error if any of the commands fail
+
+if [ "Windows_NT" = "${OS:-}" ]; then # Magic variable in cygwin
+  DIR=$(cygdrive -m $DIR)
+fi
+
+# Find the DRIVERS_TOOLS by walking up the folder tree until there
+# is a .evergreen folder in the same directory.
+if [ -z "${DRIVERS_TOOLS:-}" ]; then
+  DRIVER_TOOLS=$(dirname $DIR)
+  while 1
+  do
+    if [ -d "$DRIVERS_TOOLS/.evergreen" ]; then 
+      break 
+    fi
+  done
+fi

--- a/.evergreen/handle-paths.sh
+++ b/.evergreen/handle-paths.sh
@@ -14,7 +14,12 @@ if [ -z "$DIR" ]; then
   exit 1
 fi
 
-DIR="$( cd -- "$DIR" &> /dev/null && pwd )"
+if command -v realpath &> /dev/null
+then
+    DIR=$(realpath $DIR)
+else 
+  DIR="$( cd -- "$DIR" &> /dev/null && pwd )"
+fi
 if [ "Windows_NT" = "${OS:-}" ]; then # Magic variable in cygwin
   DIR=$(cygpath -m $DIR)
 fi

--- a/.evergreen/handle-paths.sh
+++ b/.evergreen/handle-paths.sh
@@ -4,33 +4,30 @@
 # paths for a script directory and DRIVERS_TOOLS.  
 # It is meant to be invoked as follows:
 #
-# DIR=$(dirname ${BASH_SOURCE:-$0})
-# . $DIR/../handle-path.sh
-#
-# See https://stackoverflow.com/questions/35006457/choosing-between-0-and-bash-source/35006505#35006505
-# for more background.
+# SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+# . $SCRIPT_DIR/../handle-path.sh
 
 set -o errexit  # Exit the script with error if any of the commands fail
 
-if [ -z "$DIR" ]; then 
-  echo "Please set $DIR first"
+if [ -z "$SCRIPT_DIR" ]; then 
+  echo "Please set $SCRIPT_DIR first"
   exit 1
 fi
 
 if command -v realpath &> /dev/null
 then
-    DIR=$(realpath $DIR)
+    SCRIPT_DIR=$(realpath $SCRIPT_DIR)
 else 
-  DIR="$( cd -- "$DIR" &> /dev/null && pwd )"
+  SCRIPT_DIR="$( cd -- "$SCRIPT_DIR" &> /dev/null && pwd )"
 fi
 if [ "Windows_NT" = "${OS:-}" ]; then # Magic variable in cygwin
-  DIR=$(cygpath -m $DIR)
+  SCRIPT_DIR=$(cygpath -m $SCRIPT_DIR)
 fi
 
 # Find the DRIVERS_TOOLS by walking up the folder tree until there
 # is a .evergreen folder in the same directory.
 if [ -z "${DRIVERS_TOOLS:-}" ]; then
-  DRIVERS_TOOLS=$(dirname $DIR)
+  DRIVERS_TOOLS=$(dirname $SCRIPT_DIR)
   while 1
   do
     if [ -d "$DRIVERS_TOOLS/.evergreen" ]; then 

--- a/.evergreen/handle-paths.sh
+++ b/.evergreen/handle-paths.sh
@@ -19,7 +19,7 @@ then
     DIR=$(realpath $DIR)
 else 
   DIR="$( cd -- "$DIR" &> /dev/null && pwd )"
-
+fi
 if [ "Windows_NT" = "${OS:-}" ]; then # Magic variable in cygwin
   DIR=$(cygpath -m $DIR)
 fi

--- a/.evergreen/handle-paths.sh
+++ b/.evergreen/handle-paths.sh
@@ -16,7 +16,7 @@ fi
 
 DIR="$( cd -- "$DIR" &> /dev/null && pwd )"
 if [ "Windows_NT" = "${OS:-}" ]; then # Magic variable in cygwin
-  DIR=$(cygdrive -m $DIR)
+  DIR=$(cygpath -m $DIR)
 fi
 
 # Find the DRIVERS_TOOLS by walking up the folder tree until there

--- a/.evergreen/init-node-and-npm-env.sh
+++ b/.evergreen/init-node-and-npm-env.sh
@@ -7,7 +7,7 @@
 ## access to `npm`, `node`, or need to install something globally from
 ## npm.
 
-DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DIR=$(dirname ${BASH_SOURCE:-$0})
 . $DIR/handle-paths.sh
 NODE_ARTIFACTS_PATH="$DIR/node-artifacts"
 if [[ "$OS" == "Windows_NT" ]]; then

--- a/.evergreen/init-node-and-npm-env.sh
+++ b/.evergreen/init-node-and-npm-env.sh
@@ -7,7 +7,7 @@
 ## access to `npm`, `node`, or need to install something globally from
 ## npm.
 
-DIR="$(dirname "${BASH_SOURCE[0]}")"
+DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 NODE_ARTIFACTS_PATH="$DIR/node-artifacts"
 if [[ "$OS" == "Windows_NT" ]]; then
   NODE_ARTIFACTS_PATH=$(cygpath --unix "$NODE_ARTIFACTS_PATH")

--- a/.evergreen/init-node-and-npm-env.sh
+++ b/.evergreen/init-node-and-npm-env.sh
@@ -8,6 +8,7 @@
 ## npm.
 
 DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+. $DIR/handle-paths.sh
 NODE_ARTIFACTS_PATH="$DIR/node-artifacts"
 if [[ "$OS" == "Windows_NT" ]]; then
   NODE_ARTIFACTS_PATH=$(cygpath --unix "$NODE_ARTIFACTS_PATH")

--- a/.evergreen/init-node-and-npm-env.sh
+++ b/.evergreen/init-node-and-npm-env.sh
@@ -7,9 +7,9 @@
 ## access to `npm`, `node`, or need to install something globally from
 ## npm.
 
-DIR=$(dirname ${BASH_SOURCE:-$0})
-. $DIR/handle-paths.sh
-NODE_ARTIFACTS_PATH="$DIR/node-artifacts"
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+. $SCRIPT_DIR/handle-paths.sh
+NODE_ARTIFACTS_PATH="$SCRIPT_DIR/node-artifacts"
 if [[ "$OS" == "Windows_NT" ]]; then
   NODE_ARTIFACTS_PATH=$(cygpath --unix "$NODE_ARTIFACTS_PATH")
 fi

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 set -o errexit  # Exit the script with error if any of the commands fail
 
-DIR=$(dirname ${BASH_SOURCE:-$0})
-. $DIR/handle-paths.sh
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+. $SCRIPT_DIR/handle-paths.sh
 
 # Functions to fetch MongoDB binaries
-. $DIR/download-mongodb.sh
+. $SCRIPT_DIR/download-mongodb.sh
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 
 get_distro

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -o errexit  # Exit the script with error if any of the commands fail
 
-DIR=$(dirname $0)
+DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 # Functions to fetch MongoDB binaries
 . $DIR/download-mongodb.sh
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -o errexit  # Exit the script with error if any of the commands fail
 
-DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DIR=$(dirname ${BASH_SOURCE:-$0})
 . $DIR/handle-paths.sh
 
 # Functions to fetch MongoDB binaries

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -2,6 +2,8 @@
 set -o errexit  # Exit the script with error if any of the commands fail
 
 DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+. $DIR/handle-paths.sh
+
 # Functions to fetch MongoDB binaries
 . $DIR/download-mongodb.sh
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')

--- a/.evergreen/install-node.sh
+++ b/.evergreen/install-node.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -o errexit  # Exit the script with error if any of the commands fail
 
-DIR=$(dirname ${BASH_SOURCE:-$0})
-. $DIR/handle-paths.sh
-pushd $DIR
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+. $SCRIPT_DIR/handle-paths.sh
+pushd $SCRIPT_DIR
 
 NODE_LTS_VERSION=${NODE_LTS_VERSION:-18}
 # npm version can be defined in the environment for cases where we need to install

--- a/.evergreen/install-node.sh
+++ b/.evergreen/install-node.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -o errexit  # Exit the script with error if any of the commands fail
 
-DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DIR=$(dirname ${BASH_SOURCE:-$0})
 . $DIR/handle-paths.sh
 pushd $DIR
 

--- a/.evergreen/install-node.sh
+++ b/.evergreen/install-node.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -o errexit  # Exit the script with error if any of the commands fail
 
-DIR="$(dirname "${BASH_SOURCE[0]}")"
+DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 pushd $DIR
 
 NODE_LTS_VERSION=${NODE_LTS_VERSION:-18}

--- a/.evergreen/install-node.sh
+++ b/.evergreen/install-node.sh
@@ -2,6 +2,7 @@
 set -o errexit  # Exit the script with error if any of the commands fail
 
 DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+. $DIR/handle-paths.sh
 pushd $DIR
 
 NODE_LTS_VERSION=${NODE_LTS_VERSION:-18}

--- a/.evergreen/run-atlas-proxy.sh
+++ b/.evergreen/run-atlas-proxy.sh
@@ -36,11 +36,11 @@ ORIG_DIR="$(pwd)"
 #--------------------------------------------------------------------------#
 
 DL_START=$(date +%s)
-DIR=$(dirname ${BASH_SOURCE:-$0})
-. $DIR/handle-paths.sh
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+. $SCRIPT_DIR/handle-paths.sh
 
 # Load download helper functions
-. $DIR/download-mongodb.sh
+. $SCRIPT_DIR/download-mongodb.sh
 
 # set $DISTRO
 get_distro

--- a/.evergreen/run-atlas-proxy.sh
+++ b/.evergreen/run-atlas-proxy.sh
@@ -22,9 +22,6 @@
 #
 # This script expects the following environment variables:
 #
-# DRIVERS_TOOLS (required) - absolute path to the checked out
-# driver-evergreen-tools repository
-#
 # MONGODB_VERSION - version of MongoDB to download and use. For Atlas
 # Proxy, must be "3.4" or "latest".  Defaults to "3.4".
 
@@ -39,7 +36,8 @@ ORIG_DIR="$(pwd)"
 #--------------------------------------------------------------------------#
 
 DL_START=$(date +%s)
-DIR=$(dirname $0)
+DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DRIVER_TOOLS=$(dirname $(dirname $DIR))
 
 # Load download helper functions
 . $DIR/download-mongodb.sh

--- a/.evergreen/run-atlas-proxy.sh
+++ b/.evergreen/run-atlas-proxy.sh
@@ -37,7 +37,7 @@ ORIG_DIR="$(pwd)"
 
 DL_START=$(date +%s)
 DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-DRIVER_TOOLS=$(dirname $(dirname $DIR))
+. $DIR/handle-paths.sh
 
 # Load download helper functions
 . $DIR/download-mongodb.sh

--- a/.evergreen/run-atlas-proxy.sh
+++ b/.evergreen/run-atlas-proxy.sh
@@ -36,7 +36,7 @@ ORIG_DIR="$(pwd)"
 #--------------------------------------------------------------------------#
 
 DL_START=$(date +%s)
-DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DIR=$(dirname ${BASH_SOURCE:-$0})
 . $DIR/handle-paths.sh
 
 # Load download helper functions

--- a/.evergreen/run-load-balancer.sh
+++ b/.evergreen/run-load-balancer.sh
@@ -2,7 +2,7 @@
 
 set -o errexit  # Exit the script with error if any of the commands fail
 
-DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DIR=$(dirname ${BASH_SOURCE:-$0})
 . $DIR/handle-paths.sh
 MONGODB_URI=${MONGODB_URI:-}
 

--- a/.evergreen/run-load-balancer.sh
+++ b/.evergreen/run-load-balancer.sh
@@ -2,8 +2,8 @@
 
 set -o errexit  # Exit the script with error if any of the commands fail
 
-DIR=$(dirname ${BASH_SOURCE:-$0})
-. $DIR/handle-paths.sh
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+. $SCRIPT_DIR/handle-paths.sh
 MONGODB_URI=${MONGODB_URI:-}
 
 start() {

--- a/.evergreen/run-load-balancer.sh
+++ b/.evergreen/run-load-balancer.sh
@@ -3,7 +3,7 @@
 set -o errexit  # Exit the script with error if any of the commands fail
 
 DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-DRIVERS_TOOLS=$(dirname $(dirname $DIR))
+. $DIR/handle-paths.sh
 MONGODB_URI=${MONGODB_URI:-}
 
 start() {

--- a/.evergreen/run-load-balancer.sh
+++ b/.evergreen/run-load-balancer.sh
@@ -2,7 +2,8 @@
 
 set -o errexit  # Exit the script with error if any of the commands fail
 
-DRIVERS_TOOLS=$(cd "$(dirname "$0")" && pwd)/..
+DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DRIVERS_TOOLS=$(dirname $(dirname $DIR))
 MONGODB_URI=${MONGODB_URI:-}
 
 start() {

--- a/.evergreen/run-orchestration.sh
+++ b/.evergreen/run-orchestration.sh
@@ -30,7 +30,7 @@ INSTALL_LEGACY_SHELL=${INSTALL_LEGACY_SHELL:-}
 DL_START=$(date +%s)
 # See https://stackoverflow.com/questions/35006457/choosing-between-0-and-bash-source/35006505#35006505
 # Why we need this syntax when sh is not aliased to bash (this script must be able to be called from sh)
-SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]:-$0})
 . $SCRIPT_DIR/handle-paths.sh
 
 # Functions to fetch MongoDB binaries.

--- a/.evergreen/run-orchestration.sh
+++ b/.evergreen/run-orchestration.sh
@@ -29,6 +29,8 @@ INSTALL_LEGACY_SHELL=${INSTALL_LEGACY_SHELL:-}
 
 DL_START=$(date +%s)
 DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+. $DIR/handle-paths.sh
+
 # Functions to fetch MongoDB binaries.
 . $DIR/download-mongodb.sh
 

--- a/.evergreen/run-orchestration.sh
+++ b/.evergreen/run-orchestration.sh
@@ -28,16 +28,18 @@ ORCHESTRATION_FILE=${ORCHESTRATION_FILE}
 INSTALL_LEGACY_SHELL=${INSTALL_LEGACY_SHELL:-}
 
 DL_START=$(date +%s)
-DIR=$(dirname ${BASH_SOURCE:-$0})
-. $DIR/handle-paths.sh
+# See https://stackoverflow.com/questions/35006457/choosing-between-0-and-bash-source/35006505#35006505
+# Why we need this syntax when sh is not aliased to bash (this script must be able to be called from sh)
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+. $SCRIPT_DIR/handle-paths.sh
 
 # Functions to fetch MongoDB binaries.
-. $DIR/download-mongodb.sh
+. $SCRIPT_DIR/download-mongodb.sh
 
 # To continue supporting `sh run-orchestration.sh` for backwards-compatibility,
 # explicitly invoke Bash as a subshell here when running `find_python3`.
 echo "Finding Python3 binary..."
-PYTHON="$(bash -c ". $DIR/find-python3.sh && find_python3 2>/dev/null")"
+PYTHON="$(bash -c ". $SCRIPT_DIR/find-python3.sh && find_python3 2>/dev/null")"
 echo "Finding Python3 binary... done."
 
 get_distro
@@ -118,7 +120,7 @@ fi
 export ORCHESTRATION_URL="http://localhost:8889/v1/${TOPOLOGY}s"
 
 # Start mongo-orchestration
-PYTHON="${PYTHON:?}" bash $DIR/start-orchestration.sh "$MONGO_ORCHESTRATION_HOME"
+PYTHON="${PYTHON:?}" bash $SCRIPT_DIR/start-orchestration.sh "$MONGO_ORCHESTRATION_HOME"
 
 if ! curl --silent --show-error --data @"$ORCHESTRATION_FILE" "$ORCHESTRATION_URL" --max-time 600 --fail -o tmp.json; then
   echo Failed to start cluster, see $MONGO_ORCHESTRATION_HOME/out.log:

--- a/.evergreen/run-orchestration.sh
+++ b/.evergreen/run-orchestration.sh
@@ -28,7 +28,7 @@ ORCHESTRATION_FILE=${ORCHESTRATION_FILE}
 INSTALL_LEGACY_SHELL=${INSTALL_LEGACY_SHELL:-}
 
 DL_START=$(date +%s)
-DIR=$(dirname $0)
+DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 # Functions to fetch MongoDB binaries.
 . $DIR/download-mongodb.sh
 

--- a/.evergreen/run-orchestration.sh
+++ b/.evergreen/run-orchestration.sh
@@ -30,7 +30,7 @@ INSTALL_LEGACY_SHELL=${INSTALL_LEGACY_SHELL:-}
 DL_START=$(date +%s)
 # See https://stackoverflow.com/questions/35006457/choosing-between-0-and-bash-source/35006505#35006505
 # Why we need this syntax when sh is not aliased to bash (this script must be able to be called from sh)
-SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]:-$0})
+SCRIPT_DIR=$(dirname ${BASH_SOURCE:-$0})
 . $SCRIPT_DIR/handle-paths.sh
 
 # Functions to fetch MongoDB binaries.

--- a/.evergreen/run-orchestration.sh
+++ b/.evergreen/run-orchestration.sh
@@ -28,7 +28,7 @@ ORCHESTRATION_FILE=${ORCHESTRATION_FILE}
 INSTALL_LEGACY_SHELL=${INSTALL_LEGACY_SHELL:-}
 
 DL_START=$(date +%s)
-DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DIR=$(dirname ${BASH_SOURCE:-$0})
 . $DIR/handle-paths.sh
 
 # Functions to fetch MongoDB binaries.

--- a/.evergreen/serverless/create-instance.sh
+++ b/.evergreen/serverless/create-instance.sh
@@ -51,7 +51,7 @@ if [ -z "$SERVERLESS_INSTANCE_NAME" ]; then
     SERVERLESS_INSTANCE_NAME="$RANDOM-DRIVERTEST"
 fi
 
-DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DIR=$(dirname ${BASH_SOURCE:-$0})
 . $DIR/../handle-paths.sh
 
 # Ensure that a Python binary is available for JSON decoding

--- a/.evergreen/serverless/create-instance.sh
+++ b/.evergreen/serverless/create-instance.sh
@@ -51,7 +51,7 @@ if [ -z "$SERVERLESS_INSTANCE_NAME" ]; then
     SERVERLESS_INSTANCE_NAME="$RANDOM-DRIVERTEST"
 fi
 
-DIR=$(dirname $0)
+DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Ensure that a Python binary is available for JSON decoding
 . $DIR/../find-python3.sh || exit 1

--- a/.evergreen/serverless/create-instance.sh
+++ b/.evergreen/serverless/create-instance.sh
@@ -52,6 +52,7 @@ if [ -z "$SERVERLESS_INSTANCE_NAME" ]; then
 fi
 
 DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+. $DIR/../handle-paths.sh
 
 # Ensure that a Python binary is available for JSON decoding
 . $DIR/../find-python3.sh || exit 1

--- a/.evergreen/serverless/create-instance.sh
+++ b/.evergreen/serverless/create-instance.sh
@@ -51,11 +51,11 @@ if [ -z "$SERVERLESS_INSTANCE_NAME" ]; then
     SERVERLESS_INSTANCE_NAME="$RANDOM-DRIVERTEST"
 fi
 
-DIR=$(dirname ${BASH_SOURCE:-$0})
-. $DIR/../handle-paths.sh
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+. $SCRIPT_DIR/../handle-paths.sh
 
 # Ensure that a Python binary is available for JSON decoding
-. $DIR/../find-python3.sh || exit 1
+. $SCRIPT_DIR/../find-python3.sh || exit 1
 echo "Finding Python3 binary..."
 PYTHON_BINARY="$(find_python3 2>/dev/null)" || exit 1
 echo "Finding Python3 binary... done."
@@ -93,7 +93,7 @@ echo ""
 SECONDS=0
 
 while [ true ]; do
-    API_RESPONSE=`SERVERLESS_INSTANCE_NAME=$SERVERLESS_INSTANCE_NAME bash $DIR/get-instance.sh`
+    API_RESPONSE=`SERVERLESS_INSTANCE_NAME=$SERVERLESS_INSTANCE_NAME bash $SCRIPT_DIR/get-instance.sh`
     STATE_NAME=`echo $API_RESPONSE | $PYTHON_BINARY -c "import sys, json; print(json.load(sys.stdin)['stateName'])" | tr -d '\r\n'`
     SERVERLESS_MONGODB_VERSION=`echo $API_RESPONSE | $PYTHON_BINARY -c "import sys, json; print(json.load(sys.stdin)['mongoDBVersion'])" | tr -d '\r\n'`
 
@@ -123,7 +123,7 @@ EOF
 
         if [ "$SERVERLESS_SKIP_CRYPT" != "OFF" ]; then
           # Download binaries and crypt_shared
-          MONGODB_VERSION=rapid sh $DIR/download-crypt.sh
+          MONGODB_VERSION=rapid sh $SCRIPT_DIR/download-crypt.sh
         fi
 
         exit 0

--- a/.evergreen/serverless/download-crypt.sh
+++ b/.evergreen/serverless/download-crypt.sh
@@ -2,7 +2,7 @@
 
 MONGODB_VERSION=${MONGODB_VERSION:-latest}
 
-DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+DIR=$(dirname ${BASH_SOURCE:-$0})
 . $DIR/../handle-paths.sh
 
 # Functions to fetch MongoDB binaries

--- a/.evergreen/serverless/download-crypt.sh
+++ b/.evergreen/serverless/download-crypt.sh
@@ -2,11 +2,11 @@
 
 MONGODB_VERSION=${MONGODB_VERSION:-latest}
 
-DIR=$(dirname ${BASH_SOURCE:-$0})
-. $DIR/../handle-paths.sh
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+. $SCRIPT_DIR/../handle-paths.sh
 
 # Functions to fetch MongoDB binaries
-. $DIR/../download-mongodb.sh
+. $SCRIPT_DIR/../download-mongodb.sh
 
 get_distro
 get_mongodb_download_url_for "$DISTRO" "$MONGODB_VERSION"

--- a/.evergreen/serverless/download-crypt.sh
+++ b/.evergreen/serverless/download-crypt.sh
@@ -3,6 +3,8 @@
 MONGODB_VERSION=${MONGODB_VERSION:-latest}
 
 DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+. $DIR/../handle-paths.sh
+
 # Functions to fetch MongoDB binaries
 . $DIR/../download-mongodb.sh
 

--- a/.evergreen/serverless/download-crypt.sh
+++ b/.evergreen/serverless/download-crypt.sh
@@ -2,7 +2,7 @@
 
 MONGODB_VERSION=${MONGODB_VERSION:-latest}
 
-DIR=$(dirname $0)
+DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 # Functions to fetch MongoDB binaries
 . $DIR/../download-mongodb.sh
 

--- a/.evergreen/start-orchestration.sh
+++ b/.evergreen/start-orchestration.sh
@@ -18,8 +18,11 @@ MONGO_ORCHESTRATION_HOME="$1"
 
 echo From shell `date` > $MONGO_ORCHESTRATION_HOME/server.log
 
+DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+. $DIR/handle-paths.sh
+
 declare det_evergreen_dir
-det_evergreen_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+det_evergreen_dir=$DIR/.evergreen
 . "$det_evergreen_dir/find-python3.sh"
 . "$det_evergreen_dir/venv-utils.sh"
 
@@ -45,7 +48,7 @@ cd -
 
 # Create default config file if it doesn't exist
 if [ ! -f $MONGO_ORCHESTRATION_HOME/orchestration.config ]; then
-  MONGODB_BINARIES=${MONGODB_BINARIES:-$(dirname "$(dirname "$0")")/mongodb/bin}
+  MONGODB_BINARIES=${MONGODB_BINARIES:-${DRIVERS_TOOLS}/mongodb/bin}
   echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" > $MONGO_ORCHESTRATION_HOME/orchestration.config
 fi
 

--- a/.evergreen/start-orchestration.sh
+++ b/.evergreen/start-orchestration.sh
@@ -18,11 +18,11 @@ MONGO_ORCHESTRATION_HOME="$1"
 
 echo From shell `date` > $MONGO_ORCHESTRATION_HOME/server.log
 
-DIR=$(dirname ${BASH_SOURCE:-$0})
-. $DIR/handle-paths.sh
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+. $SCRIPT_DIR/handle-paths.sh
 
 declare det_evergreen_dir
-det_evergreen_dir=$DIR
+det_evergreen_dir=$SCRIPT_DIR
 . "$det_evergreen_dir/find-python3.sh"
 . "$det_evergreen_dir/venv-utils.sh"
 

--- a/.evergreen/start-orchestration.sh
+++ b/.evergreen/start-orchestration.sh
@@ -22,7 +22,7 @@ DIR=$(dirname ${BASH_SOURCE:-$0})
 . $DIR/handle-paths.sh
 
 declare det_evergreen_dir
-det_evergreen_dir=$DIR/.evergreen
+det_evergreen_dir=$DIR
 . "$det_evergreen_dir/find-python3.sh"
 . "$det_evergreen_dir/venv-utils.sh"
 

--- a/.evergreen/start-orchestration.sh
+++ b/.evergreen/start-orchestration.sh
@@ -19,7 +19,7 @@ MONGO_ORCHESTRATION_HOME="$1"
 echo From shell `date` > $MONGO_ORCHESTRATION_HOME/server.log
 
 declare det_evergreen_dir
-det_evergreen_dir="$(dirname "${BASH_SOURCE[0]}")"
+det_evergreen_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 . "$det_evergreen_dir/find-python3.sh"
 . "$det_evergreen_dir/venv-utils.sh"
 

--- a/.evergreen/start-orchestration.sh
+++ b/.evergreen/start-orchestration.sh
@@ -18,7 +18,7 @@ MONGO_ORCHESTRATION_HOME="$1"
 
 echo From shell `date` > $MONGO_ORCHESTRATION_HOME/server.log
 
-DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+DIR=$(dirname ${BASH_SOURCE:-$0})
 . $DIR/handle-paths.sh
 
 declare det_evergreen_dir

--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,7 @@ testazureoidc-expansions.yml
 venv
 authawsvenv
 authoidcvenv
+kmstlsvenv
 
 /uri.txt
 /results.json


### PR DESCRIPTION
#383 caused a regression in the way paths are handled in `aws_setup.sh`:

`mv: 'secrets-export.sh' and '/data/mci/1e7ceedf7f78683b5034736f250f800b/drivers-tools/.evergreen/auth_aws/secrets-export.sh' are the same file`

https://spruce.mongodb.com/task/mongo_go_driver_v1_aws_auth_test__version~4.4_os_aws_auth~ubuntu2004_64_go_1_20_aws_auth_test_1415137a1a3cbf6886ad7d6a4a576c2d05f4f83c_24_01_05_17_26_12/logs?execution=0

This PR adjusts path handling so that the path to the script is always absolute across platforms, and finds the appropriate parent DRIVERS_TOOLS directory, using a new `handle-paths.sh` script.

Here is a passing build for [pymongo](https://spruce.mongodb.com/version/659b09aed6d80ad0c4b2c88c/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC
) across all build variants (except Atlas Data Lake, which is unrelated).
