### PR TITLE
CDRIVER-4512 run `aws_tester.py` for `session-creds` and `env-creds` test cases

### DIFF
--- a/.evergreen/auth_aws/README.md
+++ b/.evergreen/auth_aws/README.md
@@ -23,7 +23,7 @@ on how the secrets are managed.
 ```bash
 cd $DRIVERS_TOOLS/.evergreen/auth_aws
 # Create a python virtual environment.
-cd ./activate-authawsvenv.sh
+./activate-authawsvenv.sh
 # Source the environment variables.
 . aws_setup.sh <variant>
 # Configure the environment and the server.

--- a/.evergreen/auth_aws/README.md
+++ b/.evergreen/auth_aws/README.md
@@ -24,10 +24,8 @@ on how the secrets are managed.
 cd $DRIVERS_TOOLS/.evergreen/auth_aws
 # Create a python virtual environment.
 ./activate-authawsvenv.sh
-# Source the environment variables.
+# Source the environment variables. Configure the environment and the server.
 . aws_setup.sh <variant>
-# Configure the environment and the server.
-python aws_tester.py <variant>
 # Run your driver-specific tests here.
 ```
 

--- a/.evergreen/auth_aws/README.md
+++ b/.evergreen/auth_aws/README.md
@@ -50,7 +50,7 @@ cp ${PROJECT_DIRECTORY}/.evergreen/run-mongodb-aws-ecs-test.sh $ECS_SRC_DIR/.eve
 # Driver-specific - compile/build code if needed.
 # Driver-specific - move artifacts needed for test to $ECS_SRC_DIR
 # Run the test
-PROJECT_DIRECTORY="$ECS_SRC_DIR" $AUTH_AWS_DIR/aws_setup.sh ecs
+PROJECT_DIRECTORY="$ECS_SRC_DIR" MONGODB_BINARIES="/path/to/mongodb/bin" $AUTH_AWS_DIR/aws_setup.sh ecs
 ```
 
 ## Deprecated Scripts

--- a/.evergreen/auth_aws/README.md
+++ b/.evergreen/auth_aws/README.md
@@ -23,7 +23,7 @@ on how the secrets are managed.
 ```bash
 cd $DRIVERS_TOOLS/.evergreen/auth_aws
 # Create a python virtual environment.
-./activate-authawsvenv.sh
+. ./activate-authawsvenv.sh
 # Source the environment variables. Configure the environment and the server.
 . aws_setup.sh <variant>
 # Run your driver-specific tests here.

--- a/.evergreen/auth_aws/aws_setup.sh
+++ b/.evergreen/auth_aws/aws_setup.sh
@@ -29,7 +29,9 @@ fi
 # Handle the test setup if not using env variables.
 case $1 in
     session-creds | env-creds)
-        echo "Skipping aws_tester.py"
+        echo "Running aws_tester.py with assume-role"
+        # Set up credentials with assume-role to create user in MongoDB and write AWS credentials.
+        python aws_tester.py "assume-role"
         ;;
     *)
         python aws_tester.py "$1"

--- a/.evergreen/auth_aws/aws_setup.sh
+++ b/.evergreen/auth_aws/aws_setup.sh
@@ -28,10 +28,15 @@ fi
 
 # Handle the test setup if not using env variables.
 case $1 in
-    session-creds | env-creds)
+    session-creds)
         echo "Running aws_tester.py with assume-role"
         # Set up credentials with assume-role to create user in MongoDB and write AWS credentials.
         python aws_tester.py "assume-role"
+        ;;
+    env-creds)
+        echo "Running aws_tester.py with regular"
+        # Set up credentials with regular to create user in MongoDB and write AWS credentials.
+        python aws_tester.py "regular"
         ;;
     *)
         python aws_tester.py "$1"


### PR DESCRIPTION
# Summary

- Run `assume-role` setup before `session-creds` test case.
- Run `regular` setup before `env-creds` test case.
- Update setup steps in README.

This PR was tested with Go driver: https://spruce.mongodb.com/version/65a163291e2d174ef9b4d3df and C driver: https://spruce.mongodb.com/version/65a167d0850e61bbdb91b2d6

# Background

`aws_setup.sh "session-creds"` expects `creds.json` to exist (via `jsonkey` [here](https://github.com/mongodb-labs/drivers-evergreen-tools/blob/b01493d57e6716cb6385afaa4dc06330e4f33e01/.evergreen/auth_aws/aws_setup.sh#L68)). However, `aws_setup.sh "session-creds"` does not run `aws_tester.py`.

I expect this is OK in the Go driver. The Go driver runs the AWS test cases in the same Evergreen task. I expect `aws_setup.sh "assume-role"` is run before `aws_setup.sh "session-creds"`.

The C driver runs each AWS [test scenario](https://github.com/mongodb/specifications/blob/7145efa0aabaa14f356ff15d3f2a732785f67497/source/auth/tests/mongodb-aws.rst) in a separate Evergreen task.

This resulted in an error in the C driver [patch build](https://spruce.mongodb.com/task/mongo_c_driver_aws_ubuntu2004_test_aws_openssl_lambda_latest_patch_0da4704d32f80a9eac7d264f1fda2bd70ebe399d_65948af22a60ed86aac79777_24_01_02_22_15_16/logs?execution=1): `aws_setup.sh: line 50: ./creds.json: No such file or directory`

To support running AWS test cases in isolation, this PR runs `aws_tester.py` before the `session-creds` and `env-creds` test cases.
