### PR TITLE
Add Docker support for pre-4.4 Servers

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -374,7 +374,7 @@ functions:
           ${PREPARE_SHELL}
           set -ex
           cd $DRIVERS_TOOLS/.evergreen/docker
-          ENTRYPOINT=/root/test-entrypoint.sh bash run-server.sh
+          TARGET_IMAGE=${TARGET_IMAGE} ENTRYPOINT=/root/test-entrypoint.sh bash run-server.sh
           # Generate a test results file
           cd ${PROJECT_DIRECTORY}
           make test
@@ -813,6 +813,9 @@ tasks:
       tags: ["latest", "docker"]
       commands:
         - func: "run docker test"
+        - func: "run docker test"
+          vars:
+            TARGET_IMAGE: ubuntu18.04
         - func: "cleanup docker"
 
     - name: "test-oidc"

--- a/.evergreen/docker/README.md
+++ b/.evergreen/docker/README.md
@@ -45,6 +45,13 @@ Note that the default `TOPOLOGY` is [`servers`](https://github.com/mongodb-labs/
 ```bash
 TOPOLOGY=replica_set ORCHESTRATION_FILE=auth.json bash ./run-server.sh 
 ```
+
+If you want to test server versions older than 4.4, you can use the 18.04 image, e.g.:
+
+```bash
+TOPOLOGY=sharded_cluster MONGODB_VERSION=4.2 TARGET_IMAGE=ubuntu18.04 ./run-server.sh
+```
+
 ## Driver Testing using this Docker container
 
 First, start this container with the appropriate environment variables, running as:

--- a/.evergreen/docker/ubuntu18.04/Dockerfile
+++ b/.evergreen/docker/ubuntu18.04/Dockerfile
@@ -1,0 +1,55 @@
+FROM ubuntu:18.04
+
+RUN export DEBIAN_FRONTEND=noninteractive && \
+  apt-get -qq update && apt-get -qqy install --no-install-recommends \
+  git \
+  ca-certificates \
+  curl \
+  wget \
+  sudo \
+  gnupg \
+  python \
+  lsof \
+  software-properties-common \
+  # python3 deps
+  build-essential \
+  zlib1g-dev \
+  libncurses5-dev \
+  libgdbm-dev \
+  libnss3-dev \
+  libssl-dev \
+  libsqlite3-dev \
+  libreadline-dev \
+  libffi-dev wget \
+  libbz2-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install mongodb server to get deps
+RUN export DEBIAN_FRONTEND=noninteractive \
+  && export TZ=Etc/UTC \
+  && curl -fsSL https://pgp.mongodb.com/server-4.4.asc | gpg -o /usr/share/keyrings/mongodb-server-4.4.gpg --dearmor \
+  && echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-4.4.gpg ] https://repo.mongodb.com/apt/ubuntu bionic/mongodb-enterprise/4.4 multiverse" | tee /etc/apt/sources.list.d/mongodb-enterprise-4.4.list \
+  && apt-get update \
+  && apt-get install -y mongodb-enterprise
+
+# Install python 3.8 from source
+RUN wget https://www.python.org/ftp/python/3.8.10/Python-3.8.10.tgz \
+  && tar -xf Python-3.8.10.tgz \
+  && cd Python-3.8.10 \
+  && ./configure --enable-optimizations \
+  && make -j 8 \
+  && make install
+
+ARG USER_ID
+ARG GROUP_ID
+
+ENV DRIVERS_TOOLS=/root/drivers-evergreen-tools
+ENV PROJECT_ORCHESTRATION_HOME=/root/drivers-evergreen-tools/.evergreen/orchestration
+ENV MONGODB_BINARIES=/root/drivers-evergreen-tools/.evergreen/docker/ubuntu18.04/mongodb/bin
+ENV MONGODB_BINARY_ROOT=/root/drivers-evergreen-tools/.evergreen/docker/ubuntu18.04/
+ENV MONGO_ORCHESTRATION_HOME=/root
+ENV DOCKER_RUNNING=true
+
+COPY ./local-entrypoint.sh /root/local-entrypoint.sh
+COPY ./base-entrypoint.sh /root/base-entrypoint.sh
+COPY ./test-entrypoint.sh /root/test-entrypoint.sh

--- a/.evergreen/docker/ubuntu18.04/Dockerfile
+++ b/.evergreen/docker/ubuntu18.04/Dockerfile
@@ -2,27 +2,27 @@ FROM ubuntu:18.04
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
   apt-get -qq update && apt-get -qqy install --no-install-recommends \
-  git \
-  ca-certificates \
-  curl \
-  wget \
-  sudo \
-  gnupg \
-  python \
-  lsof \
-  software-properties-common \
-  # python3 deps
-  build-essential \
-  zlib1g-dev \
-  libncurses5-dev \
-  libgdbm-dev \
-  libnss3-dev \
-  libssl-dev \
-  libsqlite3-dev \
-  libreadline-dev \
-  libffi-dev wget \
-  libbz2-dev \
- && rm -rf /var/lib/apt/lists/*
+    git \
+    ca-certificates \
+    curl \
+    wget \
+    sudo \
+    gnupg \
+    python \
+    lsof \
+    software-properties-common \
+    # python3 deps
+    build-essential \
+    zlib1g-dev \
+    libncurses5-dev \
+    libgdbm-dev \
+    libnss3-dev \
+    libssl-dev \
+    libsqlite3-dev \
+    libreadline-dev \
+    libffi-dev wget \
+    libbz2-dev \
+  && rm -rf /var/lib/apt/lists/*
 
 # Install mongodb server to get deps
 RUN export DEBIAN_FRONTEND=noninteractive \
@@ -30,7 +30,8 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   && curl -fsSL https://pgp.mongodb.com/server-4.4.asc | gpg -o /usr/share/keyrings/mongodb-server-4.4.gpg --dearmor \
   && echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-4.4.gpg ] https://repo.mongodb.com/apt/ubuntu bionic/mongodb-enterprise/4.4 multiverse" | tee /etc/apt/sources.list.d/mongodb-enterprise-4.4.list \
   && apt-get update \
-  && apt-get install -y mongodb-enterprise
+  && apt-get install -qqy mongodb-enterprise \
+  && rm -rf /var/lib/apt/lists/*
 
 # Install python 3.8 from source
 RUN wget https://www.python.org/ftp/python/3.8.10/Python-3.8.10.tgz \
@@ -38,7 +39,8 @@ RUN wget https://www.python.org/ftp/python/3.8.10/Python-3.8.10.tgz \
   && cd Python-3.8.10 \
   && ./configure --enable-optimizations \
   && make -j 8 \
-  && make install
+  && make install \
+  && rm -rf Python-3.8.10
 
 ARG USER_ID
 ARG GROUP_ID

--- a/.evergreen/docker/ubuntu18.04/base-entrypoint.sh
+++ b/.evergreen/docker/ubuntu18.04/base-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -eux
+
+rm -f $DRIVERS_TOOLS/results.json
+cd $DRIVERS_TOOLS/.evergreen
+bash run-orchestration.sh
+
+# Preserve host permissions of files we have created.
+cd $DRIVERS_TOOLS
+files=(results.json uri.txt .evergreen/mongo_crypt_v1.so .evergreen/mo-expansion.yml)
+chown --reference=action.yml "${files[@]}"
+chmod --reference=action.yml "${files[@]}"
+
+echo "Server started!"

--- a/.evergreen/docker/ubuntu18.04/local-entrypoint.sh
+++ b/.evergreen/docker/ubuntu18.04/local-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -eu
+
+bash /root/base-entrypoint.sh
+tail -f $MONGO_ORCHESTRATION_HOME/server.log

--- a/.evergreen/docker/ubuntu18.04/test-entrypoint.sh
+++ b/.evergreen/docker/ubuntu18.04/test-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -eu
+
+bash /root/base-entrypoint.sh
+source $DRIVERS_TOOLS/.evergreen/mo-expansion.sh
+$MONGODB_BINARIES/mongosh --eval 'db'
+echo "Test complete!"

--- a/.gitignore
+++ b/.gitignore
@@ -99,7 +99,7 @@ kmstlsvenv
 /results.json
 /mongodb
 mongodb-binaries.tgz
-/.evergreen/docker/ubuntu20.04/mongodb
+/.evergreen/docker/ubuntu*/mongodb
 /mongosh
 mo-expansion.yml
 mo-expansion.sh


### PR DESCRIPTION
Add support for pre-4.4 servers in Docker.  Created to help implement [DRIVERS-1641](https://jira.mongodb.org/browse/DRIVERS-1641): pre-4.4 mongos writeConcernError does not determine retryability