### PR TITLE
minor: fix a typo in .evergreen/serverless/README.md

### DIFF
--- a/.evergreen/serverless/README.md
+++ b/.evergreen/serverless/README.md
@@ -17,7 +17,7 @@ bash $DRIVERS_TOOLS/.evergreen/serverless/setup-secrets.sh
 If targeting the dev version of Serverless, use:
 
 ```bash
-$DRIVERS_TOOLS/.evergreen/serverless/setup-secrets.sh serverless-next
+$DRIVERS_TOOLS/.evergreen/serverless/setup-secrets.sh serverless_next
 ```
 
 Next, start the cluster with:


### PR DESCRIPTION
Turns out it doesn't work with a dash :)