### PR TITLE
Bump mongosh and server versions

### DIFF
--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -53,17 +53,17 @@ get_mongodb_download_url_for ()
    _VERSION=$2
    _DEBUG=$3
 
-   VERSION_MONGOSH="1.8.1"
+   VERSION_MONGOSH="2.1.1"
    # Set VERSION_RAPID to the latest rapid release each quarter.
-   VERSION_RAPID="6.3.1"
-   VERSION_70="7.0.4"
+   VERSION_RAPID="7.2.0"
+   VERSION_70="7.0.5"
    VERSION_60_LATEST="v6.0-latest"
-   VERSION_60="6.0.12"
+   VERSION_60="6.0.13"
    # The perf version must always remain pinned to the same patch
    VERSION_60_PERF="6.0.6"
-   VERSION_50="5.0.23"
-   VERSION_44="4.4.26"
-   VERSION_42="4.2.24"
+   VERSION_50="5.0.24"
+   VERSION_44="4.4.28"
+   VERSION_42="4.2.25"
    VERSION_40="4.0.28"
    VERSION_36="3.6.23"
    VERSION_34="3.4.24"


### PR DESCRIPTION
This PR bumps the following server versions:
* 7.0.4 -> 7.0.5
* 6.0.12 -> 6.0.13
* 5.0.23 -> 5.0.24
* 4.4.26 -> 4.4.28
* 4.2.24 -> 4.2.25

In addition, this PR updates mongosh from 1.8.1 to 2.1.1, and changes the version identifier for the rapid release from 6.3.1 to 7.2.0 (we apparently never updated this for 7.1).

I've tested the changes in the PHP driver and they work fine, including installing the new major version of mongosh: https://spruce.mongodb.com/version/65b7733e1e2d17d86f6187fb/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC