### PR TITLE
DRIVERS-2384 Allow extra args to sam build

### DIFF
--- a/.evergreen/aws_lambda/run-deployed-lambda-aws-tests.sh
+++ b/.evergreen/aws_lambda/run-deployed-lambda-aws-tests.sh
@@ -88,7 +88,7 @@ trap cleanup EXIT SIGHUP
 
 cd "${TEST_LAMBDA_DIRECTORY}"
 
-sam build ${SAM_BUILD_ARGS}
+sam build ${SAM_BUILD_ARGS:-}
 
 deploy_lambda_function
 

--- a/.evergreen/aws_lambda/run-deployed-lambda-aws-tests.sh
+++ b/.evergreen/aws_lambda/run-deployed-lambda-aws-tests.sh
@@ -11,6 +11,10 @@ set -o errexit  # Exit the script with error if any of the commands fail
 # DRIVERS_ATLAS_GROUP_ID: The id of the individual projects under the drivers org, per language.
 # LAMBDA_STACK_NAME: The name of the stack on lambda "dbx-<language>-lambda"
 # AWS_REGION: The region for the function - generally us-east-1
+#
+# Explanation of optional environment variables:
+#
+# SAM_BUILD_ARGS: Additional arguments to pass to the "sam build" command.
 
 VARLIST=(
 TEST_LAMBDA_DIRECTORY
@@ -84,7 +88,7 @@ trap cleanup EXIT SIGHUP
 
 cd "${TEST_LAMBDA_DIRECTORY}"
 
-sam build
+sam build ${SAM_BUILD_ARGS}
 
 deploy_lambda_function
 


### PR DESCRIPTION
The motivating use case here is Rust, which requires the `--beta-features` flag.