### PR TITLE
DRIVERS-2384 Skip deployment confirmation

### DIFF
--- a/.evergreen/aws_lambda/run-deployed-lambda-aws-tests.sh
+++ b/.evergreen/aws_lambda/run-deployed-lambda-aws-tests.sh
@@ -49,6 +49,7 @@ deploy_lambda_function ()
 {
   echo "Deploying Lambda function..."
   sam deploy \
+    --no-confirm-changeset \
     --stack-name "${FUNCTION_NAME}" \
     --capabilities CAPABILITY_IAM \
     --resolve-s3 \


### PR DESCRIPTION
Honestly a little confused as to how other drivers setups are working; without this, the Rust evergreen run fails when it hits the `Deploy this changeset? [y/N]` prompt.