### PR TITLE
docs: fix aws auth typo

### DIFF
--- a/.evergreen/secrets_handling/README.md
+++ b/.evergreen/secrets_handling/README.md
@@ -16,7 +16,7 @@ The `setup-secrets.sh` script in this folder can be used for other vaults such a
 | drivers/adl               | Used in `../atlas_data_lake` for Atlas Data Lake testing. |
 | drivers/atlas             | Used in `../atlas` to launch an atlas cluster. |
 | drivers/atlas_connect     | Has the URIs used in the Atlas Connect Drivers tests. |
-| drivers/auth_aws          | Used in `../auth_aws`  for AWS Auth testing. |
+| drivers/aws_auth          | Used in `../auth_aws`  for AWS Auth testing. |
 | drives/azurekms           | Used in `../csfle/azurekms` for Azure KMS testing. |
 | drivers/azure_oidc        | Used in `../auth_oidc/azure` for OIDC Testing on Azure. |
 | drivers/comment-bot       | Used in `../github_app` for the DBX Comment bot. |


### PR DESCRIPTION
While the directory in `.evergreen` is `auth_aws`, the actual name in AWS secrets manager is `aws_auth`:

```
> $ ./setup-secrets.sh drivers/aws_auth                                                                  ⬡ 18.12.1 [±master ✓]
~/work/mongodb-labs/drivers-evergreen-tools/.evergreen/auth_aws ~/work/mongodb-labs/drivers-evergreen-tools/.evergreen/secrets_handling
~/work/mongodb-labs/drivers-evergreen-tools/.evergreen/secrets_handling
+ echo 'Getting secrets:' drivers/aws_auth
Getting secrets: drivers/aws_auth
+ python /Users/modetojoy/work/mongodb-labs/drivers-evergreen-tools/.evergreen/secrets_handling/setup_secrets.py drivers/aws_auth
++ pwd
+ source /Users/modetojoy/work/mongodb-labs/drivers-evergreen-tools/.evergreen/secrets_handling/secrets-export.sh
++ set +x
Got secrets
```