### PR TITLE
DRIVERS-2851 Fix Handling of Atlas Cluster Creation

### DIFF
--- a/.evergreen/atlas/README.md
+++ b/.evergreen/atlas/README.md
@@ -22,22 +22,25 @@ An example task group running on a Linux EVG host might look like:
       params:
         binary: bash
         env:
-            LAMBDA_STACK_NAME: dbx-python-lambda
+            LAMBDA_STACK_NAME: dbx-python
         args:
-          - ${DRIVERS_TOOLS}/.evergreen/atlas/setup-atlas-cluster.sh
+          - ${DRIVERS_TOOLS}/.evergreen/atlas/setup.sh
     - command: expansions.update
       params:
         # Set MONGODB_URI
         file: atlas-expansion.yml
-  teardown_task:
+  teardown_group:
     - command: subprocess.exec
       params:
         working_dir: src
         binary: bash
         args:
-          - ${DRIVERS_TOOLS}/.evergreen/atlas/teardown-atlas-cluster.sh
+          - ${DRIVERS_TOOLS}/.evergreen/atlas/teardown.sh
+    - func: "cleanup"
   setup_group_can_fail_task: true
   setup_group_timeout_secs: 1800
+  teardown_group_can_fail_task: true
+  teardown_group_timeout_secs: 1800
   tasks:
     - test-aws-lambda-deployed
 ```

--- a/.evergreen/atlas/README.md
+++ b/.evergreen/atlas/README.md
@@ -15,6 +15,10 @@ An example task group running on a Linux EVG host might look like:
 
 ```yaml
 - name: test_atlas_group
+  setup_group_can_fail_task: true
+  setup_group_timeout_secs: 1800 # 30 minutes
+  teardown_group_can_fail_task: true
+  teardown_group_timeout_secs: 1800 # 30 minutes
   setup_group:
     - func: fetch source
     - func: prepare resources
@@ -37,10 +41,6 @@ An example task group running on a Linux EVG host might look like:
         args:
           - ${DRIVERS_TOOLS}/.evergreen/atlas/teardown.sh
     - func: "cleanup"
-  setup_group_can_fail_task: true
-  setup_group_timeout_secs: 1800
-  teardown_group_can_fail_task: true
-  teardown_group_timeout_secs: 1800
   tasks:
     - run-atlas-test
 ```

--- a/.evergreen/atlas/README.md
+++ b/.evergreen/atlas/README.md
@@ -10,8 +10,7 @@ from the `drivers/atlas` vault.
 ## Usage
 
 It is recommended that you use the cluster's task group to ensure the cluster is shut down properly.
-Note that we have to pass "task_id" and "execution" to ensure unique cluster name,
-and the `LAMBDA_STACK_NAME`.
+Note that we have to pass a `LAMBDA_STACK_NAME`, which is used to generate the Atlas cluster name.
 An example task group running on a Linux EVG host might look like:
 
 ```yaml
@@ -22,7 +21,6 @@ An example task group running on a Linux EVG host might look like:
     - command: subprocess.exec
       params:
         binary: bash
-        include_expansions_in_env: ["task_id", "execution"]
         env:
             LAMBDA_STACK_NAME: dbx-python-lambda
         args:

--- a/.evergreen/atlas/README.md
+++ b/.evergreen/atlas/README.md
@@ -10,11 +10,11 @@ from the `drivers/atlas` vault.
 ## Usage
 
 It is recommended that you use the cluster's task group to ensure the cluster is shut down properly.
-Note that we have to pass a `LAMBDA_STACK_NAME`, which is used to generate the Atlas cluster name.
+Note that we have to pass a `CLUSTER_PREFIX`, which is used to generate the Atlas cluster name.
 An example task group running on a Linux EVG host might look like:
 
 ```yaml
-- name: test_aws_lambda_task_group
+- name: test_atlas_group
   setup_group:
     - func: fetch source
     - func: prepare resources
@@ -22,7 +22,7 @@ An example task group running on a Linux EVG host might look like:
       params:
         binary: bash
         env:
-            LAMBDA_STACK_NAME: dbx-python
+          CLUSTER_PREFIX: dbx-python
         args:
           - ${DRIVERS_TOOLS}/.evergreen/atlas/setup.sh
     - command: expansions.update
@@ -42,7 +42,7 @@ An example task group running on a Linux EVG host might look like:
   teardown_group_can_fail_task: true
   teardown_group_timeout_secs: 1800
   tasks:
-    - test-aws-lambda-deployed
+    - run-atlas-test
 ```
 
 If other OSes are needed, use the `setup-secrets.sh` script in this directory with the full `ec2.assume_role`

--- a/.evergreen/atlas/setup-atlas-cluster.sh
+++ b/.evergreen/atlas/setup-atlas-cluster.sh
@@ -31,7 +31,7 @@ if [ -f ./secrets-export.sh ]; then
 fi
 
 # Attempt to handle the secrets automatically if env vars are not set.
-if [ -z "${DRIVERS_ATLAS_PUBLIC_API_KEY:}" ]; then
+if [ -z "${DRIVERS_ATLAS_PUBLIC_API_KEY:-}" ]; then
   . ../secrets_handling/setup-secrets.sh drivers/atlas
 fi
 

--- a/.evergreen/atlas/setup-atlas-cluster.sh
+++ b/.evergreen/atlas/setup-atlas-cluster.sh
@@ -6,9 +6,9 @@ set -eu
 # DRIVERS_ATLAS_PUBLIC_API_KEY: The public Atlas key for the drivers org.
 # DRIVERS_ATLAS_PRIVATE_API_KEY: The private Atlas key for the drivers org.
 # DRIVERS_ATLAS_GROUP_ID: The id of the individual projects under the drivers org, per language.
-# DRIVERS_ATLAS_LAMBDA_USER: The user for the lambda cluster.
-# DRIVERS_ATLAS_LAMBDA_PASSWORD: The password for the user.
-# LAMBDA_STACK_NAME: The name of the stack on lambda "dbx-<language>-lambda"
+# DRIVERS_ATLAS_USER: The user for the cluster.
+# DRIVERS_ATLAS_PASSWORD: The password for the user.
+# CLUSTER_PREFIX: The prefix for the cluster name, (e.g. dbx-python)
 # MONGODB_VERSION: The major version of the cluster to deploy.  Defaults to 6.0.
 
 # Explanation of generated variables:
@@ -35,13 +35,18 @@ if [ -z "${DRIVERS_ATLAS_PUBLIC_API_KEY:}" ]; then
   . ../secrets_handling/setup-secrets.sh drivers/atlas
 fi
 
+# Backwards compatibility: map LAMBDA_STACK_NAME to CLUSTER_PREFIX
+if [ -n "${LAMBDA_STACK_NAME:-}" ]; then
+  CLUSTER_PREFIX=$LAMBDA_STACK_NAME
+fi
+
 VARLIST=(
 DRIVERS_ATLAS_PUBLIC_API_KEY
 DRIVERS_ATLAS_PRIVATE_API_KEY
 DRIVERS_ATLAS_GROUP_ID
-DRIVERS_ATLAS_LAMBDA_USER
-DRIVERS_ATLAS_LAMBDA_PASSWORD
-LAMBDA_STACK_NAME
+DRIVERS_ATLAS_USER
+DRIVERS_ATLAS_PASSWORD
+CLUSTER_PREFIX
 )
 
 # Ensure that all variables required to run the test are set, otherwise throw
@@ -150,7 +155,7 @@ check_cluster ()
     echo "Setting MONGODB_URI in the environment to the new cluster."
     # else set the mongodb uri
     URI=$(echo $SRV_ADDRESS | grep -Eo "[^(\/\/)]*$" | cat)
-    MONGODB_URI="mongodb+srv://${DRIVERS_ATLAS_LAMBDA_USER}:${DRIVERS_ATLAS_LAMBDA_PASSWORD}@${URI}"
+    MONGODB_URI="mongodb+srv://${DRIVERS_ATLAS_USER}:${DRIVERS_ATLAS_PASSWORD}@${URI}"
     # Put the MONGODB_URI in an expansions yml and secrets file.
     echo 'MONGODB_URI: "'$MONGODB_URI'"' > $CURRENT_DIR/atlas-expansion.yml
     echo "export MONGODB_URI=$MONGODB_URI" >> ./secrets-export.sh

--- a/.evergreen/atlas/setup-atlas-cluster.sh
+++ b/.evergreen/atlas/setup-atlas-cluster.sh
@@ -118,9 +118,10 @@ create_cluster ()
     "${ATLAS_BASE_URL}/groups/${DRIVERS_ATLAS_GROUP_ID}/clusters?pretty=true" \
     -o /dev/stderr  \
     -w "%{http_code}")
-  # if [[ "$resp" != "200" ]]; then
-  #   exit 1
-  # fi
+  if [[ "$resp" != "201" ]]; then
+    echo "Exiting due to response code $resp != 201"
+    exit 1
+  fi
   echo "Got repsponse $resp"
   echo "Creating new Atlas Cluster... done."
 }

--- a/.evergreen/atlas/setup-atlas-cluster.sh
+++ b/.evergreen/atlas/setup-atlas-cluster.sh
@@ -110,12 +110,18 @@ EOF
 create_cluster ()
 {
   echo "Creating new Atlas Cluster..."
-  curl \
+  resp=$(curl \
     --digest -u "${DRIVERS_ATLAS_PUBLIC_API_KEY}:${DRIVERS_ATLAS_PRIVATE_API_KEY}" \
     -d "${CREATE_CLUSTER_JSON}" \
     -H 'Content-Type: application/json' \
     -X POST \
-    "${ATLAS_BASE_URL}/groups/${DRIVERS_ATLAS_GROUP_ID}/clusters?pretty=true"
+    "${ATLAS_BASE_URL}/groups/${DRIVERS_ATLAS_GROUP_ID}/clusters?pretty=true" \
+    -o /dev/stderr  \
+    -w "%{http_code}")
+  if [[ resp -neq 200 ]]; then
+    exit 1
+  fi
+  echo "Creating new Atlas Cluster... done."
 }
 
 # Check if cluster has a srv address, and assume once it does, it can be used.

--- a/.evergreen/atlas/setup-atlas-cluster.sh
+++ b/.evergreen/atlas/setup-atlas-cluster.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -o errexit  # Exit the script with error if any of the commands fail
+set -eu
 
 # Explanation of required environment variables:
 #
@@ -42,8 +42,6 @@ DRIVERS_ATLAS_GROUP_ID
 DRIVERS_ATLAS_LAMBDA_USER
 DRIVERS_ATLAS_LAMBDA_PASSWORD
 LAMBDA_STACK_NAME
-task_id
-execution
 )
 
 # Ensure that all variables required to run the test are set, otherwise throw
@@ -156,6 +154,8 @@ check_cluster ()
     # Put the MONGODB_URI in an expansions yml and secrets file.
     echo 'MONGODB_URI: "'$MONGODB_URI'"' > $CURRENT_DIR/atlas-expansion.yml
     echo "export MONGODB_URI=$MONGODB_URI" >> ./secrets-export.sh
+    echo "export ATLAS_BASE_URL=$ATLAS_BASE_URL" >> ./secrets-export.sh
+    echo "export FUNCTION_NAME=$FUNCTION_NAME" >> ./secrets-export.sh
   fi
 }
 

--- a/.evergreen/atlas/setup-atlas-cluster.sh
+++ b/.evergreen/atlas/setup-atlas-cluster.sh
@@ -14,7 +14,7 @@ set -eu
 # Explanation of generated variables:
 #
 # MONGODB_URI: The URI for the created Atlas cluster during this script.
-# FUNCTION_NAME: Uses the stack name plus the current commit sha to create a unique cluster and function.
+# CLUSTER_NAME: Uses the stack name plus the current commit sha to create a unique cluster and function.
 # CREATE_CLUSTER_JSON: The JSON used to create a cluster via the Atlas API.
 # ATLAS_BASE_URL: Where the Atlas API root resides.
 
@@ -81,7 +81,7 @@ CREATE_CLUSTER_JSON=$(cat <<EOF
   "diskSizeGB" : 10.0,
   "encryptionAtRestProvider" : "NONE",
   "mongoDBMajorVersion" : "${VERSION}",
-  "name" : "${FUNCTION_NAME}",
+  "name" : "${CLUSTER_NAME}",
   "numShards" : 1,
   "paused" : false,
   "pitEnabled" : false,
@@ -141,7 +141,7 @@ check_cluster ()
     SRV_ADDRESS=$(curl \
       --digest -u "${DRIVERS_ATLAS_PUBLIC_API_KEY}:${DRIVERS_ATLAS_PRIVATE_API_KEY}" \
       -X GET \
-      "${ATLAS_BASE_URL}/groups/${DRIVERS_ATLAS_GROUP_ID}/clusters/${FUNCTION_NAME}" \
+      "${ATLAS_BASE_URL}/groups/${DRIVERS_ATLAS_GROUP_ID}/clusters/${CLUSTER_NAME}" \
       | jq -r '.srvAddress'
     );
     count=$(( $count + 1 ))
@@ -160,7 +160,7 @@ check_cluster ()
     echo 'MONGODB_URI: "'$MONGODB_URI'"' > $CURRENT_DIR/atlas-expansion.yml
     echo "export MONGODB_URI=$MONGODB_URI" >> ./secrets-export.sh
     echo "export ATLAS_BASE_URL=$ATLAS_BASE_URL" >> ./secrets-export.sh
-    echo "export FUNCTION_NAME=$FUNCTION_NAME" >> ./secrets-export.sh
+    echo "export CLUSTER_NAME=$CLUSTER_NAME" >> ./secrets-export.sh
   fi
 }
 

--- a/.evergreen/atlas/setup-atlas-cluster.sh
+++ b/.evergreen/atlas/setup-atlas-cluster.sh
@@ -118,7 +118,7 @@ create_cluster ()
     "${ATLAS_BASE_URL}/groups/${DRIVERS_ATLAS_GROUP_ID}/clusters?pretty=true" \
     -o /dev/stderr  \
     -w "%{http_code}")
-  if [[ resp -neq 200 ]]; then
+  if [[ "$resp" -neq "200" ]]; then
     exit 1
   fi
   echo "Creating new Atlas Cluster... done."

--- a/.evergreen/atlas/setup-atlas-cluster.sh
+++ b/.evergreen/atlas/setup-atlas-cluster.sh
@@ -118,9 +118,10 @@ create_cluster ()
     "${ATLAS_BASE_URL}/groups/${DRIVERS_ATLAS_GROUP_ID}/clusters?pretty=true" \
     -o /dev/stderr  \
     -w "%{http_code}")
-  if [[ "$resp" != "200" ]]; then
-    exit 1
-  fi
+  # if [[ "$resp" != "200" ]]; then
+  #   exit 1
+  # fi
+  echo "Got repsponse $resp"
   echo "Creating new Atlas Cluster... done."
 }
 

--- a/.evergreen/atlas/setup-atlas-cluster.sh
+++ b/.evergreen/atlas/setup-atlas-cluster.sh
@@ -118,7 +118,7 @@ create_cluster ()
     "${ATLAS_BASE_URL}/groups/${DRIVERS_ATLAS_GROUP_ID}/clusters?pretty=true" \
     -o /dev/stderr  \
     -w "%{http_code}")
-  if [[ "$resp" -neq "200" ]]; then
+  if [[ "$resp" != "200" ]]; then
     exit 1
   fi
   echo "Creating new Atlas Cluster... done."

--- a/.evergreen/atlas/setup-atlas-cluster.sh
+++ b/.evergreen/atlas/setup-atlas-cluster.sh
@@ -31,7 +31,7 @@ if [ -f ./secrets-export.sh ]; then
 fi
 
 # Attempt to handle the secrets automatically if env vars are not set.
-if [ -z "$DRIVERS_ATLAS_PUBLIC_API_KEY" ]; then
+if [ -z "${DRIVERS_ATLAS_PUBLIC_API_KEY:}" ]; then
   . ../secrets_handling/setup-secrets.sh drivers/atlas
 fi
 

--- a/.evergreen/atlas/setup-atlas-cluster.sh
+++ b/.evergreen/atlas/setup-atlas-cluster.sh
@@ -122,7 +122,6 @@ create_cluster ()
     echo "Exiting due to response code $resp != 201"
     exit 1
   fi
-  echo "Got repsponse $resp"
   echo "Creating new Atlas Cluster... done."
 }
 

--- a/.evergreen/atlas/setup-variables.sh
+++ b/.evergreen/atlas/setup-variables.sh
@@ -15,11 +15,6 @@ set -eu
 DEFAULT_URL="https://cloud.mongodb.com/api/atlas/v1.0"
 ATLAS_BASE_URL="${DRIVERS_ATLAS_BASE_URL:-$DEFAULT_URL}"
 
-# Create a unique atlas project
-# Use the timestamp so we can prune old projects.
-# Add a random suffix to differentiate clusters.
-timestamp=$(date +%s)
-salt=$(node -e "process.stdout.write((Math.random() + 1).toString(36).substring(2))")
-
-# Add git commit to name of function and cluster.
-CLUSTER_NAME="${CLUSTER_PREFIX}-${timestamp}-${salt}"
+# Create a unique atlas project.
+suffix=$(node -e "require('crypto').randomBytes(32).toString('hex').slice(0,16)")
+CLUSTER_NAME="${CLUSTER_PREFIX}-${suffix}"

--- a/.evergreen/atlas/setup-variables.sh
+++ b/.evergreen/atlas/setup-variables.sh
@@ -3,18 +3,17 @@ set -eu
 
 # Explanation of required environment variables:
 #
-# LAMBDA_STACK_NAME: The name of the stack on lambda "dbx-<language>-lambda"
+# CLUSTER_PREFIX: The prefix for the cluster name, (e.g. dbx-python)
 
 # Explanation of generated variables:
 #
-# FUNCTION_NAME: Uses the stack name plus the current commit sha to create a unique cluster and function.
+# CLUSTER_NAME: The name of the created cluster.
 # ATLAS_BASE_URL: Where the Atlas API root resides.
 
-# The Atlas API version
-ATLAS_API_VERSION="v1.0"
 # The base Atlas API url. We use the API directly as the CLI does not yet
 # support testing cluster outages.
-ATLAS_BASE_URL="https://cloud.mongodb.com/api/atlas/$ATLAS_API_VERSION"
+DEFAULT_URL="https://cloud.mongodb.com/api/atlas/v1.0"
+ATLAS_BASE_URL="${DRIVERS_ATLAS_BASE_URL:-$DEFAULT_URL}"
 
 # Create a unique atlas project
 # Use the timestamp so we can prune old projects.
@@ -23,4 +22,4 @@ timestamp=$(date +%s)
 salt=$(node -e "process.stdout.write((Math.random() + 1).toString(36).substring(2))")
 
 # Add git commit to name of function and cluster.
-FUNCTION_NAME="${LAMBDA_STACK_NAME}-${timestamp}-${salt}"
+CLUSTER_NAME="${CLUSTER_PREFIX}-${timestamp}-${salt}"

--- a/.evergreen/atlas/setup-variables.sh
+++ b/.evergreen/atlas/setup-variables.sh
@@ -15,6 +15,6 @@ set -eu
 DEFAULT_URL="https://cloud.mongodb.com/api/atlas/v1.0"
 ATLAS_BASE_URL="${DRIVERS_ATLAS_BASE_URL:-$DEFAULT_URL}"
 
-# Create a unique atlas project.
-suffix=$(node -e "require('crypto').randomBytes(32).toString('hex').slice(0,16)")
+# Create a unique atlas project name.
+suffix=$(node -e "process.stdout.write(require('crypto').randomBytes(32).toString('hex').slice(0,16))")
 CLUSTER_NAME="${CLUSTER_PREFIX}-${suffix}"

--- a/.evergreen/atlas/teardown-atlas-cluster.sh
+++ b/.evergreen/atlas/teardown-atlas-cluster.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -o errexit  # Exit the script with error if any of the commands fail
+set -eu
 
 # Explanation of required environment variables:
 #
@@ -18,8 +18,6 @@ DRIVERS_ATLAS_PUBLIC_API_KEY
 DRIVERS_ATLAS_PRIVATE_API_KEY
 DRIVERS_ATLAS_GROUP_ID
 LAMBDA_STACK_NAME
-task_id
-execution
 )
 
 # Set up the common variables.
@@ -39,7 +37,9 @@ for VARNAME in ${VARLIST[*]}; do
 done
 
 # Set up the cluster variables.
-. $SCRIPT_DIR/setup-variables.sh
+if [ -z "${FUNCTION_NAME:-}" ]; then
+  . $SCRIPT_DIR/setup-variables.sh
+fi
 
 # Delete the cluster.
 echo "Deleting Atlas Cluster..."

--- a/.evergreen/atlas/teardown-atlas-cluster.sh
+++ b/.evergreen/atlas/teardown-atlas-cluster.sh
@@ -10,7 +10,7 @@ set -eu
 
 # Explanation of generated variables:
 #
-# FUNCTION_NAME: Uses the stack name plus the current commit sha to create a unique cluster and function.
+# CLUSTER_NAME: Uses the stack name plus the current commit sha to create a unique cluster and function.
 # ATLAS_BASE_URL: Where the Atlas API root resides.
 
 # Backwards compatibility: map LAMBDA_STACK_NAME to CLUSTER_PREFIX

--- a/.evergreen/atlas/teardown-atlas-cluster.sh
+++ b/.evergreen/atlas/teardown-atlas-cluster.sh
@@ -6,18 +6,23 @@ set -eu
 # DRIVERS_ATLAS_PUBLIC_API_KEY: The public Atlas key for the drivers org.
 # DRIVERS_ATLAS_PRIVATE_API_KEY: The private Atlas key for the drivers org.
 # DRIVERS_ATLAS_GROUP_ID: The id of the individual projects under the drivers org, per language.
-# LAMBDA_STACK_NAME: The name of the stack on lambda "dbx-<language>-lambda"
+# CLUSTER_PREFIX: The prefix for the cluster name, (e.g. dbx-python)
 
 # Explanation of generated variables:
 #
 # FUNCTION_NAME: Uses the stack name plus the current commit sha to create a unique cluster and function.
 # ATLAS_BASE_URL: Where the Atlas API root resides.
 
+# Backwards compatibility: map LAMBDA_STACK_NAME to CLUSTER_PREFIX
+if [ -n "${LAMBDA_STACK_NAME:-}" ]; then
+  CLUSTER_PREFIX=$LAMBDA_STACK_NAME
+fi
+
 VARLIST=(
 DRIVERS_ATLAS_PUBLIC_API_KEY
 DRIVERS_ATLAS_PRIVATE_API_KEY
 DRIVERS_ATLAS_GROUP_ID
-LAMBDA_STACK_NAME
+CLUSTER_PREFIX
 )
 
 # Set up the common variables.
@@ -37,7 +42,7 @@ for VARNAME in ${VARLIST[*]}; do
 done
 
 # Set up the cluster variables.
-if [ -z "${FUNCTION_NAME:-}" ]; then
+if [ -z "${CLUSTER_NAME:-}" ]; then
   . $SCRIPT_DIR/setup-variables.sh
 fi
 
@@ -46,6 +51,6 @@ echo "Deleting Atlas Cluster..."
 curl \
   --digest -u ${DRIVERS_ATLAS_PUBLIC_API_KEY}:${DRIVERS_ATLAS_PRIVATE_API_KEY} \
   -X DELETE \
-  "${ATLAS_BASE_URL}/groups/${DRIVERS_ATLAS_GROUP_ID}/clusters/${FUNCTION_NAME}?pretty=true"
+  "${ATLAS_BASE_URL}/groups/${DRIVERS_ATLAS_GROUP_ID}/clusters/${CLUSTER_NAME}?pretty=true"
 
 popd

--- a/.evergreen/atlas/teardown-atlas-cluster.sh
+++ b/.evergreen/atlas/teardown-atlas-cluster.sh
@@ -6,23 +6,12 @@ set -eu
 # DRIVERS_ATLAS_PUBLIC_API_KEY: The public Atlas key for the drivers org.
 # DRIVERS_ATLAS_PRIVATE_API_KEY: The private Atlas key for the drivers org.
 # DRIVERS_ATLAS_GROUP_ID: The id of the individual projects under the drivers org, per language.
-# CLUSTER_PREFIX: The prefix for the cluster name, (e.g. dbx-python)
-
-# Explanation of generated variables:
-#
-# CLUSTER_NAME: Uses the stack name plus the current commit sha to create a unique cluster and function.
-# ATLAS_BASE_URL: Where the Atlas API root resides.
-
-# Backwards compatibility: map LAMBDA_STACK_NAME to CLUSTER_PREFIX
-if [ -n "${LAMBDA_STACK_NAME:-}" ]; then
-  CLUSTER_PREFIX=$LAMBDA_STACK_NAME
-fi
 
 VARLIST=(
 DRIVERS_ATLAS_PUBLIC_API_KEY
 DRIVERS_ATLAS_PRIVATE_API_KEY
 DRIVERS_ATLAS_GROUP_ID
-CLUSTER_PREFIX
+CLUSTER_NAME
 )
 
 # Set up the common variables.
@@ -40,11 +29,6 @@ fi
 for VARNAME in ${VARLIST[*]}; do
 [[ -z "${!VARNAME:-}" ]] && echo "ERROR: $VARNAME not set" && exit 1;
 done
-
-# Set up the cluster variables.
-if [ -z "${CLUSTER_NAME:-}" ]; then
-  . $SCRIPT_DIR/setup-variables.sh
-fi
 
 # Delete the cluster.
 echo "Deleting Atlas Cluster..."

--- a/.evergreen/aws_lambda/run-deployed-lambda-aws-tests.sh
+++ b/.evergreen/aws_lambda/run-deployed-lambda-aws-tests.sh
@@ -43,9 +43,6 @@ for VARNAME in ${VARLIST[*]}; do
 [[ -z "${!VARNAME:-}" ]] && echo "ERROR: $VARNAME not set" && exit 1;
 done
 
-# Set up the atlas variables.
-. $SCRIPT_DIR/../atlas/setup-variables.sh
-
 # Restarts the cluster's primary node.
 restart_cluster_primary ()
 {

--- a/.evergreen/aws_lambda/run-deployed-lambda-aws-tests.sh
+++ b/.evergreen/aws_lambda/run-deployed-lambda-aws-tests.sh
@@ -53,7 +53,7 @@ restart_cluster_primary ()
   curl \
     --digest -u ${DRIVERS_ATLAS_PUBLIC_API_KEY}:${DRIVERS_ATLAS_PRIVATE_API_KEY} \
     -X POST \
-    "${ATLAS_BASE_URL}/groups/${DRIVERS_ATLAS_GROUP_ID}/clusters/${FUNCTION_NAME}/restartPrimaries"
+    "${ATLAS_BASE_URL}/groups/${DRIVERS_ATLAS_GROUP_ID}/clusters/${CLUSTER_NAME}/restartPrimaries"
 }
 
 # Deploys a lambda function to the set stack name.
@@ -62,7 +62,7 @@ deploy_lambda_function ()
   echo "Deploying Lambda function..."
   sam deploy \
     --no-confirm-changeset \
-    --stack-name "${FUNCTION_NAME}" \
+    --stack-name "${CLUSTER_NAME}" \
     --capabilities CAPABILITY_IAM \
     --resolve-s3 \
     --parameter-overrides "MongoDbUri=${MONGODB_URI}" \
@@ -74,7 +74,7 @@ get_lambda_function_arn ()
 {
   echo "Getting Lambda function ARN..."
   LAMBDA_FUNCTION_ARN=$(sam list stack-outputs \
-    --stack-name ${FUNCTION_NAME} \
+    --stack-name ${CLUSTER_NAME} \
     --region ${AWS_REGION} \
     --output json | jq '.[] | select(.OutputKey == "MongoDBFunction") | .OutputValue' | tr -d '"'
   )
@@ -85,7 +85,7 @@ get_lambda_function_arn ()
 delete_lambda_function ()
 {
   echo "Deleting Lambda Function..."
-  sam delete --stack-name ${FUNCTION_NAME} --no-prompts --region us-east-1
+  sam delete --stack-name ${CLUSTER_NAME} --no-prompts --region us-east-1
 }
 
 cleanup ()

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1165,7 +1165,7 @@ buildvariants:
       - "ubuntu-20.04"
   display_name: "Atlas ${os-requires-50}"
   tasks:
-    - test_atlas_task_group_task_group
+    - test_atlas_task_group
 
 - matrix_name: "serverless"
   matrix_spec:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -843,15 +843,21 @@ task_groups:
         params:
           # Set MONGODB_URI
           file: atlas-expansion.yml
-    teardown_task:
+    teardown_group:
       - command: subprocess.exec
         params:
           working_dir: src
           binary: bash
           args:
             - ${DRIVERS_TOOLS}/.evergreen/atlas/teardown-atlas-cluster.sh
+      - func: "teardown assets"
+      - func: "upload logs"
+      - func: "upload test results"
+      - func: "cleanup"
     setup_group_can_fail_task: true
     setup_group_timeout_secs: 1800
+    teardown_group_can_fail_task: true
+    teardown_group_timeout_secs: 1800
     tasks:
       - ".atlas"
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -355,6 +355,17 @@ functions:
           CRYPT_SHARED_LIB_PATH="${CRYPT_SHARED_LIB_PATH}" \
             bash ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
 
+  "run atlas tests":
+    - command: shell.exec
+      type: test
+      params:
+        working_dir: "src"
+        script: |
+          ${PREPARE_SHELL}
+          set +o xtrace
+          MONGODB_URI="${MONGODB_URI}" \
+            bash ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
+
   "run docker test":
     - command: shell.exec
       type: test
@@ -757,6 +768,11 @@ tasks:
       commands:
         - func: "run serverless tests"
 
+    - name: "test-atlas"
+      tags: ["atlas", "pr"]
+      commands:
+        - func: "run atlas tests"
+
     - name: "test-docker"
       tags: ["latest", "docker", "pr"]
       commands:
@@ -811,6 +827,34 @@ task_groups:
       - func: "cleanup"
     tasks:
       - ".serverless"
+
+  - name: test_atlas_task_group
+    setup_group:
+      - func: fetch source
+      - func: prepare resources
+      - command: subprocess.exec
+        params:
+          binary: bash
+          include_expansions_in_env: ["task_id", "execution"]
+          env:
+              LAMBDA_STACK_NAME: dbx-drivers-tools
+          args:
+            - ${DRIVERS_TOOLS}/.evergreen/atlas/setup-atlas-cluster.sh
+      - command: expansions.update
+        params:
+          # Set MONGODB_URI
+          file: atlas-expansion.yml
+    teardown_task:
+      - command: subprocess.exec
+        params:
+          working_dir: src
+          binary: bash
+          args:
+            - ${DRIVERS_TOOLS}/.evergreen/atlas/teardown-atlas-cluster.sh
+    setup_group_can_fail_task: true
+    setup_group_timeout_secs: 1800
+    tasks:
+      - ".atlas"
 
   - name: testazureoidc_task_group
     setup_group_can_fail_task: true
@@ -1114,6 +1158,14 @@ buildvariants:
       then:
         add_tasks:
           - "test-3.6-standalone"
+
+- matrix_name: "atlas"
+  matrix_spec:
+    os-requires-50:
+      - "ubuntu-20.04"
+  display_name: "Atlas ${os-requires-50}"
+  tasks:
+    - test_atlas_task_group_task_group
 
 - matrix_name: "serverless"
   matrix_spec:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -829,6 +829,10 @@ task_groups:
       - ".serverless"
 
   - name: test_atlas_task_group
+    setup_group_can_fail_task: true
+    setup_group_timeout_secs: 1800 # 30 minutes
+    teardown_group_can_fail_task: true
+    teardown_group_timeout_secs: 1800 # 30 minutes
     setup_group:
       - func: fetch source
       - func: prepare resources
@@ -854,10 +858,6 @@ task_groups:
       - func: "upload logs"
       - func: "upload test results"
       - func: "cleanup"
-    setup_group_can_fail_task: true
-    setup_group_timeout_secs: 1800
-    teardown_group_can_fail_task: true
-    teardown_group_timeout_secs: 1800
     tasks:
       - ".atlas"
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -838,7 +838,7 @@ task_groups:
           env:
               LAMBDA_STACK_NAME: dbx-drivers-tools
           args:
-            - ${DRIVERS_TOOLS}/.evergreen/atlas/setup-atlas-cluster.sh
+            - ${DRIVERS_TOOLS}/.evergreen/atlas/setup.sh
       - command: expansions.update
         params:
           # Set MONGODB_URI
@@ -849,7 +849,7 @@ task_groups:
           working_dir: src
           binary: bash
           args:
-            - ${DRIVERS_TOOLS}/.evergreen/atlas/teardown-atlas-cluster.sh
+            - ${DRIVERS_TOOLS}/.evergreen/atlas/teardown.sh
       - func: "teardown assets"
       - func: "upload logs"
       - func: "upload test results"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -835,7 +835,6 @@ task_groups:
       - command: subprocess.exec
         params:
           binary: bash
-          include_expansions_in_env: ["task_id", "execution"]
           env:
               LAMBDA_STACK_NAME: dbx-drivers-tools
           args:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -836,7 +836,7 @@ task_groups:
         params:
           binary: bash
           env:
-              LAMBDA_STACK_NAME: dbx-drivers-tools
+            CLUSTER_PREFIX: dbx-drivers-tools
           args:
             - ${DRIVERS_TOOLS}/.evergreen/atlas/setup.sh
       - command: expansions.update


### PR DESCRIPTION
- Enforce status code when creating cluster.
- Remove the need to pass in `execution` and `task_id` by storing the cluster name.
- Make Atlas standalone and not tied to Lambda, since it is used in other contexts.
- Make the Atlas base URI configurable so we can change it to non-prod.
- Add Atlas Test.


Tested with the Go Driver [here](https://spruce.mongodb.com/version/65e7dc5a562343a977ef45c6/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).