### PR TITLE
PYTHON-4243  Handle Submitted Review in Auto Review Assignment Script

### DIFF
--- a/.evergreen/github_app/assign-reviewer.mjs
+++ b/.evergreen/github_app/assign-reviewer.mjs
@@ -66,6 +66,18 @@ if (issue.draft) {
     process.exit(0);
 }
 
+// See if there are any reviews.
+resp = await octokit.request("GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews", {
+    owner,
+    repo,
+    pull_number: number,
+    headers
+});
+if (resp.data.length > 0) {
+    console.log("Review already submitted!");
+    process.exit(0);
+}
+
 const reviewers = [];
 const reviewersSource = fs.readFileSync(reviewersFilePath, { encoding: "utf-8"});
 for (let line of reviewersSource.split('\n')) {


### PR DESCRIPTION
Tested against https://github.com/mongodb/mongo-python-driver/pull/1545

```
node assign-reviewer.mjs -p /Users/steve.silvester/workspace/mongo-python-driver/.github/reviewers.txt -h 994c368f505a85012995a4ebc912d111a8852006 -o mongodb -n mongo-python-driver
Review already submitted!
+ popd
~/workspace/drivers-evergreen-tools/.evergreen/github_app
```