### PR TITLE
DRIVERS-2851 Use Cloud-Dev for Atlas Clusters

### DIFF
--- a/.evergreen/atlas/README.md
+++ b/.evergreen/atlas/README.md
@@ -5,7 +5,7 @@ The scripts in this folder are used to setup and teardown Atlas clusters.
 ## Prerequisites
 
 See [Secrets Handling](../secrets_handling/README.md) for details on how to access the secrets
-from the `drivers/atlas` vault.
+from the `drivers/atlas-dev` or `drivers/atlas` vault.
 
 ## Usage
 
@@ -47,3 +47,6 @@ An example task group running on a Linux EVG host might look like:
 
 If other OSes are needed, use the `setup-secrets.sh` script in this directory with the full `ec2.assume_role`
 method described in [Secrets Handling](../secrets_handling/README.md).
+
+By default, it will use the `drivers/atlas-dev` credentials for Cloud Dev.  You can pass `atlas` to
+either `setup-secrets.sh` or `setup.sh` to use a Prod environment instead.

--- a/.evergreen/atlas/setup-atlas-cluster.sh
+++ b/.evergreen/atlas/setup-atlas-cluster.sh
@@ -32,7 +32,7 @@ fi
 
 # Attempt to handle the secrets automatically if env vars are not set.
 if [ -z "${DRIVERS_ATLAS_PUBLIC_API_KEY:-}" ]; then
-  . ../secrets_handling/setup-secrets.sh drivers/atlas
+  . ./setup-secrets.sh
 fi
 
 # Backwards compatibility: map LAMBDA_STACK_NAME to CLUSTER_PREFIX

--- a/.evergreen/atlas/setup-atlas-cluster.sh
+++ b/.evergreen/atlas/setup-atlas-cluster.sh
@@ -32,7 +32,7 @@ fi
 
 # Attempt to handle the secrets automatically if env vars are not set.
 if [ -z "${DRIVERS_ATLAS_PUBLIC_API_KEY:-}" ]; then
-  . ./setup-secrets.sh
+  . ./setup-secrets.sh "$@"
 fi
 
 # Backwards compatibility: map LAMBDA_STACK_NAME to CLUSTER_PREFIX

--- a/.evergreen/atlas/setup-secrets.sh
+++ b/.evergreen/atlas/setup-secrets.sh
@@ -5,5 +5,5 @@ set -eu
 SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
 . $SCRIPT_DIR/../handle-paths.sh
 pushd $SCRIPT_DIR
-. $SCRIPT_DIR/../secrets_handling/setup-secrets.sh drivers/atlas
+. $SCRIPT_DIR/../secrets_handling/setup-secrets.sh drivers/atlas-dev
 popd

--- a/.evergreen/atlas/setup-secrets.sh
+++ b/.evergreen/atlas/setup-secrets.sh
@@ -5,5 +5,6 @@ set -eu
 SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
 . $SCRIPT_DIR/../handle-paths.sh
 pushd $SCRIPT_DIR
-. $SCRIPT_DIR/../secrets_handling/setup-secrets.sh drivers/atlas-dev
+VAULT_NAME="${1:-atlas-dev}"
+. $SCRIPT_DIR/../secrets_handling/setup-secrets.sh drivers/$VAULT_NAME
 popd

--- a/.evergreen/atlas/setup.sh
+++ b/.evergreen/atlas/setup.sh
@@ -5,4 +5,4 @@ set -o errexit
 SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
 . $SCRIPT_DIR/../handle-paths.sh
 
-. $SCRIPT_DIR/setup-atlas-cluster.sh
+. $SCRIPT_DIR/setup-atlas-cluster.sh "$@"

--- a/.evergreen/aws_lambda/README.md
+++ b/.evergreen/aws_lambda/README.md
@@ -3,4 +3,4 @@
 See the [FaaS Automated Testing specification](https://github.com/mongodb/specifications/blob/master/source/faas-automated-testing/faas-automated-testing.rst) for details.
 
 See [Secrets Handling README](../secrets-handling/README.md) for details on how to access the secrets
-from the `drivers/atlas` vault.
+from the `drivers/atlas-dev` vault.

--- a/.evergreen/secrets_handling/README.md
+++ b/.evergreen/secrets_handling/README.md
@@ -15,7 +15,8 @@ The `setup-secrets.sh` script in this folder can be used for other vaults such a
 | Vault                     | Usage |
 | -----                     | ------|
 | drivers/adl               | Used in [`atlas_data_lake`](../atlas_data_lake/README.md) for Atlas Data Lake testing. |
-| drivers/atlas             | Used in [`atlas`](../atlas/README.md) to launch an atlas cluster. |
+| drivers/atlas             | Can be manually used in conjunction with [`atlas`](../atlas/README.md) to launch an atlas cluster in the prod environment. |
+| drivers/atlas-dev         | Used in [`atlas`](../atlas/README.md) to launch an atlas cluster in the dev environment. |
 | drivers/atlas_connect     | Has the URIs used in the Atlas Connect Drivers tests. |
 | drivers/aws_auth          | Used in [`auth_aws`](../auth_aws/README.md)  for AWS Auth testing. |
 | drives/azurekms           | Used in [`csfle/azurekms`](../csfle/azurekms/README.md) for Azure KMS testing. |


### PR DESCRIPTION
Tested with Python driver [here](https://spruce.mongodb.com/version/6602be018a65e0000796feaf/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).