### PR TITLE
Fix serverless cluster setup

### DIFF
--- a/.evergreen/atlas/atlas-utils.sh
+++ b/.evergreen/atlas/atlas-utils.sh
@@ -80,7 +80,7 @@ check_deployment ()
       "${ATLAS_BASE_URL}/groups/${ATLAS_GROUP_ID}/${TYPE}/${DEPLOYMENT_NAME}")
     if [[ "$RESP" =~ '"stateName":"IDLE"' ]]; then
         if [ $TYPE = "serverless" ]; then
-            PROP="['connectionString']['standardSrv']"
+            PROP="['connectionStrings']['standardSrv']"
         else
             PROP="['srvAddress']"
         fi


### PR DESCRIPTION
#433 removed up usage of `jq` in atlas-utils.sh, but in doing so introduced a small typo which led to an error when parsing the response. There was also an additional usage of `jq` left in setup-cluster.sh, which I removed with analogous code. I've tested these changes and can confirm that they fix PHP's serverless tests on Debian 11.