### PR TITLE
Bump stable server versions

### DIFF
--- a/.evergreen/atlas/atlas-utils.sh
+++ b/.evergreen/atlas/atlas-utils.sh
@@ -27,19 +27,19 @@ create_deployment ()
 
   ATLAS_BASE_URL=${ATLAS_BASE_URL:-"https://account-dev.mongodb.com/api/atlas/v1.0"}
   TYPE=${DEPLOYMENT_TYPE:-"clusters"}
-  echo "Creating new Atlas Deployment in Group $ATLAS_GROUP_ID..."
+  echo "Creating new Atlas Deployment in Group $ATLAS_GROUP_ID..." 1>&2
   RESP=$(curl -sS -L \
     --digest -u "${ATLAS_PUBLIC_API_KEY}:${ATLAS_PRIVATE_API_KEY}" \
     -d "${DEPLOYMENT_DATA}" \
     -H 'Content-Type: application/json' \
     -X POST \
     "${ATLAS_BASE_URL}/groups/${ATLAS_GROUP_ID}/${TYPE}?pretty=true")
-  echo "$RESP"
+  echo "$RESP" 1>&2
   if [[ ! "$RESP" =~ '"stateName" : "CREATING"' ]]; then
-    echo "Exiting due to unexpected response state"
+    echo "Exiting due to unexpected response state" 1>&2
     exit 1
   fi
-  echo "Creating new Atlas Deployment in Group $ATLAS_GROUP_ID... done."
+  echo "Creating new Atlas Deployment in Group $ATLAS_GROUP_ID... done." 1>&2
 }
 
 # Check if deployment has a srv address, and assume once it does, it can be used.

--- a/.evergreen/atlas/atlas-utils.sh
+++ b/.evergreen/atlas/atlas-utils.sh
@@ -36,7 +36,7 @@ create_deployment ()
     "${ATLAS_BASE_URL}/groups/${ATLAS_GROUP_ID}/${TYPE}?pretty=true")
   echo "$RESP"
   if [[ ! "$RESP" =~ '"stateName" : "CREATING"' ]]; then
-    echo "Exiting due to unexpected response $STATE"
+    echo "Exiting due to unexpected response state"
     exit 1
   fi
   echo "Creating new Atlas Deployment in Group $ATLAS_GROUP_ID... done."

--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -56,10 +56,10 @@ get_mongodb_download_url_for ()
    VERSION_MONGOSH="2.1.1"
    # Set VERSION_RAPID to the latest rapid release each quarter.
    VERSION_RAPID="7.3.1"
-   VERSION_70="7.0.6"
+   VERSION_70="7.0.9"
    VERSION_60_LATEST="v6.0-latest"
-   VERSION_60="6.0.14"
-   VERSION_50="5.0.25"
+   VERSION_60="6.0.15"
+   VERSION_50="5.0.26"
    VERSION_44="4.4.29"
 
    # This version is used for performance benchmarking. Do not update to a newer version


### PR DESCRIPTION
Tested with go driver: https://spruce.mongodb.com/version/662fd1fcea00a40007adee4f/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC