### PR TITLE
Add Python binary path for AWS Mac Fleet

### DIFF
--- a/.evergreen/find-python3.sh
+++ b/.evergreen/find-python3.sh
@@ -233,6 +233,9 @@ find_python3() (
     # /opt/mongodbtoolchain/vX/bin/python
     append_bins "/opt/mongodbtoolchain" "v[0-9]*" "bin/python3" "bin/python"
 
+    # /Library/Frameworks/Python.Framework/Versions/XXX/bin/python3 (used by AWS Mac Fleet)
+    append_bins "/Library/Frameworks/Python.Framework/Versions/" "[0-9]*" "bin/python3"
+
     bin="python3"
     if is_python3 "$bin"; then bins+=("$bin"); fi
 


### PR DESCRIPTION
We need to check for Python in another location for `macos-14` and `macos-14-arm64` distos.
Here is [example run](https://spruce.mongodb.com/task/dot_net_driver_tests_compression_macOS__version~6.0_os~macos_14_arm64_topology~standalone_auth~noauth_ssl~nossl_compressor~snappy_test_netstandard21_patch_9eb4dca262de9cc8facc9829b3893cdd1b1cd8d4_663e544fd0bf5b0007aa926c_24_05_10_17_07_43?execution=0&sortBy=STATUS&sortDir=ASC) of that distos.
