### PR TITLE
Fix OIDC self-test

### DIFF
--- a/.evergreen/auth_oidc/azure/remote-scripts/run-self-test.sh
+++ b/.evergreen/auth_oidc/azure/remote-scripts/run-self-test.sh
@@ -9,7 +9,8 @@ pushd ./drivers-evergreen-tools/.evergreen/auth_oidc
 # Run the Python Driver Test
 git clone https://github.com/mongodb/mongo-python-driver
 pushd mongo-python-driver
-python setup.py install --no_ext
+pip install -U -q pip
+pip install .
 popd
 pip install -q requests
 python azure/remote-scripts/test.py

--- a/.evergreen/auth_oidc/gcp/remote-scripts/run-self-test.sh
+++ b/.evergreen/auth_oidc/gcp/remote-scripts/run-self-test.sh
@@ -8,8 +8,8 @@ pushd mongo-python-driver
 python3 -m venv .venv
 source .venv/bin/activate
 pip install -U -q pip
-pip install -U -q requests setuptools
-python setup.py -q install --no_ext
+pip install -U -q requests
+pip install .
 popd
 echo "Installing dependencies ... end"
 


### PR DESCRIPTION
We use a different build backend now, so a direct invocation of setup.py doesn't work.