### PR TITLE
Use bash -c option to invoke command with its own args

### DIFF
--- a/.evergreen/secrets_handling/README.md
+++ b/.evergreen/secrets_handling/README.md
@@ -43,7 +43,7 @@ If using a Linux host on Evergreen, the shorthand version of the script can be u
       - ${DRIVERS_TOOLS}/.evergreen/atlas/setup-secrets.sh
 ```
 
-if using one of the convenience scripts in one of the subfolders, or the following to use the
+If using one of the convenience scripts in one of the subfolders, or the following to use the
 script in this directory:
 
 ```yaml
@@ -52,6 +52,7 @@ script in this directory:
     working_dir: src
     binary: bash
     args:
+      - -c
       - ${DRIVERS_TOOLS}/.evergreen/secrets_handling/setup-secrets.sh drivers/enterprise_auth
 ```
 


### PR DESCRIPTION
The `-c` option is necessary to ensure the vault name arg is passed to `setup-secrets.sh` and not `bash` itself. This was overlooked in https://github.com/mongodb-labs/drivers-evergreen-tools/pull/449.