### PR TITLE
Use newer version of oscrypto for OCSP mock server

### DIFF
--- a/.evergreen/ocsp/mock-ocsp-responder-requirements.txt
+++ b/.evergreen/ocsp/mock-ocsp-responder-requirements.txt
@@ -4,5 +4,5 @@ flask==2.2.5
 itsdangerous==2.1.2
 Jinja2==3.1.4
 MarkupSafe==2.1.4
-oscrypto==1.3.0
+git+https://github.com/wbond/oscrypto.git@d5f3437
 Werkzeug==3.0.3


### PR DESCRIPTION
The stable version of oscrypto has a [bug](https://github.com/wbond/oscrypto/issues/75) that prevents it from working with OpenSSL 3.0.10:

```
Traceback (most recent call last):
[2024/06/27 14:49:14.487]   File "/data/mci/91c84d5568444dead3a62ac8435331d4/drivers-tools/.evergreen/ocsp/ocsp_mock.py", line 13, in <module>
[2024/06/27 14:49:14.487]     import mock_ocsp_responder
[2024/06/27 14:49:14.487]   File "/data/mci/91c84d5568444dead3a62ac8435331d4/drivers-tools/.evergreen/ocsp/mock_ocsp_responder.py", line 56, in <module>
[2024/06/27 14:49:14.487]     from oscrypto import asymmetric
[2024/06/27 14:49:14.487]   File "/data/mci/91c84d5568444dead3a62ac8435331d4/drivers-tools/.evergreen/ocsp/ocspvenv/lib/python3.10/site-packages/oscrypto/asymmetric.py", line 19, in <module>
[2024/06/27 14:49:14.487]     from ._asymmetric import _unwrap_private_key_info
[2024/06/27 14:49:14.487]   File "/data/mci/91c84d5568444dead3a62ac8435331d4/drivers-tools/.evergreen/ocsp/ocspvenv/lib/python3.10/site-packages/oscrypto/_asymmetric.py", line 27, in <module>
[2024/06/27 14:49:14.487]     from .kdf import pbkdf1, pbkdf2, pkcs12_kdf
[2024/06/27 14:49:14.487]   File "/data/mci/91c84d5568444dead3a62ac8435331d4/drivers-tools/.evergreen/ocsp/ocspvenv/lib/python3.10/site-packages/oscrypto/kdf.py", line 9, in <module>
[2024/06/27 14:49:14.487]     from .util import rand_bytes
[2024/06/27 14:49:14.487]   File "/data/mci/91c84d5568444dead3a62ac8435331d4/drivers-tools/.evergreen/ocsp/ocspvenv/lib/python3.10/site-packages/oscrypto/util.py", line 14, in <module>
[2024/06/27 14:49:14.487]     from ._openssl.util import rand_bytes
[2024/06/27 14:49:14.487]   File "/data/mci/91c84d5568444dead3a62ac8435331d4/drivers-tools/.evergreen/ocsp/ocspvenv/lib/python3.10/site-packages/oscrypto/_openssl/util.py", line 6, in <module>
[2024/06/27 14:49:14.487]     from ._libcrypto import libcrypto, libcrypto_version_info, handle_openssl_error
[2024/06/27 14:49:14.487]   File "/data/mci/91c84d5568444dead3a62ac8435331d4/drivers-tools/.evergreen/ocsp/ocspvenv/lib/python3.10/site-packages/oscrypto/_openssl/_libcrypto.py", line 15, in <module>
[2024/06/27 14:49:14.487]     from ._libcrypto_ctypes import (
[2024/06/27 14:49:14.487]   File "/data/mci/91c84d5568444dead3a62ac8435331d4/drivers-tools/.evergreen/ocsp/ocspvenv/lib/python3.10/site-packages/oscrypto/_openssl/_libcrypto_ctypes.py", line 47, in <module>
[2024/06/27 14:49:14.487]     raise LibraryNotFoundError('Error detecting the version of libcrypto')
```

This PR updates to an unstable version of oscrypto while we're waiting for a stable release.

I've tested the change in the PHP driver and it fixes the broken OCSP tests.