### PR TITLE
Standardise bash shebang

### DIFF
--- a/.evergreen/ensure-binary.sh
+++ b/.evergreen/ensure-binary.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Ensure the given binary is on the PATH.
 # Should be called as:

--- a/.evergreen/handle-paths.sh
+++ b/.evergreen/handle-paths.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # This script will handle the correct cross-platform absolute
 # paths for a script directory and DRIVERS_TOOLS.

--- a/.evergreen/ocsp/ecdsa/mock-delegate-revoked.sh
+++ b/.evergreen/ocsp/ecdsa/mock-delegate-revoked.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 python3 ../ocsp_mock.py \
   --ca_file ca.pem \
   --ocsp_responder_cert ocsp-responder.crt \

--- a/.evergreen/ocsp/ecdsa/mock-delegate-valid.sh
+++ b/.evergreen/ocsp/ecdsa/mock-delegate-valid.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 python3 ../ocsp_mock.py \
   --ca_file ca.pem \
   --ocsp_responder_cert ocsp-responder.crt \

--- a/.evergreen/ocsp/ecdsa/mock-revoked.sh
+++ b/.evergreen/ocsp/ecdsa/mock-revoked.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # Use the CA as the OCSP responder
 python3 ../ocsp_mock.py \
   --ca_file ca.pem \

--- a/.evergreen/ocsp/ecdsa/mock-valid.sh
+++ b/.evergreen/ocsp/ecdsa/mock-valid.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 python3 ../ocsp_mock.py \
   --ca_file ca.pem \
   --ocsp_responder_cert ca.crt \

--- a/.evergreen/ocsp/rsa/mock-delegate-revoked.sh
+++ b/.evergreen/ocsp/rsa/mock-delegate-revoked.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 python3 ../ocsp_mock.py \
   --ca_file ca.pem \
   --ocsp_responder_cert ocsp_responder.crt \

--- a/.evergreen/ocsp/rsa/mock-delegate-valid.sh
+++ b/.evergreen/ocsp/rsa/mock-delegate-valid.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 python3 ../ocsp_mock.py \
   --ca_file ca.pem \
   --ocsp_responder_cert ocsp-responder.crt \

--- a/.evergreen/ocsp/rsa/mock-revoked.sh
+++ b/.evergreen/ocsp/rsa/mock-revoked.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 python3 ../ocsp_mock.py \
   --ca_file ca.pem \
   --ocsp_responder_cert ca.crt \

--- a/.evergreen/ocsp/rsa/mock-valid.sh
+++ b/.evergreen/ocsp/rsa/mock-valid.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 python3 ../ocsp_mock.py \
   --ca_file ca.pem \
   --ocsp_responder_cert ca.crt \

--- a/.evergreen/run-orchestration.sh
+++ b/.evergreen/run-orchestration.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -o errexit  # Exit the script with error if any of the commands fail
 
 # Supported environment variables:

--- a/.evergreen/stop-orchestration.sh
+++ b/.evergreen/stop-orchestration.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -o errexit  # Exit the script with error if any of the commands fail
 
 cd "$MONGO_ORCHESTRATION_HOME"


### PR DESCRIPTION
Related to DRIVERS-2852

The GitHub Action does not explicitly use a shell when calling `run-orchestration.sh`, but instead relies on the shebang to choose the appropriate shell. This causes warnings when running the action:

```
/home/runner/work/drivers-evergreen-tools/drivers-evergreen-tools/.//.evergreen/run-orchestration.sh: 23: /home/runner/work/drivers-evergreen-tools/drivers-evergreen-tools/.//.evergreen/handle-paths.sh: [[: not found
/home/runner/work/drivers-evergreen-tools/drivers-evergreen-tools/.//.evergreen/run-orchestration.sh: 40: /home/runner/work/drivers-evergreen-tools/drivers-evergreen-tools/.//.evergreen/handle-paths.sh: [[: not found
/home/runner/work/drivers-evergreen-tools/drivers-evergreen-tools/.//.evergreen/run-orchestration.sh: 59: /home/runner/work/drivers-evergreen-tools/drivers-evergreen-tools/.//.evergreen/handle-paths.sh: [[: not found
```

This PR changes all shebangs to use `/usr/bin/env bash`, so that any invocations of scripts that do not explicitly use `sh` (as is the case in some evergreen configs) use bash. This removes warnings above.

Note that any drivers that have not yet completed DRIVERS-2852 (currently C, C++, Node, Ruby, Rust) might see changes in behaviour on Evergreen if they do not use an explicit shell when invoking run-orchestration.sh or any other script changed here. I don't think there are any negative side-effects to this, but wanted to point it out.

### Testing

To test this PR, change the `uses` key in the GitHub Action Workflow using this action to the following, then run the workflow:

```yaml
uses: alcaeus/drivers-evergreen-tools@use-bash-shebang
```

A green build with no warnings indicates that this PR does what it's supposed to do.