### PR TITLE
Download correct crypt_shared version when starting serverless instance

### DIFF
--- a/.evergreen/serverless/create-instance.sh
+++ b/.evergreen/serverless/create-instance.sh
@@ -140,7 +140,7 @@ fi
 
 if [ "${SERVERLESS_SKIP_CRYPT:-}" != "OFF" ]; then
   # Download binaries and crypt_shared
-  MONGODB_VERSION=rapid bash ./download-crypt.sh
+  MONGODB_VERSION=$(echo $SERVERLESS_MONGODB_VERSION | cut -d '.' -f-2) bash ./download-crypt.sh
 fi
 
 popd

--- a/.evergreen/serverless/download-crypt.sh
+++ b/.evergreen/serverless/download-crypt.sh
@@ -2,6 +2,8 @@
 
 MONGODB_VERSION=${MONGODB_VERSION:-latest}
 
+echo "Download crypt_shared for MongoDB ${MONGODB_VERSION}"
+
 SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
 . $SCRIPT_DIR/../handle-paths.sh
 


### PR DESCRIPTION
We currently download the rapid release for serverless, but this is prone to being outdated and needs manual updating. With this change, the serverless `create-instance` script attempts to download crypt_shared for the matching version. If this version is not available, the setup will fail, indicating there's a problem with the serverless version. Previously, you would sometimes get test failures (for example in CSFLE/QE tests) when versions don't match.

Tested with the PHP driver and confirmed that it downloads MongoDB 8.0 (our serverless instances are running 8.0.0-rc13).