### PR TITLE
Run action tests on MacOS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,7 @@ jobs:
         os:
           - "ubuntu-latest"
           - "windows-latest"
+          - "macos-latest"
         mongodb-version:
           - "7.0"
         topology:


### PR DESCRIPTION
This adds testing on MacOS for the GitHub Action, ensuring that mongo-orchestration is able to start servers.