### PR TITLE
fix `run-server.sh` volume path in Cygwin

### DIFF
--- a/.evergreen/docker/run-server.sh
+++ b/.evergreen/docker/run-server.sh
@@ -69,7 +69,13 @@ fi
 test -t 1 && ARGS+=" -t"
 
 # Map in the DRIVERS_TOOLS directory.
-ARGS+=" -v `pwd`:/root/drivers-evergreen-tools"
+HOSTPATH="$(pwd)"
+if [[ "$(uname -s)" == CYGWIN* ]]; then
+  # Convert to Windows-style path when run in Cygwin.
+  HOSTPATH=$(cygpath -w "$HOSTPATH")
+fi
+
+ARGS+=" -v $HOSTPATH:/root/drivers-evergreen-tools"
 
 # Launch server docker container.
 docker run $ARGS $NAME $ENTRYPOINT


### PR DESCRIPTION
To fix an observed error running `run-server.sh` with a Cygwin shell:

```
/root/base-entrypoint.sh: line 10: cd: /root/drivers-evergreen-tools/.evergreen:
 No such file or directory
```

The error appears caused by the Unix-style path in the host path of the `-v` argument. This PR changes the host path to Windows-style.

Example before:
```
-v /cygdrive/c/code/drivers-evergreen-tools:/root/drivers-evergreen-tools
```

Example after:
```
-v C:\code\drivers-evergreen-tools:/root/drivers-evergreen-tools
```

https://docs.docker.com/reference/cli/docker/container/run/#volume notes:

> On Windows, you must specify the paths using Windows-style path semantics.