### PR TITLE
Revert "fix `run-server.sh` volume path in Cygwin (#464)"

### DIFF
--- a/.evergreen/docker/run-server.sh
+++ b/.evergreen/docker/run-server.sh
@@ -69,13 +69,7 @@ fi
 test -t 1 && ARGS+=" -t"
 
 # Map in the DRIVERS_TOOLS directory.
-HOSTPATH="$(pwd)"
-if [[ "$(uname -s)" == CYGWIN* ]]; then
-  # Convert to Windows-style path when run in Cygwin.
-  HOSTPATH=$(cygpath -w "$HOSTPATH")
-fi
-
-ARGS+=" -v $HOSTPATH:/root/drivers-evergreen-tools"
+ARGS+=" -v `pwd`:/root/drivers-evergreen-tools"
 
 # Launch server docker container.
 docker run $ARGS $NAME $ENTRYPOINT


### PR DESCRIPTION
This reverts commit b0e2d57ece3d041313f8026edf0da2a6803aa6db.

To fix [failing GitHub actions tests](https://github.com/mongodb-labs/drivers-evergreen-tools/actions/runs/10254785646). I am not-yet sure what the cause of the failure is. 