### PR TITLE
Fix dpkg contention in VM setup scripts

### DIFF
--- a/.evergreen/csfle/azurekms/remote-scripts/setup-azure-vm.sh
+++ b/.evergreen/csfle/azurekms/remote-scripts/setup-azure-vm.sh
@@ -6,7 +6,7 @@ set -o pipefail
 echo "Installing dependencies ... begin"
 # Skip the "Processing triggers for man-db" step.
 echo "set man-db/auto-update false" | sudo debconf-communicate
-sudo dpkg-reconfigure -o DPkg::Lock::Timeout=-1 -f noninteractive man-db
+sudo dpkg-reconfigure -f noninteractive man-db || true  # This may fail if the lock file is held.
 sudo apt-get -qq update
 OPTIONS="-qq -y -o DPkg::Lock::Timeout=-1"
 # Dependencies for mongod: https://www.mongodb.com/docs/manual/tutorial/install-mongodb-enterprise-on-debian-tarball/

--- a/.evergreen/csfle/azurekms/remote-scripts/setup-azure-vm.sh
+++ b/.evergreen/csfle/azurekms/remote-scripts/setup-azure-vm.sh
@@ -5,7 +5,8 @@ set -o pipefail
 
 echo "Installing dependencies ... begin"
 # Skip the "Processing triggers for man-db" step.
-echo "set man-db/auto-update false" | sudo debconf-communicate; sudo dpkg-reconfigure -f noninteractive man-db
+echo "set man-db/auto-update false" | sudo debconf-communicate
+sudo dpkg-reconfigure -o DPkg::Lock::Timeout=-1 -f noninteractive man-db
 sudo apt-get -qq update
 OPTIONS="-qq -y -o DPkg::Lock::Timeout=-1"
 # Dependencies for mongod: https://www.mongodb.com/docs/manual/tutorial/install-mongodb-enterprise-on-debian-tarball/

--- a/.evergreen/csfle/gcpkms/remote-scripts/setup-gce-instance.sh
+++ b/.evergreen/csfle/gcpkms/remote-scripts/setup-gce-instance.sh
@@ -7,7 +7,7 @@ set -o errexit # Exit on first command error.
 echo "Installing dependencies ... begin"
 # Skip the "Processing triggers for man-db" step.
 echo "set man-db/auto-update false" | sudo debconf-communicate
-sudo dpkg-reconfigure -o DPkg::Lock::Timeout=-1 -f noninteractive man-db
+sudo dpkg-reconfigure -f noninteractive man-db || true  # This may fail if the lock file is held.
 sudo apt-get -qq update
 OPTIONS="-y -qq -o DPkg::Lock::Timeout=-1"
 # Dependencies for mongod: https://www.mongodb.com/docs/manual/tutorial/install-mongodb-enterprise-on-debian-tarball/

--- a/.evergreen/csfle/gcpkms/remote-scripts/setup-gce-instance.sh
+++ b/.evergreen/csfle/gcpkms/remote-scripts/setup-gce-instance.sh
@@ -6,7 +6,8 @@ set -o errexit # Exit on first command error.
 
 echo "Installing dependencies ... begin"
 # Skip the "Processing triggers for man-db" step.
-echo "set man-db/auto-update false" | sudo debconf-communicate; sudo dpkg-reconfigure -f noninteractive man-db
+echo "set man-db/auto-update false" | sudo debconf-communicate
+sudo dpkg-reconfigure -o DPkg::Lock::Timeout=-1 -f noninteractive man-db
 sudo apt-get -qq update
 OPTIONS="-y -qq -o DPkg::Lock::Timeout=-1"
 # Dependencies for mongod: https://www.mongodb.com/docs/manual/tutorial/install-mongodb-enterprise-on-debian-tarball/


### PR DESCRIPTION
The `dpkg-reconfigure` step is optional, and may fail if there is a global lock in place.   We can't use the `Lock::Timeout=-1` trick for this call, so we just have to ignore the error code.