### PR TITLE
 DRIVERS-2956 Fix return value of findComment in Github App

### DIFF
--- a/.evergreen/github_app/utils.mjs
+++ b/.evergreen/github_app/utils.mjs
@@ -54,7 +54,7 @@ async function findComment(octokit, owner, repo, targetSha, bodyMatch, state) {
         issue_number: issue.number,
         headers
     });
-    return { comment: resp.data.find(comment => comment.body.includes(bodyMatch)), number: issue.number}
+    return { comment: resp.data.find(comment => comment.body.includes(bodyMatch)), issue_number: issue.number}
 }
 
 


### PR DESCRIPTION
It is consumed as `const {comment, issue_number } = await findComment(octokit, owner, repo, targetSha, bodyMatch, "open");`, which was getting read in as an `undefined` `issue_number`.