### PR TITLE
RUST-2024 Fix CRYPT_SHARED_LIB_PATH expansion

### DIFF
--- a/.evergreen/serverless/create-instance.sh
+++ b/.evergreen/serverless/create-instance.sh
@@ -115,9 +115,9 @@ if [ -f "./secrets-export.sh" ]; then
   echo "export SERVERLESS_URI=$SERVERLESS_URI" >> ./secrets-export.sh
 fi
 
+popd
+
 if [ "${SERVERLESS_SKIP_CRYPT:-}" != "OFF" ]; then
   # Download binaries and crypt_shared
-  MONGODB_VERSION=$(echo $SERVERLESS_MONGODB_VERSION | cut -d '.' -f-2) bash ./download-crypt.sh
+  MONGODB_VERSION=$(echo $SERVERLESS_MONGODB_VERSION | cut -d '.' -f-2) bash $SCRIPT_DIR/download-crypt.sh
 fi
-
-popd


### PR DESCRIPTION
Without this fix, `download-crypt.sh` will write the expansion to `$SCRIPT_DIR/serverless-expansion.yml` rather than `$CURRENT_DIR/serverless-expansion.yml`.