### PR TITLE
PYTHON-4734 Allow download-mongodb to run under sh

### DIFF
--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -3,7 +3,7 @@
 #For future use the feed to get full list of distros : http://downloads.mongodb.org/full.json
 
 set -o errexit  # Exit the script with error if any of the commands fail
-SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+SCRIPT_DIR=$(dirname ${BASH_SOURCE:-$0})
 . $SCRIPT_DIR/handle-paths.sh
 
 get_distro ()


### PR DESCRIPTION
Copies the pattern used in `run-orchestration.sh`.