### PR TITLE
fix: make function syntax compatible with sh

### DIFF
--- a/.evergreen/retry-with-backoff.sh
+++ b/.evergreen/retry-with-backoff.sh
@@ -9,7 +9,7 @@
 #
 # Successive backoffs double the timeout.
 #
-function retry_with_backoff {
+retry_with_backoff() {
   local max_attempts=${ATTEMPTS-5}
   local timeout=${TIMEOUT-1}
   local attempt=0


### PR DESCRIPTION
Change function declaration syntax used to be compatible with sh.