### PR TITLE
PYTHON-4764 Update to use current supported EVG hosts

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1194,9 +1194,9 @@ axes:
         display_name: "macOS 11"
         run_on: macos-11
 
-      - id: windows-2022
+      - id: windows
         display_name: "Windows 64"
-        run_on: windows-2022-small
+        run_on: windows-64-vsMulti-small
 
   # OSes that support versions of MongoDB>=7.0 with SSL.
   - id: os-requires-70

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1188,7 +1188,7 @@ axes:
 
       - id: rhel8
         display_name: "RHEL 8"
-        run_on: rhel88-small
+        run_on: rhel8.8-small
 
       - id: macos-14
         display_name: "macOS 14"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1188,15 +1188,15 @@ axes:
 
       - id: rhel8
         display_name: "RHEL 8"
-        run_on: rhel87-small
+        run_on: rhel88-small
 
-      - id: macos-1100
-        display_name: "macOS 11.00"
-        run_on: macos-1100
+      - id: macos-11
+        display_name: "macOS 11"
+        run_on: macos-11
 
-      - id: windows-64-vsMulti-small
+      - id: windows-2022
         display_name: "Windows 64"
-        run_on: windows-64-vsMulti-small
+        run_on: windows-2022-small
 
   # OSes that support versions of MongoDB>=7.0 with SSL.
   - id: os-requires-70
@@ -1215,9 +1215,13 @@ axes:
         display_name: "Amazon Linux 2023 x64"
         run_on: amazon2023.0-small
 
+      - id: macos-14-arm64
+        display_name: "macOS 14 arm64"
+        run_on: macos-14-arm64
+
       - id: rhel9
-        display_name: "RHEL 9.0 x64"
-        run_on: rhel91-small
+        display_name: "RHEL 9 x64"
+        run_on: rhel94-small
 
   # OSes that support versions of MongoDB>=5.0 with SSL.
   - id: os-requires-50
@@ -1232,21 +1236,21 @@ axes:
         display_name: "Ubuntu 20.04"
         run_on: ubuntu2004-test
 
-      - id: ubuntu2004-arm64-small
+      - id: ubuntu2004-arm64
         display_name: "Ubuntu 20.04 (ARM64)"
         run_on: ubuntu2004-arm64-small
 
-      - id: rhel70-small
+      - id: rhel7
         display_name: "RHEL 7"
         run_on: rhel70-small
 
-      - id: rhel87-power8
+      - id: rhel8-power8
         display_name: "RHEL 8 (POWER8)"
-        run_on: rhel81-power8-small
+        run_on: rhel8-power-small
 
-      - id: rhel83-zseries-small
+      - id: rhel8-zseries
         display_name: "RHEL8 (zSeries)"
-        run_on: rhel83-zseries-small
+        run_on: rhel8-zseries-small
 
   - id: topology
     display_name: Topology

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1190,9 +1190,9 @@ axes:
         display_name: "RHEL 8"
         run_on: rhel88-small
 
-      - id: macos-11
-        display_name: "macOS 11"
-        run_on: macos-11
+      - id: macos-14
+        display_name: "macOS 14"
+        run_on: macos-14
 
       - id: windows
         display_name: "Windows 64"
@@ -1246,7 +1246,7 @@ axes:
 
       - id: rhel8-power8
         display_name: "RHEL 8 (POWER8)"
-        run_on: rhel8-power-small
+        run_on: rhel8-power-large
 
       - id: rhel8-zseries
         display_name: "RHEL8 (zSeries)"

--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -155,7 +155,7 @@ get_mongodb_download_url_for ()
              MONGODB_60_PERF="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-rhel90${DEBUG}-${VERSION_60_PERF}.tgz"
              MONGODB_60="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-rhel90${DEBUG}-${VERSION_60}.tgz"
       ;;
-      linux-rhel-8.1-ppc64le)
+      linux-rhel-8*-ppc64le)
          MONGODB_LATEST="http://downloads.10gen.com/linux/mongodb-linux-ppc64le-enterprise-rhel81${DEBUG}-latest.tgz"
          MONGOSH="https://downloads.mongodb.com/compass/mongosh-${VERSION_MONGOSH}-linux-ppc64le.tgz"
              MONGODB_RAPID="http://downloads.10gen.com/linux/mongodb-linux-ppc64le-enterprise-rhel81${DEBUG}-${VERSION_RAPID}.tgz"
@@ -213,7 +213,7 @@ get_mongodb_download_url_for ()
              MONGODB_36="http://downloads.10gen.com/linux/mongodb-linux-s390x-enterprise-rhel72${DEBUG}-3.6.4.tgz"
              MONGODB_34="http://downloads.10gen.com/linux/mongodb-linux-s390x-enterprise-rhel72${DEBUG}-3.4.14.tgz"
       ;;
-      linux-rhel-7.1-ppc64le)
+      linux-rhel-7*-ppc64le)
          MONGODB_LATEST="http://downloads.10gen.com/linux/mongodb-linux-ppc64le-enterprise-rhel71${DEBUG}-latest.tgz"
          MONGOSH="https://downloads.mongodb.com/compass/mongosh-${VERSION_MONGOSH}-linux-ppc64le.tgz"
              MONGODB_50="http://downloads.10gen.com/linux/mongodb-linux-ppc64le-enterprise-rhel71${DEBUG}-${VERSION_50}.tgz"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         os:
           - "ubuntu-latest"


### PR DESCRIPTION
[DEVPROD-5083](https://jira.mongodb.org/browse/DEVPROD-5083)
[DEVPROD-40](https://jira.mongodb.org/browse/DEVPROD-40)
[DEVPROD-21](https://jira.mongodb.org/browse/DEVPROD-21)