### PR TITLE
RUST-2035 Fix invocation of mongosh for requireApiVersion

### DIFF
--- a/.evergreen/run-orchestration.sh
+++ b/.evergreen/run-orchestration.sh
@@ -173,5 +173,5 @@ EOT
 
 # Set the requireApiVersion parameter
 if [ ! -z "$REQUIRE_API_VERSION" ]; then
-  mongosh $URI $MONGO_ORCHESTRATION_HOME/require-api-version.js
+  $MONGODB_BINARIES/mongosh $URI $MONGO_ORCHESTRATION_HOME/require-api-version.js
 fi


### PR DESCRIPTION
RUST-2035

Example [failing run](https://parsley.mongodb.com/evergreen/mongo_rust_driver_stable_api_test_latest_standalone_61621db9719653b888652f1a56387009683fe280_24_09_13_13_56_55/0/task?bookmarks=0,1174&shareLine=1001) and [passing run](https://spruce.mongodb.com/version/66e9b4e75ae3be000756f058/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) against my fork with the fix.

I'm honestly not sure how this worked before; `mongosh` is [moved into](https://github.com/mongodb-labs/drivers-evergreen-tools/blob/master/.evergreen/download-mongodb.sh#L751) the `$MONGODB_BINARIES` path by the install script and isn't in `$PATH`.