### PR TITLE
Add a Rust Installer

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -503,6 +503,32 @@ functions:
           cd ${PROJECT_DIRECTORY}
           make test
 
+  "run install binaries test":
+    - command: shell.exec
+      type: test
+      params:
+        shell: bash
+        script: |-
+          set -o errexit
+          cd ${DRIVERS_TOOLS}
+          .evergreen/install-node.sh
+          .evergreen/install-rust.sh
+          PATH=.bin:$PATH
+          if [ $OS == "Windows_NT" ]; then
+            exit 0
+          fi
+          case $(uname -m) in
+            aarch64 | x86_64 | arm64)
+              . ./.evergreen/ensure-binary.sh gcloud
+              gcloud --version
+              . ./.evergreen/ensure-binary.sh kubectl
+              which kubectl
+              ;;
+          esac
+          # Generate a test results file
+          cd ${PROJECT_DIRECTORY}
+          make test
+
   "teardown assets":
     - command: subprocess.exec
       params:
@@ -938,6 +964,11 @@ tasks:
         #   vars:
         #     VARIANT: aks
 
+    - name: "test-install-binaries"
+      tags: ["pr"]
+      commands:
+        - func: "run install binaries test"
+
 # }}}
 
 task_groups:
@@ -1367,6 +1398,13 @@ buildvariants:
      - name: "test-3.6-replica_set"
      - name: "test-3.6-sharded_cluster"
      - name: "test-3.6-standalone"
+  rules:
+    - if:
+        auth: "auth"
+        ssl: "ssl"
+        os-requires-50: "*"
+      then:
+        add_tasks: ["test-install-binaries"]
 
 - matrix_name: "tests-os-requires-50"
   matrix_spec: {"os-requires-50": "*", auth: "*", ssl: "*" }
@@ -1384,6 +1422,13 @@ buildvariants:
      - name: "test-5.0-replica_set"
      - name: "test-5.0-sharded_cluster"
      - name: "test-5.0-standalone"
+  rules:
+    - if:
+        auth: "auth"
+        ssl: "ssl"
+        os-requires-50: "*"
+      then:
+        add_tasks: ["test-install-binaries"]
 
 - matrix_name: "tests-os-requires-70"
   matrix_spec: {"os-requires-70": "*", auth: "*", ssl: "*" }
@@ -1398,6 +1443,13 @@ buildvariants:
      - name: "test-7.0-replica_set"
      - name: "test-7.0-sharded_cluster"
      - name: "test-7.0-standalone"
+  rules:
+    - if:
+        auth: "auth"
+        ssl: "ssl"
+        os-requires-70: "*"
+      then:
+        add_tasks: ["test-install-binaries"]
 
 # Storage Engine Tests on Ubuntu 20.04
 - matrix_name: "tests-storage-engines"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -511,7 +511,7 @@ functions:
         script: |-
           set -o errexit
           cd ${DRIVERS_TOOLS}
-          if [ -n "${SKIP_NODE}" ]; then
+          if [ -z "${SKIP_NODE}" ]; then
             .evergreen/install-node.sh
           fi
           .evergreen/install-rust.sh

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -511,7 +511,9 @@ functions:
         script: |-
           set -o errexit
           cd ${DRIVERS_TOOLS}
-          .evergreen/install-node.sh
+          if [ -n "${SKIP_NODE}" ]; then
+            .evergreen/install-node.sh
+          fi
           .evergreen/install-rust.sh
           PATH=.bin:$PATH
           if [ $OS == "Windows_NT" ]; then
@@ -1274,6 +1276,8 @@ axes:
       - id: rhel7
         display_name: "RHEL 7"
         run_on: rhel70-small
+        variables:
+          SKIP_NODE: 1
 
       - id: rhel8-power8
         display_name: "RHEL 8 (POWER8)"
@@ -1402,7 +1406,7 @@ buildvariants:
     - if:
         auth: "auth"
         ssl: "ssl"
-        os-requires-50: "*"
+        os-fully-featured: "*"
       then:
         add_tasks: ["test-install-binaries"]
 

--- a/.evergreen/ensure-binary.sh
+++ b/.evergreen/ensure-binary.sh
@@ -86,6 +86,7 @@ else
   "$SCRIPT_DIR/retry-with-backoff.sh" curl -L -s $URL -o $FNAME
   tar xfz $FNAME
   popd
+  mkdir -p ${DRIVERS_TOOLS}/.bin
   ln -s /tmp/google-cloud-sdk/bin/gcloud $DRIVERS_TOOLS/.bin/gcloud
 fi
 

--- a/.evergreen/install-rust.sh
+++ b/.evergreen/install-rust.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -ue
+set -eu
 
 SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
 . $SCRIPT_DIR/handle-paths.sh
@@ -17,7 +17,7 @@ if [ "Windows_NT" == "${OS:-}" ]; then
   CARGO_HOME=$(cygpath ${CARGO_HOME} --windows)
 fi
 
-"$SCRIPT_DIR/retry-with-backoff.sh" curl https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path ${DEFAULT_HOST_OPTIONS:-}
+curl --retry 8 https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path ${DEFAULT_HOST_OPTIONS:-}
 
 if [ "Windows_NT" == "${OS:-}" ]; then
   # This file is not created by default on Windows

--- a/.evergreen/install-rust.sh
+++ b/.evergreen/install-rust.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -ue
+
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+. $SCRIPT_DIR/handle-paths.sh
+pushd $SCRIPT_DIR
+
+export RUSTUP_HOME="${RUSTUP_HOME:-"${DRIVERS_TOOLS}/.rustup"}"
+export CARGO_HOME="${CARGO_HOME:-"${DRIVERS_TOOLS}/.cargo"}"
+export PATH="${RUSTUP_HOME}/bin:${CARGO_HOME}/bin:$PATH"
+
+# Make sure to use msvc toolchain rather than gnu, which is the default for cygwin
+if [ "Windows_NT" == "${OS:-}" ]; then
+  export DEFAULT_HOST_OPTIONS='--default-host x86_64-pc-windows-msvc'
+  # rustup/cargo need the native Windows paths
+  RUSTUP_HOME=$(cygpath ${RUSTUP_HOME} --windows)
+  CARGO_HOME=$(cygpath ${CARGO_HOME} --windows)
+  # This file is not created by default on Windows
+  echo 'export PATH="$PATH:${CARGO_HOME}/bin"' >>${CARGO_HOME}/env
+  echo "export CARGO_NET_GIT_FETCH_WITH_CLI=true" >>${CARGO_HOME}/env
+fi
+
+"$SCRIPT_DIR/retry-with-backoff.sh" curl https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path ${DEFAULT_HOST_OPTIONS:-}
+
+echo "cargo location: $(which cargo)"
+echo "cargo version: $(cargo --version)"
+echo "rustc location: $(which rustc)"
+echo "rustc version: $(rustc --version)"
+
+popd

--- a/.evergreen/install-rust.sh
+++ b/.evergreen/install-rust.sh
@@ -15,12 +15,15 @@ if [ "Windows_NT" == "${OS:-}" ]; then
   # rustup/cargo need the native Windows paths
   RUSTUP_HOME=$(cygpath ${RUSTUP_HOME} --windows)
   CARGO_HOME=$(cygpath ${CARGO_HOME} --windows)
+fi
+
+"$SCRIPT_DIR/retry-with-backoff.sh" curl https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path ${DEFAULT_HOST_OPTIONS:-}
+
+if [ "Windows_NT" == "${OS:-}" ]; then
   # This file is not created by default on Windows
   echo 'export PATH="$PATH:${CARGO_HOME}/bin"' >>${CARGO_HOME}/env
   echo "export CARGO_NET_GIT_FETCH_WITH_CLI=true" >>${CARGO_HOME}/env
 fi
-
-"$SCRIPT_DIR/retry-with-backoff.sh" curl https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path ${DEFAULT_HOST_OPTIONS:-}
 
 echo "cargo location: $(which cargo)"
 echo "cargo version: $(cargo --version)"

--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,8 @@ mo-expansion.sh
 .env
 .bin
 .kube
+.cargo
+.rustup
 
 # Azure functions.
 .python_packages/


### PR DESCRIPTION
The Python team has a need for a Rust compiler on the hosts.

Copied from [rust driver](https://github.com/mongodb/mongo-rust-driver/blob/6a23464f6351a77ee97ff2cfbbc7fc196fd5a849/.evergreen/install-dependencies.sh).

Also adds test for our binary installers.