### PR TITLE
GODRIVER-3358 Add authSource override to OIDC connection strings

### DIFF
--- a/.evergreen/auth_oidc/gcp/setup.sh
+++ b/.evergreen/auth_oidc/gcp/setup.sh
@@ -98,7 +98,7 @@ URI=$(check_deployment)
 
 cat <<EOF >> "secrets-export.sh"
 export MONGODB_URI="$URI"
-export MONGODB_URI_SINGLE="$URI/?authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:gcp,TOKEN_RESOURCE:$GCPOIDC_AUDIENCE"
+export MONGODB_URI_SINGLE="$URI/?authMechanism=MONGODB-OIDC&authSource=%24external&authMechanismProperties=ENVIRONMENT:gcp,TOKEN_RESOURCE:$GCPOIDC_AUDIENCE"
 export OIDC_ADMIN_USER=$GCPOIDC_ATLAS_USER
 export OIDC_ADMIN_PWD=$GCPOIDC_ATLAS_PASSWORD
 EOF

--- a/.evergreen/auth_oidc/setup.sh
+++ b/.evergreen/auth_oidc/setup.sh
@@ -97,7 +97,7 @@ EOF
   URI=$(check_deployment)
   cat <<EOF >> "secrets-export.sh"
 export MONGODB_URI="$URI"
-export MONGODB_URI_SINGLE="$URI/?authMechanism=MONGODB-OIDC"
+export MONGODB_URI_SINGLE="$URI/?authMechanism=MONGODB-OIDC&authSource=%24external"
 export OIDC_ADMIN_USER=$OIDC_ATLAS_USER
 export OIDC_ADMIN_PWD=$OIDC_ATLAS_PASSWORD
 EOF


### PR DESCRIPTION
Passing build of the go driver: https://spruce.mongodb.com/task/mongo_go_driver_testoidc_variant_oidc_auth_test_gcp_patch_60ded84e486dda6eea4f446d642571489a3ed3d0_66f220595dbfb3000702f953_24_09_24_02_13_56/logs?execution=0