### PR TITLE
DRIVERS-2991 Properly kill old MO server to avoid "Address already in use" errors

### DIFF
--- a/.evergreen/start-orchestration.sh
+++ b/.evergreen/start-orchestration.sh
@@ -35,7 +35,8 @@ venvcreate "${PYTHON:?}" venv
 echo "Creating virtual environment 'venv'... done."
 
 # DRIVERS-2991 bottle 0.13 causes "[Errno 98] Address already in use" errors on some hosts.
-python -m pip install --upgrade 'bottle<0.13'
+# Fallback to bottle >=0.13 only for Python >=3.13.
+python -m pip install --upgrade 'bottle<0.13' && python -c 'import bottle' || python -m pip install --upgrade bottle
 # Install from github to get the latest mongo-orchestration, fall back on published wheel.
 # The fallback was added to accommodate versions of Python 3 for which there is no compatible version
 # of the hatchling backend used by mongo-orchestration.

--- a/.evergreen/start-orchestration.sh
+++ b/.evergreen/start-orchestration.sh
@@ -34,6 +34,8 @@ echo "Creating virtual environment 'venv'..."
 venvcreate "${PYTHON:?}" venv
 echo "Creating virtual environment 'venv'... done."
 
+# DRIVERS-2991 bottle 0.13 causes "[Errno 98] Address already in use" errors on some hosts.
+python -m pip install --upgrade 'bottle<0.13'
 # Install from github to get the latest mongo-orchestration, fall back on published wheel.
 # The fallback was added to accommodate versions of Python 3 for which there is no compatible version
 # of the hatchling backend used by mongo-orchestration.

--- a/.evergreen/start-orchestration.sh
+++ b/.evergreen/start-orchestration.sh
@@ -71,7 +71,7 @@ elif [ -x "$(command -v ss)" ]; then
     kill -9 "$OLD_MO_PID" || true
   fi
 else
-  echo "Unable to identify the OS (${OSTYPE:?}) or find necessary utilities (lsof/ss) to kill the process."
+  echo "Unable to identify the OS (${OSTYPE:?}) or find necessary utilities (fuser/lsof/ss) to kill the process."
   exit 1
 fi
 

--- a/.evergreen/start-orchestration.sh
+++ b/.evergreen/start-orchestration.sh
@@ -34,9 +34,6 @@ echo "Creating virtual environment 'venv'..."
 venvcreate "${PYTHON:?}" venv
 echo "Creating virtual environment 'venv'... done."
 
-# DRIVERS-2991 bottle 0.13 causes "[Errno 98] Address already in use" errors on some hosts.
-# Fallback to bottle >=0.13 only for Python >=3.13.
-python -m pip install --upgrade 'bottle<0.13' && python -c 'import bottle' || python -m pip install --upgrade bottle
 # Install from github to get the latest mongo-orchestration, fall back on published wheel.
 # The fallback was added to accommodate versions of Python 3 for which there is no compatible version
 # of the hatchling backend used by mongo-orchestration.
@@ -61,6 +58,8 @@ if [[ "${OSTYPE:?}" == cygwin || "${OSTYPE:?}" == msys ]]; then
   if [ ! -z "$OLD_MO_PID" ]; then
     taskkill /F /T /PID "$OLD_MO_PID" || true
   fi
+elif [ -x "$(command -v fuser)" ]; then
+  fuser --kill 8889/tcp || true
 elif [ -x "$(command -v lsof)" ]; then
   OLD_MO_PID=$(lsof -t -i:8889 || true)
   if [ ! -z "$OLD_MO_PID" ]; then


### PR DESCRIPTION
DRIVERS-2991 Properly kill old MO server to avoid "Address already in use" errors.

The ss+awk solution doesn't work on RHEL 8 anymore for unknown reasons:
```
$ ss -tlnp 'sport = :8889'
State                           Recv-Q                           Send-Q                                                       Local Address:Port                                                       Peer Address:Port
LISTEN                          0                                5                                                                127.0.0.1:8889                                                            0.0.0.0:*                               users:(("mongo-orchestra",pid=7676,fd=5))
$ ss -tlnp 'sport = :8889' | awk 'NR>1 {split($7,a,","); print a[1]}'
```

Perhaps `ss` was updated and reports output differently than it used to? Or perhaps `awk` has changed? Either way using `fuser` should do the trick.