### PR TITLE
Include 7.0 and 8.0 in crypt shared version check

### DIFF
--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -632,7 +632,7 @@ get_mongodb_download_url_for ()
    case "$_VERSION" in
       latest)
          # If latest is not at least 6.0 on this OS, the crypt_shared package will not be available.
-         if [ -n "$MONGODB_60" ]; then
+         if [ -n "$MONGODB_60" ] && [ -n "$MONGODB_70" ] && [ -n "$MONGODB_80" ]; then
            MONGO_CRYPT_SHARED_DOWNLOAD_URL=$MONGODB_LATEST
          fi ;;
       rapid) MONGO_CRYPT_SHARED_DOWNLOAD_URL=$MONGODB_RAPID ;;


### PR DESCRIPTION
# Summary
Check if 7.0 or 8.0 downloads are present to determine if crypt shared is available.

# Background
Intended to address test failures observed in the C++ driver Evergreen on Debian 12 indicating the crypt shared library [is unavailable](https://spruce.mongodb.com/task/mongo_cxx_driver_debian12_release_latest_compile_and_test_with_shared_libs_cxx20_patch_fb2698102a2ddcfa0e3a120c39a8672a20e83753_66f471b703792900072d14fb_24_09_25_20_25_28/logs?execution=0). Logs print:

```
There is no crypt_shared library for distro='linux-debian-12-x86_64' and version='latest'.
``` 

Debian 12 has 7.0 and 8.0 downloads, but not 6.0. `get_mongodb_download_url_for` determines of the crypt shared library is available by checking if the distro has 6.0 or higher downloads available.