### PR TITLE
Revert "DRIVERS-2991 Properly kill old MO server to avoid "Address al…

### DIFF
--- a/.evergreen/start-orchestration.sh
+++ b/.evergreen/start-orchestration.sh
@@ -58,8 +58,6 @@ if [[ "${OSTYPE:?}" == cygwin || "${OSTYPE:?}" == msys ]]; then
   if [ ! -z "$OLD_MO_PID" ]; then
     taskkill /F /T /PID "$OLD_MO_PID" || true
   fi
-elif [ -x "$(command -v fuser)" ]; then
-  fuser --kill 8889/tcp || true
 elif [ -x "$(command -v lsof)" ]; then
   OLD_MO_PID=$(lsof -t -i:8889 || true)
   if [ ! -z "$OLD_MO_PID" ]; then
@@ -71,7 +69,7 @@ elif [ -x "$(command -v ss)" ]; then
     kill -9 "$OLD_MO_PID" || true
   fi
 else
-  echo "Unable to identify the OS (${OSTYPE:?}) or find necessary utilities (fuser/lsof/ss) to kill the process."
+  echo "Unable to identify the OS (${OSTYPE:?}) or find necessary utilities (lsof/ss) to kill the process."
   exit 1
 fi
 


### PR DESCRIPTION
…ready in use" errors (#504)"

This reverts commit 3608d5220c6a09f949ab7ccadf4bfcecc38ac4d8.