### PR TITLE
use `||` not `&&` in crypt shared check

### DIFF
--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -632,7 +632,7 @@ get_mongodb_download_url_for ()
    case "$_VERSION" in
       latest)
          # If latest is not at least 6.0 on this OS, the crypt_shared package will not be available.
-         if [ -n "$MONGODB_60" ] && [ -n "$MONGODB_70" ] && [ -n "$MONGODB_80" ]; then
+         if [ -n "$MONGODB_60" ] || [ -n "$MONGODB_70" ] || [ -n "$MONGODB_80" ]; then
            MONGO_CRYPT_SHARED_DOWNLOAD_URL=$MONGODB_LATEST
          fi ;;
       rapid) MONGO_CRYPT_SHARED_DOWNLOAD_URL=$MONGODB_RAPID ;;


### PR DESCRIPTION
Follow-up to #505. Fixes check to use `&&` instead of `||`.

Verified with a temporary Debian 12 task in the C++ driver to verify `CRYPT_SHARED_LIB_PATH` is set. Without this fix, the [task fails](https://spruce.mongodb.com/version/66f6b7605e4a7000075afe3e). With this fix, the [task succeeds](https://spruce.mongodb.com/version/66f6bc4505648b0007fa8bac).
