### PR TITLE
Support handling multiple PIDs in killport

### DIFF
--- a/.evergreen/start-orchestration.sh
+++ b/.evergreen/start-orchestration.sh
@@ -66,22 +66,19 @@ killport() {
   local pid=""
 
   if [[ "${OSTYPE:?}" == cygwin || "${OSTYPE:?}" == msys ]]; then
-    pid=$(netstat -ano | grep ":$port .* LISTENING" | awk '{print $5}' | tr -d '[:space:]')
-    if [ -n "$pid" ]; then
+    for pid in $(netstat -ano | grep ":$port .* LISTENING" | awk '{print $5}' | tr -d '[:space:]'); do
       taskkill /F /T /PID "$pid" || true
-    fi
+    done
   elif [ -x "$(command -v lsof)" ]; then
-    pid=$(lsof -t "-i:$port" || true)
-    if [ -n "$pid" ]; then
+    for pid in $(lsof -t "-i:$port" || true); do
       kill "$pid" || true
-    fi
+    done
   elif [ -x "$(command -v fuser)" ]; then
     fuser --kill -SIGTERM "$port/tcp" || true
   elif [ -x "$(command -v ss)" ]; then
-    pid=$(ss -tlnp "sport = :$port" | awk 'NR>1 {split($7,a,","); print a[1]}' | tr -d '[:space:]')
-    if [ -n "$pid" ]; then
+    for pid in $(ss -tlnp "sport = :$port" | awk 'NR>1 {split($7,a,","); print a[1]}' | tr -d '[:space:]'); do
       kill "$pid" || true
-    fi
+    done
   else
     echo "Unable to identify the OS (${OSTYPE:?}) or find necessary utilities (fuser/lsof/ss) to kill the process."
     exit 1


### PR DESCRIPTION
Addresses the following possible error on certain distros (e.g. Ubuntu 18.04) due to `lsof` returning more than one PID:

```
start-orchestration.sh: line 76: kill: 4850
5401: arguments must be process or job IDs
```

Extends all find-and-kill-PID routines to support the possibility of multiple PIDs being returned by the PID query command.