### PR TITLE
Assign Github PR reviews in round-robin order.

### DIFF
--- a/.evergreen/github_app/assign-reviewer.mjs
+++ b/.evergreen/github_app/assign-reviewer.mjs
@@ -76,7 +76,8 @@ for (let line of reviewersSource.split('\n')) {
 }
 // Use the Github PR number to select the next reviewer in round-robin order. We
 // assume that Github PR numbers are sequential and that the order of reviewer
-// names is consistent across runs.
+// names is consistent across runs. Note that Github Issues must be disabled
+// because they share the same number sequence with Github PRs.
 const reviewer = reviewers[number % reviewers.length];
 
 console.log("Assigning reviewer to PR...");

--- a/.evergreen/github_app/assign-reviewer.mjs
+++ b/.evergreen/github_app/assign-reviewer.mjs
@@ -74,7 +74,10 @@ for (let line of reviewersSource.split('\n')) {
     }
     reviewers.push(line);
 }
-const reviewer = reviewers[Math.floor(Math.random() * reviewers.length)]
+// Use the Github PR number to select the next reviewer in round-robin order. We
+// assume that Github PR numbers are sequential and that the order of reviewer
+// names is consistent across runs.
+const reviewer = reviewers[number % reviewers.length];
 
 console.log("Assigning reviewer to PR...");
 resp = await octokit.request("POST /repos/{owner}/{repo}/pulls/{number}/requested_reviewers", {


### PR DESCRIPTION
Assign PR reviewers in round-robin order instead of pseudo-random order. While pseud-random order guarantees evenness across lots of PRs, it can lack evenness in the short term, sometimes assigning too many PRs to one person.