### PR TITLE
DRIVERS-2987 Restrict access to Azure VMs

### DIFF
--- a/.evergreen/auth_oidc/azure/run-driver-test.sh
+++ b/.evergreen/auth_oidc/azure/run-driver-test.sh
@@ -24,6 +24,9 @@ export AZUREKMS_RESOURCEGROUP=$AZUREOIDC_RESOURCEGROUP
 export AZUREKMS_VMNAME=$AZUREOIDC_VMNAME
 export AZUREKMS_PRIVATEKEYPATH=$SCRIPT_DIR/keyfile
 
+# Permit SSH access from current IP.
+"$DRIVERS_TOOLS"/.evergreen/csfle/azurekms/set-ssh-ip.sh
+
 # Set up the remote driver checkout.
 DRIVER_TARFILE_BASE=$(basename ${AZUREOIDC_DRIVERS_TAR_FILE})
 # shellcheck disable=SC2088

--- a/.evergreen/csfle/azurekms/copy-file.sh
+++ b/.evergreen/csfle/azurekms/copy-file.sh
@@ -18,6 +18,10 @@ if [ -z "${AZUREKMS_RESOURCEGROUP:-}" ] || \
     exit 1
 fi
 
+# Permit SSH access from current IP.
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+"$SCRIPT_DIR"/set-ssh-ip.sh
+
 echo "Copying file $AZUREKMS_SRC to Virtual Machine $AZUREKMS_DST ... begin"
 IP=$(az vm show --show-details --resource-group "$AZUREKMS_RESOURCEGROUP" --name "$AZUREKMS_VMNAME" --query publicIps -o tsv)
 # Use -o StrictHostKeyChecking=no to skip the prompt for known hosts.

--- a/.evergreen/csfle/azurekms/create-vm.sh
+++ b/.evergreen/csfle/azurekms/create-vm.sh
@@ -23,6 +23,7 @@ echo "Creating a Virtual Machine ($AZUREKMS_VMNAME) ... begin"
 # Use --nic-delete-option 'Delete' to delete the NIC.
 # Specify a name for the public IP to delete later.
 # Specify a name for the Network Security Group (NSG) to delete later.
+# Use --nsg-rule=NONE to remove default open SSH and RDP ports.
 # Pipe to /dev/null to hide the output. The output includes tenantId.
 az vm create \
     --resource-group "$AZUREKMS_RESOURCEGROUP" \
@@ -46,4 +47,17 @@ else
     SHUTDOWN_TIME=$(date -u -d "$(date) + 1 hours" +"%H%M")
 fi
 az vm auto-shutdown -g $AZUREKMS_RESOURCEGROUP -n $AZUREKMS_VMNAME --time $SHUTDOWN_TIME
+
+EXTERNAL_IP=$(curl -s http://whatismyip.akamai.com/)
+
+# Add a network security group rule to permit SSH from current IP. This rule is updated with the current IP in "set-ssh-ip.sh" to permit SSH from different Evergreen hosts.
+az network nsg rule create \
+    --name "$AZUREKMS_VMNAME-nsg-rule" \
+    --nsg-name "$AZUREKMS_VMNAME-nsg" \
+    --priority 100 \
+    --resource-group "$AZUREKMS_RESOURCEGROUP" \
+    --destination-port-ranges 22 \
+    --description "To allow SSH access" \
+    --source-address-prefixes "$EXTERNAL_IP"
+
 echo "Creating a Virtual Machine ($AZUREKMS_VMNAME) ... end"

--- a/.evergreen/csfle/azurekms/create-vm.sh
+++ b/.evergreen/csfle/azurekms/create-vm.sh
@@ -36,6 +36,7 @@ az vm create \
     --os-disk-delete-option "Delete" \
     --public-ip-address "$AZUREKMS_VMNAME-PUBLIC-IP" \
     --nsg "$AZUREKMS_VMNAME-NSG" \
+    --nsg-rule "NONE" \
     --assign-identity $AZUREKMS_IDENTITY \
     >/dev/null
 

--- a/.evergreen/csfle/azurekms/run-command.sh
+++ b/.evergreen/csfle/azurekms/run-command.sh
@@ -22,5 +22,5 @@ SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 
 echo "Running '$AZUREKMS_CMD' on Azure Virtual Machine ... begin"
 IP=$(az vm show --show-details --resource-group $AZUREKMS_RESOURCEGROUP --name $AZUREKMS_VMNAME --query publicIps -o tsv)
-ssh -o StrictHostKeyChecking=no azureuser@$IP -i "$AZUREKMS_PRIVATEKEYPATH" "$AZUREKMS_CMD"
+ssh -n -o StrictHostKeyChecking=no azureuser@$IP -i "$AZUREKMS_PRIVATEKEYPATH" "$AZUREKMS_CMD"
 echo "Running '$AZUREKMS_CMD' on Azure Virtual Machine ... end"

--- a/.evergreen/csfle/azurekms/run-command.sh
+++ b/.evergreen/csfle/azurekms/run-command.sh
@@ -16,6 +16,10 @@ for VARNAME in "${VARLIST[@]}"; do
   [[ -z "${!VARNAME:-}" ]] && echo "ERROR: $VARNAME not set" && exit 1;
 done
 
+# Permit SSH access from current IP.
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+"$SCRIPT_DIR"/set-ssh-ip.sh
+
 echo "Running '$AZUREKMS_CMD' on Azure Virtual Machine ... begin"
 IP=$(az vm show --show-details --resource-group $AZUREKMS_RESOURCEGROUP --name $AZUREKMS_VMNAME --query publicIps -o tsv)
 ssh -o StrictHostKeyChecking=no azureuser@$IP -i "$AZUREKMS_PRIVATEKEYPATH" "$AZUREKMS_CMD"

--- a/.evergreen/csfle/azurekms/set-ssh-ip.sh
+++ b/.evergreen/csfle/azurekms/set-ssh-ip.sh
@@ -26,11 +26,10 @@ EXTERNAL_IP=$(curl -s http://whatismyip.akamai.com/)
 
 echo "Adding current IP ($EXTERNAL_IP) to Azure Virtual Machine ... begin"
 az network nsg rule update \
-    --only-show-errors \
     --name "$AZUREKMS_VMNAME-nsg-rule" \
     --nsg-name "$AZUREKMS_VMNAME-nsg" \
     --resource-group "$AZUREKMS_RESOURCEGROUP" \
-    --source-address-prefixes "$EXTERNAL_IP"
+    --source-address-prefixes "$EXTERNAL_IP" > /dev/null
 
 IP=$(az vm show --show-details --resource-group "$AZUREKMS_RESOURCEGROUP" --name "$AZUREKMS_VMNAME" --query publicIps -o tsv)
 

--- a/.evergreen/csfle/azurekms/set-ssh-ip.sh
+++ b/.evergreen/csfle/azurekms/set-ssh-ip.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# set-ssh-ip.sh adds the current IP to an already-created VM.
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+# Get DRIVERS_TOOLS path.
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+. "$SCRIPT_DIR"/../../handle-paths.sh
+
+VARLIST=(
+    AZUREKMS_RESOURCEGROUP
+    AZUREKMS_VMNAME
+    AZUREKMS_PRIVATEKEYPATH
+)
+
+# Ensure that all variables required to run the test are set, otherwise throw
+# an error.
+for VARNAME in "${VARLIST[@]}"; do
+  [[ -z "${!VARNAME:-}" ]] && echo "ERROR: $VARNAME not set" && exit 1;
+done
+
+EXTERNAL_IP=$(curl -s http://whatismyip.akamai.com/)
+
+echo "Adding current IP ($EXTERNAL_IP) to Azure Virtual Machine ... begin"
+az network nsg rule update \
+    --only-show-errors \
+    --name "$AZUREKMS_VMNAME-nsg-rule" \
+    --nsg-name "$AZUREKMS_VMNAME-nsg" \
+    --resource-group "$AZUREKMS_RESOURCEGROUP" \
+    --source-address-prefixes "$EXTERNAL_IP"
+
+IP=$(az vm show --show-details --resource-group "$AZUREKMS_RESOURCEGROUP" --name "$AZUREKMS_VMNAME" --query publicIps -o tsv)
+
+"$DRIVERS_TOOLS/.evergreen/retry-with-backoff.sh" ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no azureuser@"$IP" -i "$AZUREKMS_PRIVATEKEYPATH" "echo 'hi' > /dev/null"
+
+echo "Adding current IP ($EXTERNAL_IP) to Azure Virtual Machine ... end"

--- a/.evergreen/csfle/azurekms/set-ssh-ip.sh
+++ b/.evergreen/csfle/azurekms/set-ssh-ip.sh
@@ -34,6 +34,6 @@ az network nsg rule update \
 
 IP=$(az vm show --show-details --resource-group "$AZUREKMS_RESOURCEGROUP" --name "$AZUREKMS_VMNAME" --query publicIps -o tsv)
 
-"$DRIVERS_TOOLS/.evergreen/retry-with-backoff.sh" ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no azureuser@"$IP" -i "$AZUREKMS_PRIVATEKEYPATH" "echo 'hi' > /dev/null"
+"$DRIVERS_TOOLS/.evergreen/retry-with-backoff.sh" ssh -n -o ConnectTimeout=10 -o StrictHostKeyChecking=no azureuser@"$IP" -i "$AZUREKMS_PRIVATEKEYPATH" "echo 'hi' > /dev/null"
 
 echo "Adding current IP ($EXTERNAL_IP) to Azure Virtual Machine ... end"


### PR DESCRIPTION
# Summary

Restrict access to Azure VMs. Resolves DRIVERS-2987.

Tested CSFLE with C driver: https://spruce.mongodb.com/version/66fc4490ce827200070347f9

Tested CSFLE+OIDC with Go driver: https://spruce.mongodb.com/patch/66fc50fb3bc93e0007ef36a2

## Background & Motivation

[azure vm create](https://learn.microsoft.com/en-us/cli/azure/vm?view=azure-cli-latest#az-vm-create-optional-parameters) documents:

> Defaults to open ports for allowing RDP on Windows and allowing SSH on Linux.

Though the private SSH key is expected to be secured, this PR disables the default open port to follow recommendations noted in DRIVERS-2987.

Every script that may `ssh` to the Azure VM sets the IP of the network security group. I expect the setup script (`create-and-setup-vm.sh`) may run on a different Evergreen host scripts used to test (`run-command.sh`) if Evergreen task groups are used.

After setting an IP, the `retry-with-backoff.sh` script is to wait until `ssh` succeeds. The default `ATTEMPTS` was increased to 10 due to an [observed failure on retry](https://spruce.mongodb.com/task/mongo_c_driver_testazurekms_variant_testazurekms_task_patch_9522772691432ec7dbf1639599c252f20a2fe21e_66faba1f0610150007d8f4ea_24_09_30_14_48_01/logs?execution=0).

### Adding `-n` to `ssh`

The `-n` parameter is added to `ssh` commands to prevent reading from stdin.

This appears to solve an observed issue testing with the C driver: The `shell.exec` would abruptly stop after running an Azure KMS script. [Example](https://spruce.mongodb.com/task/mongo_c_driver_testazurekms_variant_testazurekms_task_patch_9522772691432ec7dbf1639599c252f20a2fe21e_66f574021225990007334271_24_09_26_14_47_31/logs?execution=0) logs indicate:

```yaml
- command: shell.exec
  params:
    script: |-
      # ... omitted ...
      AZUREKMS_SRC="testazurekms.tgz" \
      AZUREKMS_DST="./" \
          $DRIVERS_TOOLS/.evergreen/csfle/azurekms/copy-file.sh
      # copy-file.sh succeeded, but `shell.exec` stops!
      # ... omitted ...
```

https://docs.devprod.prod.corp.mongodb.com/evergreen/Project-Configuration/Project-Commands#shellexec notes:

> By default, shell.exec runs sh then pipes your script to its stdin. Use this parameter if your script will be doing something that may change stdin, such as sshing