### PR TITLE
Use a longer timeout for k8s configuration

### DIFF
--- a/.evergreen/k8s/configure-pod.sh
+++ b/.evergreen/k8s/configure-pod.sh
@@ -31,8 +31,7 @@ echo "Waiting for pod to be ready... done."
 echo "Configuring pod $POD_NAME..."
 set -x
 # Account for initial error in connecting to pod.
-sleep 60
-../retry-with-backoff.sh kubectl cp ./remote-scripts/setup-pod.sh ${POD_NAME}:/tmp/setup-pod.sh
+TIMEOUT=5 ../retry-with-backoff.sh kubectl cp ./remote-scripts/setup-pod.sh ${POD_NAME}:/tmp/setup-pod.sh
 kubectl exec ${POD_NAME} -- /tmp/setup-pod.sh
 kubectl exec ${POD_NAME} -- git --version
 set +x

--- a/.evergreen/k8s/configure-pod.sh
+++ b/.evergreen/k8s/configure-pod.sh
@@ -31,6 +31,7 @@ echo "Waiting for pod to be ready... done."
 echo "Configuring pod $POD_NAME..."
 set -x
 # Account for initial error in connecting to pod.
+sleep 60
 ../retry-with-backoff.sh kubectl cp ./remote-scripts/setup-pod.sh ${POD_NAME}:/tmp/setup-pod.sh
 kubectl exec ${POD_NAME} -- /tmp/setup-pod.sh
 kubectl exec ${POD_NAME} -- git --version


### PR DESCRIPTION
The GKE cluster takes a while to be ready for interaction.  This increases the backoff time.

```
 [2024/10/02 06:38:06.927] + TIMEOUT=5
 [2024/10/02 06:38:06.927] + ../retry-with-backoff.sh kubectl cp ./remote-scripts/setup-pod.sh test-gke-14252:/tmp/setup-pod.sh
 [2024/10/02 06:38:06.929] Waiting for pod to be ready... done.
 [2024/10/02 06:38:06.929] Configuring pod test-gke-14252...
 [2024/10/02 06:38:06.929] retry_with_backoff: running 'kubectl cp ./remote-scripts/setup-pod.sh test-gke-14252:/tmp/setup-pod.sh' - attempt n. 1 ...
 [2024/10/02 06:38:08.594] E1002 11:38:08.594792   76783 v2.go:167] "Unhandled Error" err="next reader: read tcp 10.128.250.152:36480->34.86.146.245:443: read: connection reset by peer"
 [2024/10/02 06:38:08.594] E1002 11:38:08.594804   76783 v2.go:129] "Unhandled Error" err="next reader: read tcp 10.128.250.152:36480->34.86.146.245:443: read: connection reset by peer"
 [2024/10/02 06:38:08.594] E1002 11:38:08.594817   76783 v2.go:150] "Unhandled Error" err="next reader: read tcp 10.128.250.152:36480->34.86.146.245:443: read: connection reset by peer"
 [2024/10/02 06:38:08.596] error: error reading from error stream: next reader: read tcp 10.128.250.152:36480->34.86.146.245:443: read: connection reset by peer
 [2024/10/02 06:38:13.598] retry_with_backoff: running 'kubectl cp ./remote-scripts/setup-pod.sh test-gke-14252:/tmp/setup-pod.sh' - attempt n. 2 ...
 [2024/10/02 06:38:14.382] retry_with_backoff: attempt failed! Retrying in 5..
 [2024/10/02 06:38:14.382] error: Internal error occurred: error sending request: Post "https://10.150.0.52:10250/exec/default/test-gke-14252/debian?command=tar&command=-xmf&command=-&command=-C&command=%!F(MISSING)tmp&error=1&input=1&output=1": No agent available
 [2024/10/02 06:38:24.385] retry_with_backoff: running 'kubectl cp ./remote-scripts/setup-pod.sh test-gke-14252:/tmp/setup-pod.sh' - attempt n. 3 ...
 [2024/10/02 06:38:25.240] retry_with_backoff: attempt failed! Retrying in 10..
 [2024/10/02 06:38:25.240] E1002 11:38:25.240214   76807 v2.go:129] "Unhandled Error" err="next reader: read tcp 10.128.250.152:45098->34.86.146.245:443: read: connection reset by peer"
 [2024/10/02 06:38:25.240] E1002 11:38:25.240218   76807 v2.go:167] "Unhandled Error" err="next reader: read tcp 10.128.250.152:45098->34.86.146.245:443: read: connection reset by peer"
 [2024/10/02 06:38:25.240] E1002 11:38:25.240229   76807 v2.go:150] "Unhandled Error" err="next reader: read tcp 10.128.250.152:45098->34.86.146.245:443: read: connection reset by peer"
 [2024/10/02 06:38:25.241] error: error reading from error stream: next reader: read tcp 10.128.250.152:45098->34.86.146.245:443: read: connection reset by peer
 [2024/10/02 06:38:45.244] retry_with_backoff: running 'kubectl cp ./remote-scripts/setup-pod.sh test-gke-14252:/tmp/setup-pod.sh' - attempt n. 4 ...
 [2024/10/02 06:38:46.478] retry_with_backoff: attempt failed! Retrying in 20..
 [2024/10/02 06:38:46.478] + kubectl exec test-gke-14252 -- /tmp/setup-pod.sh
 [2024/10/02 06:40:09.186] debconf: delaying package configuration, since apt-utils is not installed
```