### PR TITLE
Revert change to 5.0 download version

### DIFF
--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -62,7 +62,7 @@ get_mongodb_download_url_for ()
    VERSION_80="8.0.0"
    VERSION_70="7.0.9"
    VERSION_60="6.0.15"
-   VERSION_50="5.0.29"
+   VERSION_50="5.0.26"
 
    # This version is used for performance benchmarking. Do not update to a newer version
    VERSION_60_PERF="6.0.6"


### PR DESCRIPTION
Failing build: https://spruce.mongodb.com/task/mongo_python_driver_prev_rel_tests_python_version_rhel8_compression__platform~rhel8_compression~snappy_python_version~3.12_c_extensions~with_c_extensions_test_5.0_standalone_ce5395085c175f344b94cdbeccb48466822c75c7_24_10_02_16_20_37/logs?execution=4