### PR TITLE
DRIVERS-2999 Use isolated orchestration file

### DIFF
--- a/.evergreen/run-orchestration.sh
+++ b/.evergreen/run-orchestration.sh
@@ -53,7 +53,7 @@ printf '%s' $MONGODB_BINARIES | $PYTHON -c 'import json,sys; print(json.dumps({"
 
 # Copy client certificate because symlinks do not work on Windows.
 mkdir -p ${MONGO_ORCHESTRATION_HOME}/lib
-cp ${DRIVERS_TOOLS}/.evergreen/x509gen/client.pem ${MONGO_ORCHESTRATION_HOME}/lib/client.pem || true
+cp ${DRIVERS_TOOLS}/.evergreen/x509gen/client.pem ${MONGO_ORCHESTRATION_HOME}/lib/client.pem 2> /dev/null || true
 
 get_distro
 if [ -z "$MONGODB_DOWNLOAD_URL" ]; then
@@ -119,13 +119,15 @@ else
 fi
 echo "ORCHESTRATION_FILE=$ORCHESTRATION_FILE"
 
+# Copy the orchestration file so we can override it.
+cp $ORCHESTRATION_FILE $MONGO_ORCHESTRATION_HOME/config.json
+ORCHESTRATION_FILE="$MONGO_ORCHESTRATION_HOME/config.json"
+
 # Handle absolute path.
 perl -p -i -e "s|ABSOLUTE_PATH_REPLACEMENT_TOKEN|$(echo $DRIVERS_TOOLS | sed 's/\\/\\\\\\\\/g')|g" $ORCHESTRATION_FILE
 
 # If running on Docker, update the orchestration file to be docker-friendly.
 if [ -n "$DOCKER_RUNNING" ]; then
-  cp $ORCHESTRATION_FILE /root/config.json
-  export ORCHESTRATION_FILE=/root/config.json
   $PYTHON $SCRIPT_DIR/docker/overwrite_orchestration.py
 fi
 

--- a/.evergreen/run-orchestration.sh
+++ b/.evergreen/run-orchestration.sh
@@ -120,7 +120,7 @@ fi
 echo "ORCHESTRATION_FILE=$ORCHESTRATION_FILE"
 
 # Copy the orchestration file so we can override it.
-cp $ORCHESTRATION_FILE $MONGO_ORCHESTRATION_HOME/config.json
+cp -f "$ORCHESTRATION_FILE" "$MONGO_ORCHESTRATION_HOME/config.json"
 ORCHESTRATION_FILE="$MONGO_ORCHESTRATION_HOME/config.json"
 
 # Handle absolute path.

--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,7 @@ mo-expansion.sh
 .kube
 .cargo
 .rustup
+.evergreen/orchestration/config.json
 
 # Azure functions.
 .python_packages/


### PR DESCRIPTION
This prevents us from modifying the orchestration files in place that use ABSOLUTE_PATH_REPLACEMENT_TOKEN.

Tested with the C driver: https://spruce.mongodb.com/version/67041e9b7f1bfe000734ae39/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC