### PR TITLE
Enable HTTP authentication failures

### DIFF
--- a/.evergreen/csfle/kms_failpoint_server.py
+++ b/.evergreen/csfle/kms_failpoint_server.py
@@ -99,7 +99,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 {"message": "failpoint set for type: '{}'".format(failpoint_type)}
             )
             return
-        
+
         if path.match("/reset"):
             remaining_http_fails = 0
             remaining_network_fails = 0


### PR DESCRIPTION
- HTTP OAuth requests properly fail if an HTTP failpoint is set
- Added reset option to clear all failpoints. Useful for local debugging.