### PR TITLE
DRIVERS-3002 Add download-mongodb capabilities to mongodl

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -482,6 +482,7 @@ functions:
       type: test
       params:
         shell: bash
+        include_expansions_in_env: ["PYTHON_BINARY"]
         script: |-
           set -o errexit
           cd ${DRIVERS_TOOLS}/.evergreen
@@ -497,6 +498,7 @@ functions:
       type: test
       params:
         shell: bash
+        include_expansions_in_env: ["PYTHON_BINARY"]
         script: |-
           set -o errexit
           cd ${DRIVERS_TOOLS}/.evergreen

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -506,18 +506,19 @@ functions:
           export VALIDATE_DISTROS=1
           $PYTHON mongodl.py --list
           if [ "$OS" != "Windows_NT" ]; then
-            $PYTHON mongodl.py --edition enterprise --version rapid --component archive-debug --no-download
+            $PYTHON mongodl.py --edition enterprise --version 7.0.1 --component archive-debug --test
           fi
           $PYTHON mongodl.py --edition enterprise --version 3.6 --component archive --test
           $PYTHON mongodl.py --edition enterprise --version 4.0 --component archive --test
           $PYTHON mongodl.py --edition enterprise --version 4.2 --component archive --test
-          $PYTHON mongodl.py --edition enterprise --version 4.4 --component archive-debug --test
+          $PYTHON mongodl.py --edition enterprise --version 4.4 --component archive --test
           $PYTHON mongodl.py --edition enterprise --version 5.0 --component archive --test
           $PYTHON mongodl.py --edition enterprise --version 6.0 --component crypt_shared --test
-          $PYTHON mongodl.py --edition enterprise --version 7.0.1 --component crypt_shared --test
-          $PYTHON mongodl.py --edition enterprise --version v6.0-perf --component cryptd --test
           $PYTHON mongodl.py --edition enterprise --version 8.0 --component archive --test
+          $PYTHON mongodl.py --edition enterprise --version rapid --component archive --test
           $PYTHON mongodl.py --edition enterprise --version latest --component archive --out $(pwd)
+          $PYTHON mongodl.py --edition enterprise --version v6.0-perf --component cryptd --test
+          $PYTHON mongodl.py --edition enterprise --version v8.0-perf --component cryptd --test
 
   "teardown assets":
     - command: subprocess.exec

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -477,7 +477,7 @@ functions:
           cd ${PROJECT_DIRECTORY}
           make test
 
-  "mongodl test":
+  "run mongodl test":
     - command: shell.exec
       type: test
       params:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -477,7 +477,21 @@ functions:
           cd ${PROJECT_DIRECTORY}
           make test
 
-  "run mongodl test":
+  "run mongodl test partial":
+    - command: shell.exec
+      type: test
+      params:
+        shell: bash
+        script: |-
+          set -o errexit
+          cd ${DRIVERS_TOOLS}/.evergreen
+          . find-python3.sh
+          PYTHON=$(find_python3 2>/dev/null)
+          $PYTHON mongodl.py --list
+          $PYTHON mongodl.py --edition enterprise --version 7.0 --component archive-debug --no-download
+          $PYTHON mongodl.py --edition enterprise --version 7.0 --component cryptd --test
+
+  "run mongodl test full":
     - command: shell.exec
       type: test
       params:
@@ -944,11 +958,15 @@ tasks:
       commands:
         - func: "run install binaries test"
 
-    - name: "test-mongodl"
+    - name: "test-mongodl-full"
       tags: ["pr"]
       commands:
-        - func: "run mongodl test"
+        - func: "run mongodl test full"
 
+    - name: "test-mongodl-partial"
+      tags: ["pr"]
+      commands:
+        - func: "run mongodl test partial"
 
 # }}}
 
@@ -1382,7 +1400,7 @@ buildvariants:
       then:
         add_tasks:
           - "test-install-binaries"
-          - "test-mongodl"
+          - "test-mongodl-full"
           - "test-8.0-standalone-require-api"
 
 - matrix_name: "tests-os-requires-50"
@@ -1407,7 +1425,9 @@ buildvariants:
         ssl: "ssl"
         os-requires-50: "*"
       then:
-        add_tasks: ["test-install-binaries"]
+        add_tasks:
+          - "test-install-binaries"
+          - "test-mongodl-partial"
 
 - matrix_name: "tests-os-requires-70"
   matrix_spec: {"os-requires-70": "*", auth: "*", ssl: "*" }
@@ -1428,7 +1448,9 @@ buildvariants:
         ssl: "ssl"
         os-requires-70: "*"
       then:
-        add_tasks: ["test-install-binaries"]
+        add_tasks:
+          - "test-install-binaries"
+          - "test-mongodl-partial"
 
 # Storage Engine Tests on Ubuntu 20.04
 - matrix_name: "tests-storage-engines"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -485,12 +485,13 @@ functions:
         script: |-
           set -o errexit
           cd ${DRIVERS_TOOLS}/.evergreen
-          python3 mongodl.py --list
-          python3 mongodl.py --edition enterprise --version rapid --component archive-debug --no-download
-          python3 mongodl.py --edition enterprise --version 6.0 --component archive --test
-          python3 mongodl.py --edition enterprise --version 7.0 --component crypt_shared --test
-          python3 mongodl.py --edition enterprise --version 8.0 --component cryptd --test
-          python3 mongodl.py --edition enterprise --version latest --component shell --out $(pwd)
+          PYTHON=/opt/mongodbtoolchain/v3/bin/python3
+          $PYTHON mongodl.py --list
+          $PYTHON mongodl.py --edition enterprise --version rapid --component archive-debug --no-download
+          $PYTHON mongodl.py --edition enterprise --version 7.0 --component archive --test
+          $PYTHON mongodl.py --edition enterprise --version 7.0.1 --component crypt_shared --test
+          $PYTHON mongodl.py --edition enterprise --version 7.0 --component cryptd --test
+          $PYTHON mongodl.py --edition enterprise --version latest --component shell --out $(pwd)
 
   "teardown assets":
     - command: subprocess.exec

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -486,7 +486,7 @@ functions:
           set -o errexit
           cd ${DRIVERS_TOOLS}/.evergreen
           . find-python3.sh
-          PYTHON=$(find_python3 2>/dev/null)
+          PYTHON=$(ensure_python3 2>/dev/null)
           echo "Using PYTHON: $PYTHON"
           $PYTHON mongodl.py --list
           $PYTHON mongodl.py --edition enterprise --version 7.0 --component archive-debug --no-download
@@ -501,7 +501,7 @@ functions:
           set -o errexit
           cd ${DRIVERS_TOOLS}/.evergreen
           . find-python3.sh
-          PYTHON=$(find_python3 2>/dev/null)
+          PYTHON=$(ensure_python3 2>/dev/null)
           echo "Using PYTHON: $PYTHON"
           # Ensure that all distros are accounted for in DISTRO_ID_TO_TARGET
           export VALIDATE_DISTROS=1

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -488,7 +488,6 @@ functions:
           . find-python3.sh
           PYTHON=$(ensure_python3)
           echo "Using PYTHON: $PYTHON"
-          $PYTHON mongodl.py --list
           $PYTHON mongodl.py --edition enterprise --version 7.0 --component archive-debug --no-download
           $PYTHON mongodl.py --edition enterprise --version 7.0 --component cryptd --test
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -477,6 +477,21 @@ functions:
           cd ${PROJECT_DIRECTORY}
           make test
 
+  "run mongodl test":
+    - command: shell.exec
+      type: test
+      params:
+        shell: bash
+        script: |-
+          set -o errexit
+          cd ${DRIVERS_TOOLS}/.evergreen
+          python3 mongodl.py --list
+          python3 mongodl.py --edition enterprise --version 8.0 --component archive-debug --no-download
+          python3 mongodl.py --edition enterprise --version 7.0 --component archive --test
+          python3 mongodl.py --edition enterprise --version 6.0 --component crypt_shared --test
+          python3 mongodl.py --edition enterprise --version latest --component cryptd --test
+          python3 mongodl.py --edition enterprise --version rapid --component shell --out $(pwd)
+
   "teardown assets":
     - command: subprocess.exec
       params:
@@ -921,10 +936,11 @@ tasks:
         #   vars:
         #     VARIANT: aks
 
-    - name: "test-install-binaries"
+    - name: "test-installs"
       tags: ["pr"]
       commands:
         - func: "run install binaries test"
+        - func: "run mongodl test"
 
 # }}}
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -477,7 +477,7 @@ functions:
           cd ${PROJECT_DIRECTORY}
           make test
 
-  "run mongodl test":
+  "mongodl test":
     - command: shell.exec
       type: test
       params:
@@ -485,12 +485,14 @@ functions:
         script: |-
           set -o errexit
           cd ${DRIVERS_TOOLS}/.evergreen
-          PYTHON=/opt/mongodbtoolchain/v3/bin/python3
+          . find-python3.sh
+          PYTHON=$(find_python3 2>/dev/null)
           $PYTHON mongodl.py --list
           $PYTHON mongodl.py --edition enterprise --version rapid --component archive-debug --no-download
-          $PYTHON mongodl.py --edition enterprise --version 7.0 --component archive --test
-          $PYTHON mongodl.py --edition enterprise --version 7.0.1 --component crypt_shared --test
+          $PYTHON mongodl.py --edition enterprise --version 5.0 --component archive --test
+          $PYTHON mongodl.py --edition enterprise --version 6.0.1 --component crypt_shared --test
           $PYTHON mongodl.py --edition enterprise --version 7.0 --component cryptd --test
+          $PYTHON mongodl.py --edition enterprise --version 8.0 --component archive --test
           $PYTHON mongodl.py --edition enterprise --version latest --component shell --out $(pwd)
 
   "teardown assets":
@@ -937,11 +939,16 @@ tasks:
         #   vars:
         #     VARIANT: aks
 
-    - name: "test-installs"
+    - name: "test-install-binaries"
       tags: ["pr"]
       commands:
         - func: "run install binaries test"
+
+    - name: "test-mongodl"
+      tags: ["pr"]
+      commands:
         - func: "run mongodl test"
+
 
 # }}}
 
@@ -1374,7 +1381,8 @@ buildvariants:
         os-fully-featured: "*"
       then:
         add_tasks:
-          - "test-installs"
+          - "test-install-binaries"
+          - "test-mongodl"
           - "test-8.0-standalone-require-api"
 
 - matrix_name: "tests-os-requires-50"
@@ -1399,7 +1407,7 @@ buildvariants:
         ssl: "ssl"
         os-requires-50: "*"
       then:
-        add_tasks: ["test-installs"]
+        add_tasks: ["test-install-binaries"]
 
 - matrix_name: "tests-os-requires-70"
   matrix_spec: {"os-requires-70": "*", auth: "*", ssl: "*" }
@@ -1420,7 +1428,7 @@ buildvariants:
         ssl: "ssl"
         os-requires-70: "*"
       then:
-        add_tasks: ["test-installs"]
+        add_tasks: ["test-install-binaries"]
 
 # Storage Engine Tests on Ubuntu 20.04
 - matrix_name: "tests-storage-engines"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -484,12 +484,9 @@ functions:
         shell: bash
         script: |-
           set -o errexit
-          if [ -n "${SKIP_MONGODL}"]; then
-            exit 0
-          fi
           cd ${DRIVERS_TOOLS}/.evergreen
           . find-python3.sh
-          PYTHON=$(ensure_python3 2>/dev/null)
+          PYTHON=$(ensure_python3)
           echo "Using PYTHON: $PYTHON"
           $PYTHON mongodl.py --list
           $PYTHON mongodl.py --edition enterprise --version 7.0 --component archive-debug --no-download
@@ -502,9 +499,6 @@ functions:
         shell: bash
         script: |-
           set -o errexit
-          if [ -n "${SKIP_MONGODL}"]; then
-            exit 0
-          fi
           cd ${DRIVERS_TOOLS}/.evergreen
           . find-python3.sh
           PYTHON=$(ensure_python3 2>/dev/null)
@@ -1280,7 +1274,6 @@ axes:
         run_on: rhel70-small
         variables:
           SKIP_NODE: 1
-          SKIP_MONGODL: 1
 
       - id: rhel8-power8
         display_name: "RHEL 8 (POWER8)"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1373,7 +1373,7 @@ buildvariants:
         os-fully-featured: "*"
       then:
         add_tasks:
-          - "test-install-binaries"
+          - "test-binaries"
           - "test-8.0-standalone-require-api"
 
 - matrix_name: "tests-os-requires-50"
@@ -1398,7 +1398,7 @@ buildvariants:
         ssl: "ssl"
         os-requires-50: "*"
       then:
-        add_tasks: ["test-install-binaries"]
+        add_tasks: ["test-binaries"]
 
 - matrix_name: "tests-os-requires-70"
   matrix_spec: {"os-requires-70": "*", auth: "*", ssl: "*" }

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -509,8 +509,8 @@ functions:
             $PYTHON mongodl.py --edition enterprise --version rapid --component archive-debug --no-download
           fi
           $PYTHON mongodl.py --edition enterprise --version 5.0 --component archive --test
-          $PYTHON mongodl.py --edition enterprise --version 6.0.1 --component crypt_shared --test
-          $PYTHON mongodl.py --edition enterprise --version 7.0 --component cryptd --test
+          $PYTHON mongodl.py --edition enterprise --version 7.0.1 --component crypt_shared --test
+          $PYTHON mongodl.py --edition enterprise --version v6.0-perf --component cryptd --test
           $PYTHON mongodl.py --edition enterprise --version 8.0 --component archive --test
           $PYTHON mongodl.py --edition enterprise --version latest --component shell --out $(pwd)
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -486,11 +486,11 @@ functions:
           set -o errexit
           cd ${DRIVERS_TOOLS}/.evergreen
           python3 mongodl.py --list
-          python3 mongodl.py --edition enterprise --version 8.0 --component archive-debug --no-download
-          python3 mongodl.py --edition enterprise --version 7.0 --component archive --test
-          python3 mongodl.py --edition enterprise --version 6.0 --component crypt_shared --test
-          python3 mongodl.py --edition enterprise --version latest --component cryptd --test
-          python3 mongodl.py --edition enterprise --version rapid --component shell --out $(pwd)
+          python3 mongodl.py --edition enterprise --version rapid --component archive-debug --no-download
+          python3 mongodl.py --edition enterprise --version 6.0 --component archive --test
+          python3 mongodl.py --edition enterprise --version 7.0 --component crypt_shared --test
+          python3 mongodl.py --edition enterprise --version 8.0 --component cryptd --test
+          python3 mongodl.py --edition enterprise --version latest --component shell --out $(pwd)
 
   "teardown assets":
     - command: subprocess.exec

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1274,6 +1274,7 @@ axes:
         run_on: rhel70-small
         variables:
           SKIP_NODE: 1
+          PYTHON_BINARY: /opt/python/3.8/bin/python
 
       - id: rhel8-power8
         display_name: "RHEL 8 (POWER8)"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -508,6 +508,9 @@ functions:
           if [ "$OS" != "Windows_NT" ]; then
             $PYTHON mongodl.py --edition enterprise --version rapid --component archive-debug --no-download
           fi
+          $PYTHON mongodl.py --edition enterprise --version 3.6 --component archive --test
+          $PYTHON mongodl.py --edition enterprise --version 4.0 --component archive --test
+          $PYTHON mongodl.py --edition enterprise --version 4.2 --component archive --test
           $PYTHON mongodl.py --edition enterprise --version 4.4 --component archive-debug --test
           $PYTHON mongodl.py --edition enterprise --version 5.0 --component archive --test
           $PYTHON mongodl.py --edition enterprise --version 6.0 --component crypt_shared --test

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1373,7 +1373,7 @@ buildvariants:
         os-fully-featured: "*"
       then:
         add_tasks:
-          - "test-binaries"
+          - "test-installs"
           - "test-8.0-standalone-require-api"
 
 - matrix_name: "tests-os-requires-50"
@@ -1398,7 +1398,7 @@ buildvariants:
         ssl: "ssl"
         os-requires-50: "*"
       then:
-        add_tasks: ["test-binaries"]
+        add_tasks: ["test-installs"]
 
 - matrix_name: "tests-os-requires-70"
   matrix_spec: {"os-requires-70": "*", auth: "*", ssl: "*" }
@@ -1419,7 +1419,7 @@ buildvariants:
         ssl: "ssl"
         os-requires-70: "*"
       then:
-        add_tasks: ["test-install-binaries"]
+        add_tasks: ["test-installs"]
 
 # Storage Engine Tests on Ubuntu 20.04
 - matrix_name: "tests-storage-engines"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -487,8 +487,11 @@ functions:
           cd ${DRIVERS_TOOLS}/.evergreen
           . find-python3.sh
           PYTHON=$(find_python3 2>/dev/null)
+          echo "Using PYTHON: $PYTHON"
           $PYTHON mongodl.py --list
-          $PYTHON mongodl.py --edition enterprise --version 7.0 --component archive-debug --no-download
+          if [ "$OS" != "Windows_NT"" ]; then
+            $PYTHON mongodl.py --edition enterprise --version 7.0 --component archive-debug --no-download
+          fi
           $PYTHON mongodl.py --edition enterprise --version 7.0 --component cryptd --test
 
   "run mongodl test full":
@@ -501,6 +504,7 @@ functions:
           cd ${DRIVERS_TOOLS}/.evergreen
           . find-python3.sh
           PYTHON=$(find_python3 2>/dev/null)
+          echo "Using PYTHON: $PYTHON"
           $PYTHON mongodl.py --list
           $PYTHON mongodl.py --edition enterprise --version rapid --component archive-debug --no-download
           $PYTHON mongodl.py --edition enterprise --version 5.0 --component archive --test

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -508,11 +508,13 @@ functions:
           if [ "$OS" != "Windows_NT" ]; then
             $PYTHON mongodl.py --edition enterprise --version rapid --component archive-debug --no-download
           fi
+          $PYTHON mongodl.py --edition enterprise --version 4.4 --component archive-debug --test
           $PYTHON mongodl.py --edition enterprise --version 5.0 --component archive --test
+          $PYTHON mongodl.py --edition enterprise --version 6.0 --component crypt_shared --test
           $PYTHON mongodl.py --edition enterprise --version 7.0.1 --component crypt_shared --test
           $PYTHON mongodl.py --edition enterprise --version v6.0-perf --component cryptd --test
           $PYTHON mongodl.py --edition enterprise --version 8.0 --component archive --test
-          $PYTHON mongodl.py --edition enterprise --version latest --component shell --out $(pwd)
+          $PYTHON mongodl.py --edition enterprise --version latest --component archive --out $(pwd)
 
   "teardown assets":
     - command: subprocess.exec

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -489,9 +489,7 @@ functions:
           PYTHON=$(find_python3 2>/dev/null)
           echo "Using PYTHON: $PYTHON"
           $PYTHON mongodl.py --list
-          if [ "$OS" != "Windows_NT"" ]; then
-            $PYTHON mongodl.py --edition enterprise --version 7.0 --component archive-debug --no-download
-          fi
+          $PYTHON mongodl.py --edition enterprise --version 7.0 --component archive-debug --no-download
           $PYTHON mongodl.py --edition enterprise --version 7.0 --component cryptd --test
 
   "run mongodl test full":
@@ -505,8 +503,12 @@ functions:
           . find-python3.sh
           PYTHON=$(find_python3 2>/dev/null)
           echo "Using PYTHON: $PYTHON"
+          # Ensure that all distros are accounted for in DISTRO_ID_TO_TARGET
+          export VALIDATE_DISTROS=1
           $PYTHON mongodl.py --list
-          $PYTHON mongodl.py --edition enterprise --version rapid --component archive-debug --no-download
+          if [ "$OS" != "Windows_NT" ]; then
+            $PYTHON mongodl.py --edition enterprise --version rapid --component archive-debug --no-download
+          fi
           $PYTHON mongodl.py --edition enterprise --version 5.0 --component archive --test
           $PYTHON mongodl.py --edition enterprise --version 6.0.1 --component crypt_shared --test
           $PYTHON mongodl.py --edition enterprise --version 7.0 --component cryptd --test

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -482,9 +482,11 @@ functions:
       type: test
       params:
         shell: bash
-        include_expansions_in_env: ["PYTHON_BINARY"]
         script: |-
           set -o errexit
+          if [ -n "${SKIP_MONGODL}"]; then
+            exit 0
+          fi
           cd ${DRIVERS_TOOLS}/.evergreen
           . find-python3.sh
           PYTHON=$(ensure_python3 2>/dev/null)
@@ -498,9 +500,11 @@ functions:
       type: test
       params:
         shell: bash
-        include_expansions_in_env: ["PYTHON_BINARY"]
         script: |-
           set -o errexit
+          if [ -n "${SKIP_MONGODL}"]; then
+            exit 0
+          fi
           cd ${DRIVERS_TOOLS}/.evergreen
           . find-python3.sh
           PYTHON=$(ensure_python3 2>/dev/null)
@@ -1276,7 +1280,7 @@ axes:
         run_on: rhel70-small
         variables:
           SKIP_NODE: 1
-          PYTHON_BINARY: /opt/python/3.8/bin/python
+          SKIP_MONGODL: 1
 
       - id: rhel8-power8
         display_name: "RHEL 8 (POWER8)"

--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -59,8 +59,8 @@ get_mongodb_download_url_for ()
    VERSION_MONGOSH="2.1.1"
    # Set VERSION_RAPID to the latest rapid release each quarter.
    VERSION_RAPID="7.3.4"
-   VERSION_80="8.0.1-rc0"
-   VERSION_70="7.0.14"
+   VERSION_80="8.0.1"
+   VERSION_70="7.0.15-rc1"
    VERSION_60="6.0.18"
    VERSION_50="5.0.29"
 

--- a/.evergreen/find-python3.sh
+++ b/.evergreen/find-python3.sh
@@ -52,8 +52,8 @@ is_python3() (
   echo " - $bin: $version_output"
 
   # shellcheck disable=SC2091
-  if ! $("$bin" -c "import sys; exit(sys.version_info[0] == 3 and sys.version_info[1] == 12)"); then
-    echo "Detected Python 3.12. Skipping due to failures to start mock KMS server. Refer: DRIVERS-2743"
+  if ! $("$bin" -c "import sys; exit(sys.version_info[0] == 3 and sys.version_info[1] >= 12)"); then
+    echo "Detected Python 3.12+. Skipping due to failures to start mock KMS server. Refer: DRIVERS-2743"
     return 1
   fi
 

--- a/.evergreen/find-python3.sh
+++ b/.evergreen/find-python3.sh
@@ -57,6 +57,13 @@ is_python3() (
     return 1
   fi
 
+  # shellcheck disable=SC2091
+  if ! $("$bin" -c "import sys; exit(sys.version_info[0] == 3 and sys.version_info[1] < 8)"); then
+    version=$($bin --version)
+    echo "Detected EOL Python ${version}, skipping."
+    return 1
+  fi
+
   # Evaluate result of this function.
   # Note: Python True (1) and False (0) is treated as fail (1) and success (0)
   # by Bash; therefore `is_python3` returns "true" when `v < 3` is false.

--- a/.evergreen/mongodl.py
+++ b/.evergreen/mongodl.py
@@ -36,6 +36,9 @@ from typing import (IO, TYPE_CHECKING, Any, Callable, Iterable, Iterator,
                         NamedTuple, Sequence, cast)
 
 
+# This version is used for performance benchmarking. Do not update to a newer version
+VERSION_60_PERF="6.0.6"
+
 #: Map common distribution names to the distribution named used in the MongoDB download list
 DISTRO_ID_MAP = {
     'elementary': 'ubuntu',
@@ -1074,6 +1077,8 @@ def main(argv: 'Sequence[str]'):
     edition = args.edition or 'enterprise'
     out = args.out or Path.cwd()
     out = out.absolute()
+    if args.version == "v6.0-perf":
+        args.version = VERSION_60_PERF
     result = _dl_component(cache,
                            out,
                            version=args.version,

--- a/.evergreen/mongodl.py
+++ b/.evergreen/mongodl.py
@@ -381,7 +381,7 @@ class CacheDB:
         for ver in data['versions']:
             version = ver['version']
             key = version[:3]
-            if key in versions and versions[key] is None:
+            if mdb_version_not_rc(version) and key in versions and versions[key] is None:
                 ver = ver.copy()
                 ver['version'] = key
                 versions[key] = ver

--- a/.evergreen/mongodl.py
+++ b/.evergreen/mongodl.py
@@ -32,7 +32,7 @@ from collections import namedtuple
 from contextlib import contextmanager
 from fnmatch import fnmatch
 from pathlib import Path, PurePath, PurePosixPath
-from typing import (IO, TYPE_CHECKING, Any, Callable, Iterable, Iterator,
+from typing import (IO, TYPE_CHECKING, Any, Callable, Iterable, Iterator, Optional,
                         NamedTuple, Sequence, cast)
 
 # The named supported minor and major versions.
@@ -126,13 +126,17 @@ DISTRO_ID_TO_TARGET = {
 }
 
 
-def infer_target() -> str:
+def infer_target(version: Optional[str] = None) -> str:
     """
     Infer the download target of the current host system.
     """
     if sys.platform == 'win32':
         return 'windows'
     if sys.platform == 'darwin':
+        # Older versions of the server used 'osx' as the target.
+        if version is not None:
+            if version.startswith("4.0") or version[0] == "3":
+                return 'osx'
         return 'macos'
     # Now the tricky bit
     cands = (Path(p) for p in ['/etc/os-release', '/usr/lib/os-release'])
@@ -1077,7 +1081,7 @@ def main(argv: 'Sequence[str]'):
         version = PERF_VERSIONS[version]
     target = args.target
     if target in (None, 'auto'):
-        target = infer_target()
+        target = infer_target(version)
     arch = args.arch
     if arch in (None, 'auto'):
         arch = infer_arch()

--- a/.evergreen/mongodl.py
+++ b/.evergreen/mongodl.py
@@ -381,7 +381,7 @@ class CacheDB:
         for ver in data['versions']:
             version = ver['version']
             key = version[:3]
-            if mdb_version_not_rc(version) and key in versions and versions[key] is None:
+            if key in versions and versions[key] is None:
                 ver = ver.copy()
                 ver['version'] = key
                 versions[key] = ver

--- a/.evergreen/mongodl.py
+++ b/.evergreen/mongodl.py
@@ -35,6 +35,8 @@ from pathlib import Path, PurePath, PurePosixPath
 from typing import (IO, TYPE_CHECKING, Any, Callable, Iterable, Iterator,
                         NamedTuple, Sequence, cast)
 
+# The named supported minor and major versions.
+SUPPORTED_VERSIONS = ["3.6", "4.0", "4.2", "4.4", "5.0", "6.0", "7.0", "8.0"]
 
 # These versions are used for performance benchmarking. Do not update to a newer version.
 PERF_VERSIONS = {
@@ -381,9 +383,8 @@ class CacheDB:
                 UNIQUE(key, download_id)
             )
         ''')
-        # Inject special versions: Major releases.
-        versions = ["3.6", "4.0", "5.0", "6.0", "7.0", "8.0"]
-        versions = dict(zip(versions, [None for _ in versions]))
+        # Inject supported versions
+        versions = dict(zip(SUPPORTED_VERSIONS, [None for _ in SUPPORTED_VERSIONS]))
         for ver in data['versions']:
             version = ver['version']
             key = version[:3]

--- a/.evergreen/mongodl.py
+++ b/.evergreen/mongodl.py
@@ -80,6 +80,7 @@ DISTRO_VERSION_MAP = {
 #: Map distribution IDs with version fnmatch() patterns to download platform targets
 DISTRO_ID_TO_TARGET = {
     'ubuntu': {
+        '24.*': 'ubuntu2404',
         '22.*': 'ubuntu2204',
         '20.*': 'ubuntu2004',
         '18.*': 'ubuntu1804',
@@ -110,6 +111,7 @@ DISTRO_ID_TO_TARGET = {
         '15.*': 'suse15',
     },
     'amzn': {
+        '2023': 'amazon2023',
         '2018.*': 'amzn64',
         '2': 'amazon2',
     },

--- a/.evergreen/mongodl.py
+++ b/.evergreen/mongodl.py
@@ -36,8 +36,11 @@ from typing import (IO, TYPE_CHECKING, Any, Callable, Iterable, Iterator,
                         NamedTuple, Sequence, cast)
 
 
-# This version is used for performance benchmarking. Do not update to a newer version
-VERSION_60_PERF="6.0.6"
+# These versions are used for performance benchmarking. Do not update to a newer version.
+PERF_VERSIONS = {
+    "v6.0-perf": "6.0.6",
+    "v8.0-perf": "8.0.1"
+}
 
 #: Map common distribution names to the distribution named used in the MongoDB download list
 DISTRO_ID_MAP = {
@@ -1068,6 +1071,9 @@ def main(argv: 'Sequence[str]'):
         raise argparse.ArgumentError(None,
                                      'A "--out" directory should be provided')
 
+    version = args.version
+    if version in PERF_VERSIONS:
+        version = PERF_VERSIONS[version]
     target = args.target
     if target in (None, 'auto'):
         target = infer_target()
@@ -1077,11 +1083,10 @@ def main(argv: 'Sequence[str]'):
     edition = args.edition or 'enterprise'
     out = args.out or Path.cwd()
     out = out.absolute()
-    if args.version == "v6.0-perf":
-        args.version = VERSION_60_PERF
+
     result = _dl_component(cache,
                            out,
-                           version=args.version,
+                           version=version,
                            target=target,
                            arch=arch,
                            edition=edition,


### PR DESCRIPTION
This is the first step in DRIVERS-3002.  
This PR adds the following capabilities for parity with download-mongodb.sh:
- Handle named versions (8.0, etc)
- Handle "rapid" version
- Add support for perf versions
- Normalize the handling of rhel downloads
- Add option to just print the url 
- Add option to download the debug version of a server

The next PR will create a mongosh-dl.py to handle finding the mongosh download link.
The final PR will use mongodl.py and mongosh-dl.py directly in download-mongodb.sh.