### PR TITLE
Add MongoDB 4.2 server archive to Debian 10

### DIFF
--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -386,6 +386,7 @@ get_mongodb_download_url_for ()
              MONGODB_60="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-debian10${DEBUG}-${VERSION_60}.tgz"
              MONGODB_50="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-debian10${DEBUG}-${VERSION_50}.tgz"
              MONGODB_44="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-debian10${DEBUG}-${VERSION_44}.tgz"
+             MONGODB_42="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-debian10${DEBUG}-${VERSION_42}.tgz"
       ;;
       linux-debian-9*)
          MONGODB_LATEST="http://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-debian92${DEBUG}-latest.tgz"


### PR DESCRIPTION
# Summary
This PR adds the 4.2 server archive link to the Debian 10 distro.

# Background
The C driver is [looking](https://github.com/mongodb/mongo-c-driver/pull/1760#discussion_r1797140094) to test the 4.2 server against a supported Linux Evergreen environment since Ubuntu 18.04 is dropped from [support](https://jira.mongodb.org/browse/DRIVERS-2592). Debian 10 is still [supported](https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=116563465) by Evergreen and [works](https://docs.google.com/spreadsheets/d/1-sZKW70HbVt2yHOWa18qwBwi-gBcn54tWmronnn89kI/edit?gid=0#gid=0) with a 4.2 server.

The 4.2 server archive was not included underneath the `linux-debian-10` distro in `download-mongodb.sh`. See [this](https://spruce.mongodb.com/task/mongo_c_driver_cse_matrix_openssl_cse_sasl_cyrus_openssl_debian10_gcc_test_4.2_server_auth_patch_e2b54b1be31f795b6d238c740ff1388679917ad7_670959139400e200073cbe7b_24_10_11_16_58_06/logs?execution=0) Evergreen task failure for prior behavior.
```
Unknown version: 4.2 for linux-debian-10-x86_64
```
A passing task using this archive can be seen [here](https://spruce.mongodb.com/version/67097965363bbc00070c17f5/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).