### PR TITLE
Address warnings in evergreen config

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -992,7 +992,7 @@ task_groups:
     setup_group_can_fail_task: true
     setup_group_timeout_secs: 1800 # 30 minutes
     teardown_task_can_fail_task: true
-    teardown_group_timeout_secs: 1800 # 30 minutes
+    teardown_group_timeout_secs: 180 # 3 minutes (maximum allowed)
     setup_group:
       - func: "fetch and prepare resources"
       - command: subprocess.exec
@@ -1018,7 +1018,7 @@ task_groups:
     setup_group_can_fail_task: true
     setup_group_timeout_secs: 1800 # 30 minutes
     teardown_task_can_fail_task: true
-    teardown_group_timeout_secs: 1800 # 30 minutes
+    teardown_group_timeout_secs: 180 # 3 minutes (maximum allowed)
     setup_group:
       - func: "fetch and prepare resources"
       - command: subprocess.exec
@@ -1050,7 +1050,7 @@ task_groups:
     setup_group_can_fail_task: true
     setup_group_timeout_secs: 1800
     teardown_task_can_fail_task: true
-    teardown_group_timeout_secs: 1800 # 30 minutes
+    teardown_group_timeout_secs: 180 # 3 minutes (maximum allowed)
     setup_group:
       - func: "fetch and prepare resources"
       - command: shell.exec
@@ -1079,9 +1079,9 @@ task_groups:
 
   - name: testgcpoidc_task_group
     setup_group_can_fail_task: true
-    setup_group_timeout_secs: 1800
+    setup_group_timeout_secs: 1800  # 30 minutes
     teardown_task_can_fail_task: true
-    teardown_group_timeout_secs: 1800 # 30 minutes
+    teardown_group_timeout_secs: 180 # 3 minutes (maximum allowed)
     setup_group:
       - func: "fetch and prepare resources"
       - command: shell.exec
@@ -1111,8 +1111,8 @@ task_groups:
   - name: test_oidc_azure_func_task_group
     setup_group_can_fail_task: true
     setup_group_timeout_secs: 1800
-    teardown_group_can_fail_task: true
-    teardown_group_timeout_secs: 1800
+    teardown_task_can_fail_task: true
+    teardown_group_timeout_secs: 180 # 3 minutes (maximum allowed)
     setup_group:
       - func: "fetch and prepare resources"
       - command: subprocess.exec
@@ -1137,7 +1137,7 @@ task_groups:
     setup_group_can_fail_task: true
     setup_group_timeout_secs: 1800
     teardown_task_can_fail_task: true
-    teardown_group_timeout_secs: 1800 # 30 minutes
+    teardown_group_timeout_secs: 180 # 3 minutes (maximum allowed)
     setup_group:
       - func: "fetch and prepare resources"
       - command: subprocess.exec
@@ -1162,7 +1162,7 @@ task_groups:
     setup_group_can_fail_task: true
     setup_group_timeout_secs: 1800
     teardown_task_can_fail_task: true
-    teardown_group_timeout_secs: 1800 # 30 minutes
+    teardown_group_timeout_secs: 180 # 3 minutes (maximum allowed)
     setup_group:
       - func: "fetch and prepare resources"
       - command: subprocess.exec

--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -579,8 +579,7 @@ get_mongodb_download_url_for ()
    # Get the download url for the latest MongoSH.
    # shellcheck disable=SC3028
    _script_dir="$(dirname ${BASH_SOURCE:-$0})"
-   . ${_script_dir}/find-python3.sh
-   _python3=$(ensure_python3 2>/dev/null)
+   _python3=$(bash -c ". $_script_dir/find-python3.sh && ensure_python3 2>/dev/null")
    MONGOSH_DOWNLOAD_URL=$($_python3 "${_script_dir}/mongosh-dl.py" --no-download | tr -d '\r')
 
    case "$_VERSION" in


### PR DESCRIPTION
WARNING: strict unmarshalling YAML: load project error(s): error unmarshalling yaml strict: yaml: unmarshal errors:
  line 1114: field teardown_group_can_fail_task not found in type model.parserTaskGroup
WARNING: task group 'serverless_task_group' has a teardown task timeout of 1800 seconds, which exceeds the maximum of 180 seconds