### PR TITLE
Fixed sending of mock http error in kms_failpoint_server.py

### DIFF
--- a/.evergreen/csfle/kms_failpoint_server.py
+++ b/.evergreen/csfle/kms_failpoint_server.py
@@ -74,6 +74,8 @@ class Handler(http.server.BaseHTTPRequestHandler):
         global remaining_http_fails
         remaining_http_fails -= 1
         self.send_response(429)
+        self.end_headers()
+        print("mock http error")
 
     def do_POST(self):
         global remaining_http_fails


### PR DESCRIPTION
Added `end_headers()`, otherwise the response is never sent.