### PR TITLE
test: increase gke pod memory

### DIFF
--- a/.evergreen/k8s/gke/setup.sh
+++ b/.evergreen/k8s/gke/setup.sh
@@ -47,7 +47,7 @@ spec:
     image: debian:12
     resources:
       limits:
-        memory: "2Gi"
+        memory: "4Gi"
         cpu: "1"
         ephemeral-storage: "2Gi"
     command: ["/bin/sleep", "3650d"]


### PR DESCRIPTION
Node testing on GKE runs out of memory with the 2GB limit. Increased to 4GB.