### PR TITLE
DRIVERS-2743 Clean up TLS settings

### DIFF
--- a/.evergreen/csfle/kms_failpoint_server.py
+++ b/.evergreen/csfle/kms_failpoint_server.py
@@ -44,7 +44,7 @@ class HTTPServerWithTLS(http.server.HTTPServer):
             cert_file = os.path.join(server_dir, "..", "x509gen", "server.pem")
             ca_file = os.path.join(server_dir, "..", "x509gen", "ca.pem")
 
-            context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+            context = ssl.SSLContext(ssl.PROTOCOL_TLS)
             context.load_verify_locations(ca_file)
             context.load_cert_chain(cert_file)
 

--- a/.evergreen/csfle/kms_failpoint_server.py
+++ b/.evergreen/csfle/kms_failpoint_server.py
@@ -47,7 +47,7 @@ class HTTPServerWithTLS(http.server.HTTPServer):
             context = ssl.SSLContext(ssl.PROTOCOL_TLS)
             context.load_verify_locations(ca_file)
             context.load_cert_chain(cert_file)
-            context.options = ssl.CERT_NONE
+            context.verify_mode = ssl.CERT_NONE
 
             self.socket = context.wrap_socket(self.socket, server_side=True)
 

--- a/.evergreen/csfle/kms_failpoint_server.py
+++ b/.evergreen/csfle/kms_failpoint_server.py
@@ -44,17 +44,11 @@ class HTTPServerWithTLS(http.server.HTTPServer):
             cert_file = os.path.join(server_dir, "..", "x509gen", "server.pem")
             ca_file = os.path.join(server_dir, "..", "x509gen", "ca.pem")
 
-            context = ssl.SSLContext(ssl.PROTOCOL_TLS)
-            context.verify_mode = ssl.CERT_REQUIRED
+            context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
             context.load_verify_locations(ca_file)
             context.load_cert_chain(cert_file)
 
-            self.socket = context.wrap_socket(
-                self.socket,
-                server_side=True,
-                do_handshake_on_connect=False,
-                suppress_ragged_eofs=True,
-            )
+            self.socket = context.wrap_socket(self.socket, server_side=True)
 
 
 class Handler(http.server.BaseHTTPRequestHandler):

--- a/.evergreen/csfle/kms_failpoint_server.py
+++ b/.evergreen/csfle/kms_failpoint_server.py
@@ -47,6 +47,7 @@ class HTTPServerWithTLS(http.server.HTTPServer):
             context = ssl.SSLContext(ssl.PROTOCOL_TLS)
             context.load_verify_locations(ca_file)
             context.load_cert_chain(cert_file)
+            context.options = ssl.CERT_NONE
 
             self.socket = context.wrap_socket(self.socket, server_side=True)
 

--- a/.evergreen/csfle/kms_http_common.py
+++ b/.evergreen/csfle/kms_http_common.py
@@ -145,10 +145,10 @@ def run(
     context.load_cert_chain(cert_file)
     if cert_required:
         context.verify_mode = ssl.CERT_REQUIRED
+    else:
+        context.verify_mode = ssl.CERT_NONE
 
-    httpd.socket = context.wrap_socket(
-        httpd.socket, server_side=True, suppress_ragged_eofs=True
-    )
+    httpd.socket = context.wrap_socket(httpd.socket, server_side=True)
     print("Mock KMS Web Server Listening on port " + str(server_address[1]))
 
     httpd.serve_forever()

--- a/.evergreen/csfle/kms_http_common.py
+++ b/.evergreen/csfle/kms_http_common.py
@@ -144,9 +144,9 @@ def run(
     context.load_verify_locations(ca_file)
     context.load_cert_chain(cert_file)
     if cert_required:
-        context.verify_mode = ssl.CERT_REQUIRED
+        context.options = ssl.CERT_REQUIRED
     else:
-        context.verify_mode = ssl.CERT_NONE
+        context.options = ssl.CERT_NONE
 
     httpd.socket = context.wrap_socket(httpd.socket, server_side=True)
     print("Mock KMS Web Server Listening on port " + str(server_address[1]))

--- a/.evergreen/csfle/kms_http_common.py
+++ b/.evergreen/csfle/kms_http_common.py
@@ -140,7 +140,7 @@ def run(
 
     httpd = server_class(server_address, handler_class)
 
-    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS)
     context.load_verify_locations(ca_file)
     context.load_cert_chain(cert_file)
     if cert_required:

--- a/.evergreen/csfle/kms_http_common.py
+++ b/.evergreen/csfle/kms_http_common.py
@@ -140,19 +140,13 @@ def run(
 
     httpd = server_class(server_address, handler_class)
 
-    context = ssl.SSLContext(ssl.PROTOCOL_TLS)
-    context.verify_mode = ssl.CERT_REQUIRED
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
     context.load_verify_locations(ca_file)
     context.load_cert_chain(cert_file)
     if cert_required:
         context.verify_mode = ssl.CERT_REQUIRED
 
-    httpd.socket = context.wrap_socket(
-        httpd.socket,
-        server_side=True,
-        do_handshake_on_connect=False,
-        suppress_ragged_eofs=True,
-    )
+    httpd.socket = context.wrap_socket(httpd.socket, server_side=True)
     print("Mock KMS Web Server Listening on port " + str(server_address[1]))
 
     httpd.serve_forever()

--- a/.evergreen/csfle/kms_http_common.py
+++ b/.evergreen/csfle/kms_http_common.py
@@ -144,9 +144,9 @@ def run(
     context.load_verify_locations(ca_file)
     context.load_cert_chain(cert_file)
     if cert_required:
-        context.options = ssl.CERT_REQUIRED
+        context.verify_mode = ssl.CERT_REQUIRED
     else:
-        context.options = ssl.CERT_NONE
+        context.verify_mode = ssl.CERT_NONE
 
     httpd.socket = context.wrap_socket(httpd.socket, server_side=True)
     print("Mock KMS Web Server Listening on port " + str(server_address[1]))

--- a/.evergreen/csfle/kms_http_common.py
+++ b/.evergreen/csfle/kms_http_common.py
@@ -146,7 +146,9 @@ def run(
     if cert_required:
         context.verify_mode = ssl.CERT_REQUIRED
 
-    httpd.socket = context.wrap_socket(httpd.socket, server_side=True)
+    httpd.socket = context.wrap_socket(
+        httpd.socket, server_side=True, suppress_ragged_eofs=True
+    )
     print("Mock KMS Web Server Listening on port " + str(server_address[1]))
 
     httpd.serve_forever()

--- a/.evergreen/csfle/kms_http_common.py
+++ b/.evergreen/csfle/kms_http_common.py
@@ -140,7 +140,7 @@ def run(
 
     httpd = server_class(server_address, handler_class)
 
-    context = ssl.SSLContext(ssl.PROTOCOL_TLS)
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
     context.load_verify_locations(ca_file)
     context.load_cert_chain(cert_file)
     if cert_required:


### PR DESCRIPTION
Verified in C# and Python: https://spruce.mongodb.com/version/6750be2084e65a00077a3df7/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC.

Python failures are legitimate and will need to be handled in follow up tickets.

Matches the settings used with the old `ssl.wrap_socket()` API.