### PR TITLE
Install curl in pod for k8s testing

### DIFF
--- a/.evergreen/k8s/remote-scripts/setup-pod.sh
+++ b/.evergreen/k8s/remote-scripts/setup-pod.sh
@@ -6,6 +6,6 @@ apt-get -qq update
 # Same dependencies used in KMS testing.
 export DEBIAN_FRONTEND=noninteractive
 apt-get -qq -y -o DPkg::Lock::Timeout=-1 install libcurl4 libgssapi-krb5-2 libldap-common libwrap0 libsasl2-2 \
-    libsasl2-modules-gssapi-mit snmp openssl liblzma5 \
+    libsasl2-modules-gssapi-mit snmp openssl liblzma5 curl \
     python3-pip python3.11-venv git sudo < /dev/null > /dev/null
 echo "Installing dependencies ... end"


### PR DESCRIPTION
Pre-instal curl on the k8s pods to let C# Driver's script to pull and install dotnet SDK.