### PR TITLE
Use node 20 as the default LTS version

### DIFF
--- a/.evergreen/install-node.sh
+++ b/.evergreen/install-node.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
 . $SCRIPT_DIR/handle-paths.sh
 pushd $SCRIPT_DIR
 
-NODE_LTS_VERSION=${NODE_LTS_VERSION:-18}
+NODE_LTS_VERSION=${NODE_LTS_VERSION:-20}
 # npm version can be defined in the environment for cases where we need to install
 # a version lower than latest to support EOL Node versions.
 NPM_VERSION=${NPM_VERSION:-latest}


### PR DESCRIPTION
Fixes https://spruce.mongodb.com/task/drivers_tools_tests_all__os_fully_featured~rhel8_auth~auth_ssl~nossl_test_install_binaries_9236d1edcae6350ac172a40d37a9d3a22932a7a1_24_12_05_22_07_26?execution=1&sortBy=STATUS&sortDir=ASC

```
[2024/12/18 16:54:43.916] + [[ -d /data/mci/e96ca0ab301bbc80047176335aacac90/drivers-tools/.evergreen/node-artifacts/nodejs/node-v18.20.5-linux-x64 ]]
[2024/12/18 16:54:43.916] + /data/mci/e96ca0ab301bbc80047176335aacac90/drivers-tools/.evergreen/retry-with-backoff.sh curl --fail --compressed --location --retry 8 --silent --show-error --max-time 900 https://nodejs.org/dist/v18.20.5/node-v18.20.5-linux-x64.tar.gz --output /data/mci/e96ca0ab301bbc80047176335aacac90/drivers-tools/.evergreen/node-artifacts/node-v18.20.5-linux-x64.tar.gz
[2024/12/18 16:54:43.917] Node.js v18.20.5 for linux-x64 released on 2024-11-11
[2024/12/18 16:54:43.917] retry_with_backoff: running 'curl --fail --compressed --location --retry 8 --silent --show-error --max-time 900 https://nodejs.org/dist/v18.20.5/node-v18.20.5-linux-x64.tar.gz --output /data/mci/e96ca0ab301bbc80047176335aacac90/drivers-tools/.evergreen/node-artifacts/node-v18.20.5-linux-x64.tar.gz' - attempt n. 1 ...
[2024/12/18 16:54:44.658] + tar -xf /data/mci/e96ca0ab301bbc80047176335aacac90/drivers-tools/.evergreen/node-artifacts/node-v18.20.5-linux-x64.tar.gz -C /data/mci/e96ca0ab301bbc80047176335aacac90/drivers-tools/.evergreen/node-artifacts
[2024/12/18 16:54:45.528] + mv /data/mci/e96ca0ab301bbc80047176335aacac90/drivers-tools/.evergreen/node-artifacts/node-v18.20.5-linux-x64 /data/mci/e96ca0ab301bbc80047176335aacac90/drivers-tools/.evergreen/node-artifacts/nodejs
[2024/12/18 16:54:46.016] + [[ linux != \w\i\n ]]
[2024/12/18 16:54:46.016] + npm install --global npm@latest
[2024/12/18 16:54:46.016] npm error code EBADENGINE
[2024/12/18 16:54:46.016] npm error engine Unsupported engine
[2024/12/18 16:54:46.016] npm error engine Not compatible with your version of node/npm: npm@11.0.0
[2024/12/18 16:54:46.016] npm error notsup Not compatible with your version of node/npm: npm@11.0.0
[2024/12/18 16:54:46.016] npm error notsup Required: {"node":"^20.17.0 || >=22.9.0"}
[2024/12/18 16:54:46.016] npm error notsup Actual:   {"npm":"10.8.2","node":"v18.20.5"}
```

