### PR TITLE
Use supported server version on ubuntu 24.04

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
           - "windows-latest"
           - "macos-latest"
         mongodb-version:
-          - "7.0"
+          - "8.0"
         topology:
           - "server"
           - "replica_set"


### PR DESCRIPTION
"Ubuntu-latest workflows will use Ubuntu-24.04 image" - https://github.com/actions/runner-images/issues/10636