### PR TITLE
DRIVERS-3032 Improve usability of mongodl

### DIFF
--- a/.evergreen/download-mongodb.sh
+++ b/.evergreen/download-mongodb.sh
@@ -101,20 +101,7 @@ get_mongodb_download_url_for ()
      exit 1
    fi
 
-   # Get the download URL for crypt_shared.
-   # The crypt_shared package is available on server 6.0 and newer.
-   # Try to download a version of crypt_shared matching the server version.
-   # If no matching version is available, try to download the latest Major release of crypt_shared.
-   case "$_VERSION" in
-      5.0 | 4.4 | 4.2 | 4.0 | 3.6)
-         # Default to using the latest Major release. Major releases are expected yearly.
-         # MONGODB_60 may be empty if there is no 6.0 download available for this platform.
-         _crypt_shared_version=latest
-         ;;
-      *)
-         _crypt_shared_version=$_VERSION
-   esac
-   MONGO_CRYPT_SHARED_DOWNLOAD_URL=$($_python3 "${_script_dir}/mongodl.py" --version $_crypt_shared_version --component crypt_shared --no-download | tr -d '\r')
+   MONGO_CRYPT_SHARED_DOWNLOAD_URL=$($_python3 "${_script_dir}/mongodl.py" --version $_VERSION --component crypt_shared --no-download | tr -d '\r')
 
    echo "$MONGODB_DOWNLOAD_URL"
 }

--- a/.evergreen/mongosh_dl.py
+++ b/.evergreen/mongosh_dl.py
@@ -110,34 +110,37 @@ def _download(
     return resp
 
 
-def main():
+def main(argv=None):
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
     dl_grp = parser.add_argument_group(
         "Download arguments",
         description="Select what to download and extract. "
-        "Non-required arguments will be inferred "
+        "Some arguments will be inferred "
         "based on the host system.",
     )
     dl_grp.add_argument(
         "--target",
         "-T",
+        default="auto",
         help="The target platform for which to download. "
         'Use "--list" to list available targets.',
     )
-    dl_grp.add_argument("--arch", "-A", help="The architecture for which to download")
+    dl_grp.add_argument(
+        "--arch", "-A", default="auto", help="The architecture for which to download"
+    )
     dl_grp.add_argument(
         "--out",
         "-o",
-        help="The directory in which to download components. (Required)",
+        help="The directory in which to download components.",
         type=Path,
     )
     dl_grp.add_argument(
         "--version",
         "-V",
         default="latest",
-        help='The product version to download (Required). Use "latest" to download '
+        help='The product version to download. Use "latest" to download '
         "the newest available stable version.",
     )
     dl_grp.add_argument(
@@ -174,16 +177,13 @@ def main():
         help="Do not extract or place any files/directories. "
         "Only print what will be extracted without placing any files.",
     )
-    args = parser.parse_args()
-
-    if args.out is None and args.test is None and args.no_download is None:
-        raise argparse.ArgumentError(None, 'A "--out" directory should be provided')
+    args = parser.parse_args(argv)
 
     target = args.target
-    if target in (None, "auto"):
+    if target == "auto":
         target = sys.platform
     arch = args.arch
-    if arch in (None, "auto"):
+    if arch == "auto":
         arch = infer_arch()
     out = args.out or Path.cwd()
     out = out.absolute()


### PR DESCRIPTION
As part of the effort to migrate to a python CLI for orchestration, move crypt_shared handling logic in `mongodl.py` and improve the default values of `mongodl.py` and `mongosh_dl.py`.  Allow both files to be called as libraries, so they can be used from the new orchestration cli.