### PR TITLE
Properly daemonize the csfle servers

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -520,6 +520,18 @@ functions:
       params:
         binary: bash
         include_expansions_in_env: [AWS_SECRET_ACCESS_KEY, AWS_ACCESS_KEY_ID, AWS_SESSION_TOKEN]
+        args: [src/.evergreen/csfle/setup.sh]
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: bash
+        include_expansions_in_env: [AWS_SECRET_ACCESS_KEY, AWS_ACCESS_KEY_ID, AWS_SESSION_TOKEN]
+        args: [src/.evergreen/csfle/teardown.sh]
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: bash
+        include_expansions_in_env: [AWS_SECRET_ACCESS_KEY, AWS_ACCESS_KEY_ID, AWS_SESSION_TOKEN]
         args: [src/.evergreen/tests/test-csfle.sh]
 
   "run cli test partial":

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -515,6 +515,7 @@ functions:
     - command: ec2.assume_role
       params:
         role_arn: ${aws_test_secrets_role}
+    # Ensure that we can run setup and teardown commands in the foreground without hanging.
     - command: subprocess.exec
       type: test
       params:
@@ -527,6 +528,7 @@ functions:
         binary: bash
         include_expansions_in_env: [AWS_SECRET_ACCESS_KEY, AWS_ACCESS_KEY_ID, AWS_SESSION_TOKEN]
         args: [src/.evergreen/csfle/teardown.sh]
+    # Test setup and teardown for each supported version of Python.
     - command: subprocess.exec
       type: test
       params:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -512,26 +512,20 @@ functions:
           make test
 
   "run csfle test":
-    - command: ec2.assume_role
-      params:
-        role_arn: ${aws_test_secrets_role}
     - command: subprocess.exec
       type: test
       params:
         binary: bash
-        include_expansions_in_env: [AWS_SECRET_ACCESS_KEY, AWS_ACCESS_KEY_ID, AWS_SESSION_TOKEN]
         args: [src/.evergreen/csfle/setup.sh]
     - command: subprocess.exec
       type: test
       params:
         binary: bash
-        include_expansions_in_env: [AWS_SECRET_ACCESS_KEY, AWS_ACCESS_KEY_ID, AWS_SESSION_TOKEN]
         args: [src/.evergreen/csfle/teardown.sh]
     - command: subprocess.exec
       type: test
       params:
         binary: bash
-        include_expansions_in_env: [AWS_SECRET_ACCESS_KEY, AWS_ACCESS_KEY_ID, AWS_SESSION_TOKEN]
         args: [src/.evergreen/tests/test-csfle.sh]
 
   "run cli test partial":

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -512,20 +512,26 @@ functions:
           make test
 
   "run csfle test":
+    - command: ec2.assume_role
+      params:
+        role_arn: ${aws_test_secrets_role}
     - command: subprocess.exec
       type: test
       params:
         binary: bash
+        include_expansions_in_env: [AWS_SECRET_ACCESS_KEY, AWS_ACCESS_KEY_ID, AWS_SESSION_TOKEN]
         args: [src/.evergreen/csfle/setup.sh]
     - command: subprocess.exec
       type: test
       params:
         binary: bash
+        include_expansions_in_env: [AWS_SECRET_ACCESS_KEY, AWS_ACCESS_KEY_ID, AWS_SESSION_TOKEN]
         args: [src/.evergreen/csfle/teardown.sh]
     - command: subprocess.exec
       type: test
       params:
         binary: bash
+        include_expansions_in_env: [AWS_SECRET_ACCESS_KEY, AWS_ACCESS_KEY_ID, AWS_SESSION_TOKEN]
         args: [src/.evergreen/tests/test-csfle.sh]
 
   "run cli test partial":

--- a/.evergreen/csfle/README.md
+++ b/.evergreen/csfle/README.md
@@ -40,9 +40,13 @@ ${DRIVERS_TOOLS}/.evergreen/csfle/teardown.sh
 
 ```yaml
 start-csfle-servers:
+  - command: ec2.assume_role
+      params:
+      role_arn: ${aws_test_secrets_role}
   - command: subprocess.exec
       params:
       binary: bash
+      include_expansions_in_env: [AWS_SECRET_ACCESS_KEY, AWS_ACCESS_KEY_ID, AWS_SESSION_TOKEN]
       args: [${DRIVERS_TOOLS}/.evergreen/csfle/setup.sh]
 ```
 

--- a/.evergreen/csfle/README.md
+++ b/.evergreen/csfle/README.md
@@ -29,22 +29,14 @@ The following servers will be started:
 - KMS HTTP server with an expired cert on port 9000
 - KMS HTTP server with an "wrong host" cert on port 9001
 - KMS HTTP server with a correct cert on port 9002
+- KMS Failpoint Server on port 9003
 - Mock Azure IMDS server on port 8080
 
 When finished, stop the servers by running:
 
 ```bash
-$DRIVERS_TOOLS/.evergreen/csfle/stop-servers.sh
+${DRIVERS_TOOLS}/.evergreen/csfle/teardown.sh
 ```
-
-If you are starting your CSFLE servers in a separate Evergreen function, it is recommended that you setup secrets
-and start the servers in the background, and then have a separate function that uses `await-servers.sh`
-in the foreground to wait for the servers to be ready.  This will ensure the servers are not torn down
-between functions (or the function may stall and not finish because there are processes still running).
-If you are starting the servers in a step within the same function as your tests, you
-can just start the servers directly in a foreground step.
-
-
 
 ```yaml
 start-csfle-servers:
@@ -53,24 +45,8 @@ start-csfle-servers:
       role_arn: ${aws_test_secrets_role}
   - command: subprocess.exec
       params:
-      working_dir: src
       binary: bash
-      include_expansions_in_env: ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"]
-      args: |
-          ${DRIVERS_TOOLS}/.evergreen/csfle/setup-secrets.sh
-  - command: subprocess.exec
-      params:
-      working_dir: src
-      binary: bash
-      background: true
-      args:
-          - ${DRIVERS_TOOLS}/.evergreen/csfle/start-servers.sh
-  - command: subprocess.exec
-      params:
-      working_dir: src
-      binary: bash
-      args:
-          - ${DRIVERS_TOOLS}/.evergreen/csfle/await-servers.sh
+      args: [${DRIVERS_TOOLS}/.evergreen/csfle/setup.sh]
 ```
 
 ## Legacy Usage

--- a/.evergreen/csfle/README.md
+++ b/.evergreen/csfle/README.md
@@ -40,9 +40,6 @@ ${DRIVERS_TOOLS}/.evergreen/csfle/teardown.sh
 
 ```yaml
 start-csfle-servers:
-  - command: ec2.assume_role
-      params:
-      role_arn: ${aws_test_secrets_role}
   - command: subprocess.exec
       params:
       binary: bash

--- a/.evergreen/csfle/start-servers.sh
+++ b/.evergreen/csfle/start-servers.sh
@@ -31,8 +31,15 @@ done
 
 # The -u options forces the stdout and stderr streams to be unbuffered.
 # TMPDIR is required to avoid "AF_UNIX path too long" errors.
+COMMAND="python -u"
+if [ "$(uname -s)" != "Darwin" ]; then
+  # The macos hosts do not support nohup.
+  COMMAND="nohup $COMMAND"
+fi
+
+
 echo "Starting KMIP Server..."
-TMPDIR="$(dirname "$DRIVERS_TOOLS")" nohup python -u kms_kmip_server.py --ca_file $CSFLE_TLS_CA_FILE --cert_file $CSFLE_TLS_CERT_FILE --port 5698 > kms_kmip_server.log 2>&1 &
+TMPDIR="$(dirname "$DRIVERS_TOOLS")" $COMMAND kms_kmip_server.py --ca_file $CSFLE_TLS_CA_FILE --cert_file $CSFLE_TLS_CERT_FILE --port 5698 > kms_kmip_server.log 2>&1 &
 echo "$!" > kmip_pids.pid
 sleep 1
 cat kms_kmip_server.log
@@ -40,7 +47,7 @@ echo "Starting KMIP Server...done."
 
 
 echo "Starting HTTP Server 1..."
-nohup python -u kms_http_server.py --ca_file $CSFLE_TLS_CA_FILE --cert_file ../x509gen/expired.pem --port 9000 > http1.log 2>&1 &
+$COMMAND kms_http_server.py --ca_file $CSFLE_TLS_CA_FILE --cert_file ../x509gen/expired.pem --port 9000 > http1.log 2>&1 &
 echo "$!" >> kmip_pids.pid
 sleep 1
 cat http1.log
@@ -48,7 +55,7 @@ echo "Starting HTTP Server 1...done."
 
 
 echo "Starting HTTP Server 2..."
-nohup python -u kms_http_server.py --ca_file $CSFLE_TLS_CA_FILE --cert_file ../x509gen/wrong-host.pem --port 9001 > http2.log 2>&1 &
+$COMMAND kms_http_server.py --ca_file $CSFLE_TLS_CA_FILE --cert_file ../x509gen/wrong-host.pem --port 9001 > http2.log 2>&1 &
 echo "$!" >> kmip_pids.pid
 sleep 1
 cat http2.log
@@ -56,7 +63,7 @@ echo "Starting HTTP Server 2...done."
 
 
 echo "Starting HTTP Server 3..."
-nohup python -u kms_http_server.py --ca_file $CSFLE_TLS_CA_FILE --cert_file $CSFLE_TLS_CERT_FILE --port 9002 --require_client_cert > http3.log 2>&1 &
+$COMMAND kms_http_server.py --ca_file $CSFLE_TLS_CA_FILE --cert_file $CSFLE_TLS_CERT_FILE --port 9002 --require_client_cert > http3.log 2>&1 &
 echo "$!" >> kmip_pids.pid
 sleep 1
 cat http3.log
@@ -64,13 +71,13 @@ echo "Starting HTTP Server 3...done."
 
 
 echo "Starting Failpoint Server..."
-nohup python -u kms_failpoint_server.py --port 9003 > failpoint.log 2>&1 &
+$COMMAND kms_failpoint_server.py --port 9003 > failpoint.log 2>&1 &
 echo "$!" >> kmip_pids.pid
 echo "Starting Failpoint Server...done."
 sleep 1
 
 echo "Starting Fake Azure IMDS..."
-nohup python bottle.py fake_azure:imds > fake_azure.log 2>&1 &
+$COMMAND bottle.py fake_azure:imds > fake_azure.log 2>&1 &
 echo "$!" >> kmip_pids.pid
 sleep 1
 cat fake_azure.log

--- a/.evergreen/csfle/start-servers.sh
+++ b/.evergreen/csfle/start-servers.sh
@@ -32,7 +32,7 @@ done
 # The -u options forces the stdout and stderr streams to be unbuffered.
 # TMPDIR is required to avoid "AF_UNIX path too long" errors.
 echo "Starting KMIP Server..."
-TMPDIR="$(dirname "$DRIVERS_TOOLS")" python -u kms_kmip_server.py --ca_file $CSFLE_TLS_CA_FILE --cert_file $CSFLE_TLS_CERT_FILE --port 5698 > kms_kmip_server.log 2>&1 &
+TMPDIR="$(dirname "$DRIVERS_TOOLS")" nohup python -u kms_kmip_server.py --ca_file $CSFLE_TLS_CA_FILE --cert_file $CSFLE_TLS_CERT_FILE --port 5698 > kms_kmip_server.log 2>&1 &
 echo "$!" > kmip_pids.pid
 sleep 1
 cat kms_kmip_server.log
@@ -40,7 +40,7 @@ echo "Starting KMIP Server...done."
 
 
 echo "Starting HTTP Server 1..."
-python -u kms_http_server.py --ca_file $CSFLE_TLS_CA_FILE --cert_file ../x509gen/expired.pem --port 9000 > http1.log 2>&1 &
+nohup python -u kms_http_server.py --ca_file $CSFLE_TLS_CA_FILE --cert_file ../x509gen/expired.pem --port 9000 > http1.log 2>&1 &
 echo "$!" >> kmip_pids.pid
 sleep 1
 cat http1.log
@@ -48,7 +48,7 @@ echo "Starting HTTP Server 1...done."
 
 
 echo "Starting HTTP Server 2..."
-python -u kms_http_server.py --ca_file $CSFLE_TLS_CA_FILE --cert_file ../x509gen/wrong-host.pem --port 9001 > http2.log 2>&1 &
+nohup python -u kms_http_server.py --ca_file $CSFLE_TLS_CA_FILE --cert_file ../x509gen/wrong-host.pem --port 9001 > http2.log 2>&1 &
 echo "$!" >> kmip_pids.pid
 sleep 1
 cat http2.log
@@ -56,7 +56,7 @@ echo "Starting HTTP Server 2...done."
 
 
 echo "Starting HTTP Server 3..."
-python -u kms_http_server.py --ca_file $CSFLE_TLS_CA_FILE --cert_file $CSFLE_TLS_CERT_FILE --port 9002 --require_client_cert > http3.log 2>&1 &
+nohup ython -u kms_http_server.py --ca_file $CSFLE_TLS_CA_FILE --cert_file $CSFLE_TLS_CERT_FILE --port 9002 --require_client_cert > http3.log 2>&1 &
 echo "$!" >> kmip_pids.pid
 sleep 1
 cat http3.log
@@ -64,13 +64,13 @@ echo "Starting HTTP Server 3...done."
 
 
 echo "Starting Failpoint Server..."
-python -u kms_failpoint_server.py --port 9003 > failpoint.log 2>&1 &
+nohup python -u kms_failpoint_server.py --port 9003 > failpoint.log 2>&1 &
 echo "$!" >> kmip_pids.pid
 echo "Starting Failpoint Server...done."
 sleep 1
 
 echo "Starting Fake Azure IMDS..."
-python bottle.py fake_azure:imds > fake_azure.log 2>&1 &
+nohup python bottle.py fake_azure:imds > fake_azure.log 2>&1 &
 echo "$!" >> kmip_pids.pid
 sleep 1
 cat fake_azure.log

--- a/.evergreen/csfle/start-servers.sh
+++ b/.evergreen/csfle/start-servers.sh
@@ -56,7 +56,7 @@ echo "Starting HTTP Server 2...done."
 
 
 echo "Starting HTTP Server 3..."
-nohup ython -u kms_http_server.py --ca_file $CSFLE_TLS_CA_FILE --cert_file $CSFLE_TLS_CERT_FILE --port 9002 --require_client_cert > http3.log 2>&1 &
+nohup python -u kms_http_server.py --ca_file $CSFLE_TLS_CA_FILE --cert_file $CSFLE_TLS_CERT_FILE --port 9002 --require_client_cert > http3.log 2>&1 &
 echo "$!" >> kmip_pids.pid
 sleep 1
 cat http3.log

--- a/.evergreen/csfle/start-servers.sh
+++ b/.evergreen/csfle/start-servers.sh
@@ -30,15 +30,17 @@ done
 . ./activate-kmstlsvenv.sh
 
 # The -u options forces the stdout and stderr streams to be unbuffered.
-# TMPDIR is required to avoid "AF_UNIX path too long" errors.
 COMMAND="python -u"
 if [ "$(uname -s)" != "Darwin" ]; then
+  # On linux and windows host, we need to use nohup to daemonize the process
+  # and prevent the task from hanging.
   # The macos hosts do not support nohup.
   COMMAND="nohup $COMMAND"
 fi
 
 
 echo "Starting KMIP Server..."
+# TMPDIR is required to avoid "AF_UNIX path too long" errors.
 TMPDIR="$(dirname "$DRIVERS_TOOLS")" $COMMAND kms_kmip_server.py --ca_file $CSFLE_TLS_CA_FILE --cert_file $CSFLE_TLS_CERT_FILE --port 5698 > kms_kmip_server.log 2>&1 &
 echo "$!" > kmip_pids.pid
 sleep 1
@@ -83,4 +85,5 @@ sleep 1
 cat fake_azure.log
 echo "Starting Fake Azure IMDS...done."
 
+# Wait for all of the servers to start.
 bash ./await-servers.sh


### PR DESCRIPTION
I tested this with the Go driver, which had use the background approach.  This will allow us to move the encryption setup to a task in the Python driver, without having to use the background approach.