### PR TITLE
DRIVERS-2882 Update k8s setup script and readme

### DIFF
--- a/.evergreen/auth_oidc/k8s/README.md
+++ b/.evergreen/auth_oidc/k8s/README.md
@@ -112,5 +112,7 @@ Where the test looks something like:
         export K8S_DRIVERS_TAR_FILE=/tmp/driver.tgz
         git archive -o $K8S_DRIVERS_TAR_FILE HEAD
         export K8S_TEST_CMD="OIDC_PROVIDER_NAME=k8s ./.evergreen/run-mongodb-oidc-test.sh"
-        bash ./.evergreen/auth_oidc/k8s/run-driver-test.sh
+        bash ${DRIVERS_TOOLS}/.evergreen/auth_oidc/k8s/setup-pod.sh
+        bash ${DRIVERS_TOOLS}/.evergreen/auth_oidc/k8s/run-driver-test.sh
+        bash ${DRIVERS_TOOLS}/.evergreen/auth_oidc/k8s/teardown-pod.sh
 ```

--- a/.evergreen/auth_oidc/k8s/setup.sh
+++ b/.evergreen/auth_oidc/k8s/setup.sh
@@ -13,7 +13,7 @@ if [ "$1" == "local" ]; then
   cat <<EOF >> "$SCRIPT_DIR/secrets-export.sh"
 export OIDC_SERVER_TYPE=local
 export MONGODB_URI="$URI"
-export MONGODB_URI_SINGLE="$URI/?authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:k8s"
+export MONGODB_URI_SINGLE="$URI/?authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:k8s&authSource=%24external"
 export OIDC_ADMIN_USER=bob
 export OIDC_ADMIN_PWD=pwd123
 EOF
@@ -97,7 +97,7 @@ URI=$(check_deployment)
 cat <<EOF >> "secrets-export.sh"
 export OIDC_SERVER_TYPE=atlas
 export MONGODB_URI="$URI"
-export MONGODB_URI_SINGLE="$URI/?authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:k8s"
+export MONGODB_URI_SINGLE="$URI/?authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:k8s&authSource=%24external"
 export OIDC_ADMIN_USER=$OIDC_ATLAS_USER
 export OIDC_ADMIN_PWD=$OIDC_ATLAS_PASSWORD
 EOF


### PR DESCRIPTION
DRIVERS-2882

This came out of my work on the Rust offshoot of this ticket ([RUST-1905](https://jira.mongodb.org/browse/RUST-1905)), and should make it easier for other drivers to do the same implementation 🙂

It updates the README to include the needed invocations of `setup-pod.sh` and `teardown-pod.sh`, and sets `authSource=$external` in the URI so the `authSource=admin` in the DNS record doesn't cause validation to fail.