### PR TITLE
chore(NODE-6636): set proper npm version on node install

### DIFF
--- a/.evergreen/install-node.sh
+++ b/.evergreen/install-node.sh
@@ -6,9 +6,16 @@ SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
 pushd $SCRIPT_DIR
 
 NODE_LTS_VERSION=${NODE_LTS_VERSION:-20}
-# npm version can be defined in the environment for cases where we need to install
-# a version lower than latest to support EOL Node versions.
-NPM_VERSION=${NPM_VERSION:-latest}
+# If NODE_LTS_VERSION is numeric and less than 18, default to 9, if less than 20, default to 10.
+# Do not override if it is already set.
+if [[ "$NODE_LTS_VERSION" =~ ^[0-9]+$ && "$NODE_LTS_VERSION" -lt 18 ]]; then
+  NPM_VERSION=${NPM_VERSION:-9}
+elif [[ "$NODE_LTS_VERSION" =~ ^[0-9]+$ && "$NODE_LTS_VERSION" -lt 20 ]]; then
+  NPM_VERSION=${NPM_VERSION:-10}
+else
+  NPM_VERSION=${NPM_VERSION:-latest}
+fi
+export NPM_VERSION=${NPM_VERSION}
 
 source "./init-node-and-npm-env.sh"
 


### PR DESCRIPTION
Move's Node's npm version fallback into drivers tools for reuse.

Example CI run in Node against this branch: https://spruce.mongodb.com/task/mongo_node_driver_next_rhel80_large_Node20_test_4.0_replica_set_patch_13ca440500b515e9aaf0aef4409503c518d13413_67850d4b11594900069dd02e_25_01_13_12_55_40/logs?execution=0