### PR TITLE
Add section concerning amd64 with rancher desktop

### DIFF
--- a/.evergreen/docker/README.md
+++ b/.evergreen/docker/README.md
@@ -110,8 +110,8 @@ export PATH="$MONGODB_BINARIES:$PATH"
 
 ## Using Rancher
 
-When using [Rancher Desktop](https://rancherdesktop.io/) on Apple Silicon or other ARM-based systems, it's _might_ be necessary to specify the amd64 architecture since some dependencies and tools are more reliable or only available for amd64. 
+When using [Rancher Desktop](https://rancherdesktop.io/) on Apple Silicon or other ARM-based systems, it's _might_ be necessary to specify the amd64 architecture since some dependencies and tools are more reliable or only available for amd64.
 
 ```
-ARCH=amd64 MONGODB_VERSION="8.0" TOPOLOGY=replica_set ./run-server.sh  
+ARCH=amd64 MONGODB_VERSION="8.0" TOPOLOGY=replica_set ./run-server.sh
 ```

--- a/.evergreen/docker/README.md
+++ b/.evergreen/docker/README.md
@@ -110,7 +110,7 @@ export PATH="$MONGODB_BINARIES:$PATH"
 
 ## Using Rancher
 
-When using [Rancher Desktop](https://rancherdesktop.io/) on Apple Silicon or other ARM-based systems, it's often necessary to specify the amd64 architecture since some dependencies and tools are more reliable or only available for amd64. 
+When using [Rancher Desktop](https://rancherdesktop.io/) on Apple Silicon or other ARM-based systems, it's _might_ be necessary to specify the amd64 architecture since some dependencies and tools are more reliable or only available for amd64. 
 
 ```
 ARCH=amd64 MONGODB_VERSION="8.0" TOPOLOGY=replica_set ./run-server.sh  

--- a/.evergreen/docker/README.md
+++ b/.evergreen/docker/README.md
@@ -107,3 +107,11 @@ crypt shared and other binaries to your PATH:
 ```bash
 export PATH="$MONGODB_BINARIES:$PATH"
 ```
+
+## Using Rancher
+
+When using [Rancher Desktop](https://rancherdesktop.io/) on Apple Silicon or other ARM-based systems, it's often necessary to specify the amd64 architecture since some dependencies and tools are more reliable or only available for amd64. 
+
+```
+ARCH=amd64 MONGODB_VERSION="8.0" TOPOLOGY=replica_set ./run-server.sh  
+```


### PR DESCRIPTION
Rancher desktop's `27.4.1-rd` does not do a great job of selecting the best architecture for an image, rather defaulting to the machine's architecture. This causes strange behavior, especially for dependencies that are specific to amd64 (libsnmp35, for example). Add section noting this to the docker README.md.