### PR TITLE
Fix order of 'kill' arguments in killport function.

### DIFF
--- a/.evergreen/process-utils.sh
+++ b/.evergreen/process-utils.sh
@@ -31,7 +31,7 @@ killport() {
   elif [ -x "$(command -v lsof)" ]; then
     for pid in $(lsof -t "-i:$port" || true); do
       echo "Killing pid $pid for port $port using kill" 1>&2
-      kill "$pid" -SIGKILL || true
+      kill -SIGKILL "$pid" || true
     done
   elif [ -x "$(command -v fuser)" ]; then
     echo "Killing process using port $port using fuser" 1>&2
@@ -39,7 +39,7 @@ killport() {
   elif [ -x "$(command -v ss)" ]; then
     for pid in $(ss -tlnp "sport = :$port" | awk 'NR>1 {split($7,a,","); print a[1]}' | tr -d '[:space:]'); do
       echo "Killing pid $pid for port $port using kill" 1>&2
-      kill "$pid" -SIGKILL || true
+      kill -SIGKILL "$pid" || true
     done
   else
     echo "Unable to identify the OS (${OSTYPE:?}) or find necessary utilities (fuser/lsof/ss) to kill the process."


### PR DESCRIPTION
The versions of `kill` on the platforms we commonly use (Ubuntu, RHEL, macOS) expect the `-SIGKILL` flag to come before the PID arguments.

## Ubuntu
```bash
$ kill "1234567890" -SIGKILL
-bash: kill: (1234567890) - No such process
-bash: kill: -SIGKILL: arguments must be process or job IDs
```
With `-SIGKILL` first:
```bash
$ kill -SIGKILL "1234567890"
-bash: kill: (1234567890) - No such process
```

## RHEL
```bash
$ kill "1234567890" -SIGKILL
-bash: kill: (1234567890) - No such process
-bash: kill: -SIGKILL: arguments must be process or job IDs
```
With `-SIGKILL` first:
```bash
$ kill -SIGKILL "1234567890"
-bash: kill: (1234567890) - No such process
```

## macos
```bash
❯ kill "1234567890" -SIGKILL
kill: kill 1234567890 failed: no such process
kill: illegal pid: -SIGKILL
```
With `-SIGKILL` first:
```bash
❯ kill -SIGKILL "1234567890"
kill: kill 1234567890 failed: no such process
```