### PR TITLE
Remove usages of xtrace

### DIFF
--- a/.evergreen/auth_aws/lib/ecs_hosted_test.sh
+++ b/.evergreen/auth_aws/lib/ecs_hosted_test.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # A shell script to run in an ECS hosted task
-set -ex
+set -e
+
+echo "Running ECS hosted test..."
 
 # The environment variable is always set during interactive logins
 # But for non-interactive logs, ~/.bashrc does not appear to be read on Ubuntu but it works on Fedora
@@ -14,3 +16,5 @@ mkdir -p /data/db || true
 sleep 1
 /root/mongosh --verbose ecs_hosted_test.js
 bash /root/src/.evergreen/run-mongodb-aws-ecs-test.sh "mongodb://localhost/aws?authMechanism=MONGODB-AWS"
+
+echo "Running ECS hosted test... done."

--- a/.evergreen/install-cli.sh
+++ b/.evergreen/install-cli.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Install the drivers orchestration scripts.
 
-set -eux
+set -eu
 
 if [ -z "$BASH" ]; then
   echo "install-cli.sh must be run in a Bash shell!" 1>&2

--- a/.evergreen/install-node.sh
+++ b/.evergreen/install-node.sh
@@ -89,8 +89,6 @@ node_download_url="https://nodejs.org/dist/${node_index_version}/${node_archive}
 
 echo "Node.js ${node_index_version} for ${operating_system}-${architecture} released on ${node_index_date}"
 
-set -o xtrace
-
 if [[ "$file_extension" = "zip" ]]; then
   if [[ -d "${NODE_ARTIFACTS_PATH}/nodejs/bin/${node_directory}" ]]; then
     echo "Node.js already installed!"

--- a/.evergreen/tests/test-cli.sh
+++ b/.evergreen/tests/test-cli.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Test mongodl and mongosh_dl.
-set -eux
+set -eu
 
 SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
 . $SCRIPT_DIR/../handle-paths.sh

--- a/.evergreen/tests/test-csfle.sh
+++ b/.evergreen/tests/test-csfle.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Test csfle
-set -eux
+set -eu
 
 SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
 . $SCRIPT_DIR/../handle-paths.sh
@@ -13,6 +13,7 @@ PYTHON_BINARY=$(bash -c ". $SCRIPT_DIR/../find-python3.sh && ensure_python3 2>/d
 export PYTHON_BINARY
 
 function run_test() {
+  echo "Running csfle test with $PYTHON_BINARY..."
   bash ./setup.sh
   bash ./teardown.sh
   # Bail on Windows due to permission errors trying to remove the kmstlsvenv folder.
@@ -20,6 +21,7 @@ function run_test() {
     return 0
   fi
   rm -rf kmstlsvenv
+  echo "Running csfle test with $PYTHON_BINARY... done."
 }
 run_test
 


### PR DESCRIPTION
Prefer to avoid using `xtrace`, which propagates to the calling script when using `.` or `source`, resulting in a log leakage risk and unintended verbosity.