### PR TITLE
Fix support for MongoDB 3.6

### DIFF
--- a/.evergreen/install-cli.sh
+++ b/.evergreen/install-cli.sh
@@ -48,23 +48,24 @@ fi
 pushd $1 > /dev/null
 
 # Add support for MongoDB 3.6, which was dropped in pymongo 4.11.
-EXTRA_ARGS=()
+EXTRA_ARGS=""
 if [ "${MONGODB_VERSION:-latest}" == "3.6" ]; then
-  EXTRA_ARGS=(--with "pymongo<4.11")
+  EXTRA_ARGS_ARR=(--with "pymongo<4.11")
+  EXTRA_ARGS="${EXTRA_ARGS_ARR[*]}"
 fi
 
 # On Windows, we have to do a bit of path manipulation.
 if [ "Windows_NT" == "${OS:-}" ]; then
   TMP_DIR=$(cygpath -m "$(mktemp -d)")
   PATH="$SCRIPT_DIR/venv/Scripts:$PATH"
-  UV_TOOL_BIN_DIR=${TMP_DIR} uv tool install "${EXTRA_ARGS[@]}" --force --editable .
+  UV_TOOL_BIN_DIR=${TMP_DIR} uv tool install "${EXTRA_ARGS}" --force --editable .
   filenames=$(ls ${TMP_DIR})
   for filename in $filenames; do
     mv $TMP_DIR/$filename "$1/${filename//.exe/}"
   done
   rm -rf $TMP_DIR
 else
-  UV_TOOL_BIN_DIR=$(pwd) uv tool install -q "${EXTRA_ARGS[@]}" --python "$(which python)" --force --editable .
+  UV_TOOL_BIN_DIR=$(pwd) uv tool install -q "${EXTRA_ARGS}" --python "$(which python)" --force --editable .
 fi
 
 popd > /dev/null

--- a/.evergreen/install-cli.sh
+++ b/.evergreen/install-cli.sh
@@ -53,7 +53,6 @@ if [ "${MONGODB_VERSION:-latest}" == "3.6" ]; then
   EXTRA_ARGS_ARR=(--with "pymongo<4.11")
   EXTRA_ARGS="${EXTRA_ARGS_ARR[*]}"
 fi
-echo "hello ${EXTRA_ARGS}"
 
 # On Windows, we have to do a bit of path manipulation.
 if [ "Windows_NT" == "${OS:-}" ]; then

--- a/.evergreen/install-cli.sh
+++ b/.evergreen/install-cli.sh
@@ -50,7 +50,7 @@ pushd $1 > /dev/null
 # Add support for MongoDB 3.6, which was dropped in pymongo 4.11.
 EXTRA_ARGS=()
 if [ "${MONGODB_VERSION:-latest}" == "3.6" ]; then
-  EXTRA_ARGS=(-with "pymongo<4.11")
+  EXTRA_ARGS=(--with "pymongo<4.11")
 fi
 
 # On Windows, we have to do a bit of path manipulation.

--- a/.evergreen/install-cli.sh
+++ b/.evergreen/install-cli.sh
@@ -53,19 +53,20 @@ if [ "${MONGODB_VERSION:-latest}" == "3.6" ]; then
   EXTRA_ARGS_ARR=(--with "pymongo<4.11")
   EXTRA_ARGS="${EXTRA_ARGS_ARR[*]}"
 fi
+echo "hello ${EXTRA_ARGS}"
 
 # On Windows, we have to do a bit of path manipulation.
 if [ "Windows_NT" == "${OS:-}" ]; then
   TMP_DIR=$(cygpath -m "$(mktemp -d)")
   PATH="$SCRIPT_DIR/venv/Scripts:$PATH"
-  UV_TOOL_BIN_DIR=${TMP_DIR} uv tool install "${EXTRA_ARGS}" --force --editable .
+  UV_TOOL_BIN_DIR=${TMP_DIR} uv tool install ${EXTRA_ARGS} --force --editable .
   filenames=$(ls ${TMP_DIR})
   for filename in $filenames; do
     mv $TMP_DIR/$filename "$1/${filename//.exe/}"
   done
   rm -rf $TMP_DIR
 else
-  UV_TOOL_BIN_DIR=$(pwd) uv tool install -q "${EXTRA_ARGS}" --python "$(which python)" --force --editable .
+  UV_TOOL_BIN_DIR=$(pwd) uv tool install -q ${EXTRA_ARGS} --python "$(which python)" --force --editable .
 fi
 
 popd > /dev/null

--- a/.evergreen/install-cli.sh
+++ b/.evergreen/install-cli.sh
@@ -64,7 +64,7 @@ if [ "Windows_NT" == "${OS:-}" ]; then
   done
   rm -rf $TMP_DIR
 else
-  UV_TOOL_BIN_DIR=$(pwd) uv tool install -q "${EXTRA_ARGS[@]}" -python "$(which python)" --force --editable .
+  UV_TOOL_BIN_DIR=$(pwd) uv tool install -q "${EXTRA_ARGS[@]}" --python "$(which python)" --force --editable .
 fi
 
 popd > /dev/null

--- a/.evergreen/install-cli.sh
+++ b/.evergreen/install-cli.sh
@@ -47,18 +47,24 @@ fi
 
 pushd $1 > /dev/null
 
+# Add support for MongoDB 3.6, which was dropped in pymongo 4.11.
+EXTRA_ARGS=()
+if [ "${MONGODB_VERSION:-latest}" == "3.6" ]; then
+  EXTRA_ARGS=(-with "pymongo<4.11")
+fi
+
 # On Windows, we have to do a bit of path manipulation.
 if [ "Windows_NT" == "${OS:-}" ]; then
   TMP_DIR=$(cygpath -m "$(mktemp -d)")
   PATH="$SCRIPT_DIR/venv/Scripts:$PATH"
-  UV_TOOL_BIN_DIR=${TMP_DIR} uv tool install --force --editable .
+  UV_TOOL_BIN_DIR=${TMP_DIR} uv tool install "${EXTRA_ARGS[@]}" --force --editable .
   filenames=$(ls ${TMP_DIR})
   for filename in $filenames; do
     mv $TMP_DIR/$filename "$1/${filename//.exe/}"
   done
   rm -rf $TMP_DIR
 else
-  UV_TOOL_BIN_DIR=$(pwd) uv tool install -q --python "$(which python)" --force --editable .
+  UV_TOOL_BIN_DIR=$(pwd) uv tool install -q "${EXTRA_ARGS[@]}" -python "$(which python)" --force --editable .
 fi
 
 popd > /dev/null

--- a/.evergreen/orchestration/drivers_orchestration.py
+++ b/.evergreen/orchestration/drivers_orchestration.py
@@ -291,6 +291,8 @@ def run(opts):
         resp = urllib.request.urlopen(req)
     except urllib.error.HTTPError as e:
         stop()
+        LOGGER.error("out.log: %s", (mo_home / "out.log").read_text())
+        LOGGER.error("server.log: %s", (mo_home / "server.log").read_text())
         raise e
     resp = json.loads(resp.read().decode("utf-8"))
     LOGGER.debug(resp)


### PR DESCRIPTION
The PyMongo 4.11 release dropped support for MongoDB 3.6, so we need to install an older version of PyMongo when testing against 3.6.