### PR TITLE
fix(DRIVERS-3086): use new ssh keys for AWS ecs tests

### DIFF
--- a/.evergreen/auth_aws/lib/container_tester.py
+++ b/.evergreen/auth_aws/lib/container_tester.py
@@ -63,6 +63,8 @@ def _scp(endpoint, src, dest):
     (user, host, port) = _userandhostandport(endpoint)
     cmd = [
         "scp",
+        "-i",
+        "/home/ubuntu/.ssh/fargate.ed25519",
         "-o",
         "StrictHostKeyChecking=no",
         "-P",
@@ -79,6 +81,8 @@ def _ssh(endpoint, cmd):
     (user, host, port) = _userandhostandport(endpoint)
     cmd = [
         "ssh",
+        "-i",
+        "/home/ubuntu/.ssh/fargate.ed25519",
         "-o",
         "StrictHostKeyChecking=no",
         "-p",


### PR DESCRIPTION
Passing run in Node: https://spruce.mongodb.com/version/679ceb0c3093610007dbc090/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC