### PR TITLE
Added sensible defaults in drivers_orchestration when env variables used

### DIFF
--- a/.evergreen/orchestration/drivers_orchestration.py
+++ b/.evergreen/orchestration/drivers_orchestration.py
@@ -121,8 +121,10 @@ def get_options():
         opts.mongo_orchestration_home = DRIVERS_TOOLS / ".evergreen/orchestration"
     if opts.mongodb_binaries is None:
         opts.mongodb_binaries = DRIVERS_TOOLS / "mongodb/bin"
-    if opts.topology == "standalone":
+    if opts.topology == "standalone" or not opts.topology:
         opts.topology = "server"
+    if not opts.version:
+        opts.version = "latest"
 
     if opts.verbose:
         LOGGER.setLevel(logging.DEBUG)


### PR DESCRIPTION
Adds sensible defaults for version (latest) and topology (server) when en passed as env vars not cli args.
This was causing failures in csharp driver.