### PR TITLE
fix: use consistent quoting in expansion file

### DIFF
--- a/.evergreen/orchestration/drivers_orchestration.py
+++ b/.evergreen/orchestration/drivers_orchestration.py
@@ -316,7 +316,7 @@ def run(opts):
     # Handle the cluster uri.
     uri = resp.get("mongodb_auth_uri", resp["mongodb_uri"])
     expansion_yaml.touch()
-    expansion_yaml.write_text(expansion_yaml.read_text() + f"\nMONGODB_URI: {uri}")
+    expansion_yaml.write_text(expansion_yaml.read_text() + f"\nMONGODB_URI: \"{uri}\"")
     uri_txt.write_text(uri)
     LOGGER.info(f"Cluster URI: {uri}")
 

--- a/.evergreen/orchestration/drivers_orchestration.py
+++ b/.evergreen/orchestration/drivers_orchestration.py
@@ -316,7 +316,7 @@ def run(opts):
     # Handle the cluster uri.
     uri = resp.get("mongodb_auth_uri", resp["mongodb_uri"])
     expansion_yaml.touch()
-    expansion_yaml.write_text(expansion_yaml.read_text() + f"\nMONGODB_URI: \"{uri}\"")
+    expansion_yaml.write_text(expansion_yaml.read_text() + f'\nMONGODB_URI: "{uri}"')
     uri_txt.write_text(uri)
     LOGGER.info(f"Cluster URI: {uri}")
 


### PR DESCRIPTION
Here's an example mo-expansion.yml file:

```
CRYPT_SHARED_LIB_PATH: "/Users/bailey.pearson/dev/drivers-evergreen-tools/mongo_crypt_v1.dylib"
MONGODB_URI: mongodb://bob:pwd123@localhost:27017/?authSource=admin
```

notice that CRYPT_SHARED_LIB_PATH has its value in quotes, whereas MONGODB_URI does not.

This PR adds quotes around MONGODB_URI for consistency.