### PR TITLE
fix: node-gyp requires 3.12+ python version

### DIFF
--- a/.evergreen/init-node-and-npm-env.sh
+++ b/.evergreen/init-node-and-npm-env.sh
@@ -21,3 +21,7 @@ export PATH="$npm_global_prefix/bin:$NODE_ARTIFACTS_PATH/nodejs/bin:$PATH"
 hash -r
 
 export NODE_OPTIONS="--trace-deprecation --trace-warnings"
+
+# https://github.com/nodejs/node-gyp#configuring-python-dependency
+source ./find-python3.sh
+export NODE_GYP_FORCE_PYTHON=$(find_python3)

--- a/.evergreen/init-node-and-npm-env.sh
+++ b/.evergreen/init-node-and-npm-env.sh
@@ -24,4 +24,5 @@ export NODE_OPTIONS="--trace-deprecation --trace-warnings"
 
 # https://github.com/nodejs/node-gyp#configuring-python-dependency
 source ./find-python3.sh
-export NODE_GYP_FORCE_PYTHON=$(find_python3)
+NODE_GYP_FORCE_PYTHON=$(find_python3)
+export NODE_GYP_FORCE_PYTHON

--- a/.evergreen/init-node-and-npm-env.sh
+++ b/.evergreen/init-node-and-npm-env.sh
@@ -23,6 +23,6 @@ hash -r
 export NODE_OPTIONS="--trace-deprecation --trace-warnings"
 
 # https://github.com/nodejs/node-gyp#configuring-python-dependency
-source ./find-python3.sh
+. $SCRIPT_DIR/find-python3.sh
 NODE_GYP_FORCE_PYTHON=$(find_python3)
 export NODE_GYP_FORCE_PYTHON


### PR DESCRIPTION
This won't actually guarantee 3.12 plus but it will get us a lot closer.