### PR TITLE
Increase ephemeral storage size to prevent Gradle execution failures.

### DIFF
--- a/.evergreen/k8s/gke/setup.sh
+++ b/.evergreen/k8s/gke/setup.sh
@@ -49,7 +49,7 @@ spec:
       limits:
         memory: "4Gi"
         cpu: "1"
-        ephemeral-storage: "8Gi"
+        ephemeral-storage: "4Gi"
     command: ["/bin/sleep", "3650d"]
     imagePullPolicy: IfNotPresent
   nodeSelector:

--- a/.evergreen/k8s/gke/setup.sh
+++ b/.evergreen/k8s/gke/setup.sh
@@ -49,7 +49,7 @@ spec:
       limits:
         memory: "4Gi"
         cpu: "1"
-        ephemeral-storage: "2Gi"
+        ephemeral-storage: "8Gi"
     command: ["/bin/sleep", "3650d"]
     imagePullPolicy: IfNotPresent
   nodeSelector:


### PR DESCRIPTION
Gradle builds in Java driver were failing due to insufficient ephemeral storage, causing out-of-memory issues. This change increases the storage allocation to prevent eviction of the pod.
