### PR TITLE
Fix `latest-build` URL for RHEL

### DIFF
--- a/.evergreen/mongodl.py
+++ b/.evergreen/mongodl.py
@@ -767,7 +767,12 @@ def _published_build_url(
 
 
 def _latest_build_url(
-    cache: Cache, target: str, arch: str, edition: str, component: str, branch: "str|None"
+    cache: Cache,
+    target: str,
+    arch: str,
+    edition: str,
+    component: str,
+    branch: "str|None",
 ) -> str:
     """
     Get the URL for an "unpublished" "latest" build.
@@ -798,7 +803,9 @@ def _latest_build_url(
     ent_infix = "enterprise-" if edition == "enterprise" else ""
     if "rhel" in target:
         # Some RHEL targets include a minor version, like "rhel93". Check the URL of the latest release.
-        latest_release_url = _published_build_url(cache, "latest", target, arch, edition, component)
+        latest_release_url = _published_build_url(
+            cache, "latest", target, arch, edition, component
+        )
         got = re.search(r"rhel[0-9][0-9]", latest_release_url)
         if got is not None:
             # Rewrite target like "rhel9" to "rhel93" to match published URL.

--- a/.evergreen/mongodl.py
+++ b/.evergreen/mongodl.py
@@ -767,7 +767,7 @@ def _published_build_url(
 
 
 def _latest_build_url(
-    target: str, arch: str, edition: str, component: str, branch: "str|None"
+    cache: Cache, target: str, arch: str, edition: str, component: str, branch: "str|None"
 ) -> str:
     """
     Get the URL for an "unpublished" "latest" build.
@@ -796,6 +796,13 @@ def _latest_build_url(
     ext = "zip" if target == "windows" else "tgz"
     # Enterprise builds have an "enterprise" infix
     ent_infix = "enterprise-" if edition == "enterprise" else ""
+    if "rhel" in target:
+        # Some RHEL targets include a minor version, like "rhel93". Check the URL of the latest release.
+        latest_release_url = _published_build_url(cache, "latest", target, arch, edition, component)
+        got = re.search(r"rhel[0-9][0-9]", latest_release_url)
+        if got is not None:
+            # Rewrite target like "rhel9" to "rhel93" to match published URL.
+            target = got.group(0)
     # Some platforms have a filename infix
     tgt_infix = (target + "-") if target not in ("windows", "win32", "macos") else ""
     # Non-master branch uses a filename infix
@@ -823,7 +830,7 @@ def _dl_component(
     LOGGER.info(f"Download {component} {version}-{edition} for {target}-{arch}")
     if version == "latest-build":
         dl_url = _latest_build_url(
-            target, arch, edition, component, latest_build_branch
+            cache, target, arch, edition, component, latest_build_branch
         )
     else:
         try:

--- a/.evergreen/tests/test-cli.sh
+++ b/.evergreen/tests/test-cli.sh
@@ -65,6 +65,7 @@ export VALIDATE_DISTROS=1
 ./mongodl --edition enterprise --version 8.0 --component archive --test
 ./mongodl --edition enterprise --version rapid --component archive --test
 ./mongodl --edition enterprise --version latest --component archive --out ${DOWNLOAD_DIR}
+./mongodl --edition enterprise --version latest-build --component archive --test
 ./mongodl --edition enterprise --version v6.0-perf --component cryptd --test
 ./mongodl --edition enterprise --version v8.0-perf --component cryptd --test
 


### PR DESCRIPTION
Fix `latest-build` download URL in mongodl for RHEL

Trying to download `latest-build` in mongodl for some RHEL distros results in error:

```
python ./.evergreen/mongodl.py  --version latest-build --target rhel9 --component archive
# Failed to download [https://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-rhel9-latest.tgz]
```

Comparing the URL in download-mongodb.sh on [before migrating to mongodl.py](https://github.com/mongodb-labs/drivers-evergreen-tools/blob/9142b7055ea5940e59ad41c4b069376f867031da/.evergreen/download-mongodb.sh#L151):

```
Old:     https://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-rhel93${DEBUG}-latest.tgz
Current: https://downloads.10gen.com/linux/mongodb-linux-x86_64-enterprise-rhel9-latest.tgz
```

I expect some `latest-build` RHEL URLs include the minor version (`93` instead of `9`). To fix: this PR checks the URL in `latest` for a minor version when building the URL for the `latest-build`.

Testing `latest-build` is added to `test-cli.sh`.

Verified with this patch build: https://spruce.mongodb.com/version/67b39deeae39430007faa599. Failures appear unrelated.