### PR TITLE
Revert "TUNE-74: source MongoDB versions from cloud.json to support 8.x binaries on AL2"

### DIFF
--- a/.evergreen/mongodl.py
+++ b/.evergreen/mongodl.py
@@ -623,11 +623,10 @@ class Cache:
 
     def refresh_full_json(self) -> None:
         """
-        Sync the content of the MongoDB cloud.json downloads list.
-        cloud.json is a superset of full.json
+        Sync the content of the MongoDB full.json downloads list.
         """
         with self._db.transaction():
-            dl = self.download_file("https://downloads.mongodb.org/cloud.json")
+            dl = self.download_file("https://downloads.mongodb.org/full.json")
             if not dl.is_changed:
                 # We still have a good cache
                 return


### PR DESCRIPTION
Reverts mongodb-labs/drivers-evergreen-tools#574 to fix failing downloads for rapid and latest binaries, due to releases being in cloud.json but not full.json.

I'll make the file name configurable next week.