### PR TITLE
DRIVERS-3119 Add options to provide certificate and CA files

### DIFF
--- a/.evergreen/orchestration/drivers_orchestration.py
+++ b/.evergreen/orchestration/drivers_orchestration.py
@@ -188,7 +188,7 @@ def handle_docker_config(data):
 def normalize_path(path: Path | str) -> str:
     path = Path(path).absolute
     if os.name != "nt":
-        return path
+        return str(path)
     path = path.as_posix()
     return re.sub("/cygdrive/(.*?)(/)", r"\1://", path, count=1)
 

--- a/.evergreen/orchestration/drivers_orchestration.py
+++ b/.evergreen/orchestration/drivers_orchestration.py
@@ -4,6 +4,8 @@ Run mongo-orchestration and launch a deployment.
 Use '--help' for more information.
 """
 
+from __future__ import annotations
+
 import argparse
 import json
 import logging

--- a/.evergreen/orchestration/drivers_orchestration.py
+++ b/.evergreen/orchestration/drivers_orchestration.py
@@ -186,7 +186,7 @@ def handle_docker_config(data):
 
 
 def normalize_path(path: Path | str) -> str:
-    path = Path(path).absolute
+    path = Path(path).absolute()
     if os.name != "nt":
         return str(path)
     path = path.as_posix()

--- a/.evergreen/orchestration/drivers_orchestration.py
+++ b/.evergreen/orchestration/drivers_orchestration.py
@@ -188,7 +188,7 @@ def handle_docker_config(data):
 def normalize_path(path: Path | str) -> str:
     if os.name != "nt":
         return str(path)
-    path = path.as_posix()
+    path = Path(path).as_posix()
     return re.sub("/cygdrive/(.*?)(/)", r"\1://", path, count=1)
 
 

--- a/.evergreen/orchestration/drivers_orchestration.py
+++ b/.evergreen/orchestration/drivers_orchestration.py
@@ -294,8 +294,10 @@ def run(opts):
         if not (opts.tls_pem_key_file and opts.tls_ca_file):
             raise ValueError("You must supply both tls-pem-key-file and tls-ca-file")
         base = "ABSOLUTE_PATH_REPLACEMENT_TOKEN/.evergreen/x509gen"
-        text = text.replace(f"{base}/server.pem", opts.tls_pem_key_file)
-        text = text.replace(f"{base}/ca.pem", opts.tls_ca_file)
+        text = text.replace(
+            f"{base}/server.pem", Path(opts.tls_pem_key_file).as_posix()
+        )
+        text = text.replace(f"{base}/ca.pem", Path(opts.tls_ca_file).as_posix())
     else:
         text = text.replace("ABSOLUTE_PATH_REPLACEMENT_TOKEN", DRIVERS_TOOLS.as_posix())
     data = json.loads(text)
@@ -409,7 +411,7 @@ def start(opts):
     # Override the client cert file if applicable.
     env = os.environ.copy()
     if opts.tls_cert_key_file:
-        env["MONGO_ORCHESTRATION_CLIENT_CERT"] = opts.tls_cert_key_file
+        env["MONGO_ORCHESTRATION_CLIENT_CERT"] = Path(opts.tls_cert_key_file).as_posix()
 
     mo_start = datetime.now()
 

--- a/.evergreen/orchestration/drivers_orchestration.py
+++ b/.evergreen/orchestration/drivers_orchestration.py
@@ -295,11 +295,9 @@ def run(opts):
             raise ValueError("You must supply both tls-pem-key-file and tls-ca-file")
         base = "ABSOLUTE_PATH_REPLACEMENT_TOKEN/.evergreen/x509gen"
         text = text.replace(
-            f"{base}/server.pem", str(opts.tls_pem_key_file).replace(os.sep, "/")
+            f"{base}/server.pem", Path(opts.tls_pem_key_file).as_posix()
         )
-        text = text.replace(
-            f"{base}/ca.pem", str(opts.tls_ca_file).replace(os.sep, "/")
-        )
+        text = text.replace(f"{base}/ca.pem", Path(opts.tls_ca_file).as_posix())
     else:
         text = text.replace("ABSOLUTE_PATH_REPLACEMENT_TOKEN", DRIVERS_TOOLS.as_posix())
     data = json.loads(text)

--- a/.evergreen/orchestration/drivers_orchestration.py
+++ b/.evergreen/orchestration/drivers_orchestration.py
@@ -186,7 +186,6 @@ def handle_docker_config(data):
 
 
 def normalize_path(path: Path | str) -> str:
-    path = Path(path).absolute()
     if os.name != "nt":
         return str(path)
     path = path.as_posix()

--- a/.evergreen/orchestration/drivers_orchestration.py
+++ b/.evergreen/orchestration/drivers_orchestration.py
@@ -295,9 +295,11 @@ def run(opts):
             raise ValueError("You must supply both tls-pem-key-file and tls-ca-file")
         base = "ABSOLUTE_PATH_REPLACEMENT_TOKEN/.evergreen/x509gen"
         text = text.replace(
-            f"{base}/server.pem", Path(opts.tls_pem_key_file).as_posix()
+            f"{base}/server.pem", str(opts.tls_pem_key_file).replace(os.sep, "/")
         )
-        text = text.replace(f"{base}/ca.pem", Path(opts.tls_ca_file).as_posix())
+        text = text.replace(
+            f"{base}/ca.pem", str(opts.tls_ca_file).replace(os.sep, "/")
+        )
     else:
         text = text.replace("ABSOLUTE_PATH_REPLACEMENT_TOKEN", DRIVERS_TOOLS.as_posix())
     data = json.loads(text)

--- a/.evergreen/run-orchestration.sh
+++ b/.evergreen/run-orchestration.sh
@@ -6,17 +6,20 @@ set -eu
 #   AUTH                   Set to "auth" to enable authentication. Defaults to "noauth"
 #   SSL                    Set to "yes" to enable SSL. Defaults to "nossl"
 #   TOPOLOGY               Set to "server", "replica_set", or "sharded_cluster". Defaults to "server" (i.e. standalone).
-#   LOAD_BALANCER          Set to a non-empty string to enable load balancer. Only supported for sharded clusters.
+#   MONGODB_VERSION        Set the MongoDB version to use. Defaults to "latest".
+#   MONGODB_DOWNLOAD_URL   Set the MongoDB download URL to use for download-mongodb.sh.
+#   ORCHESTRATION_FILE     Set the <topology>/<orchestration_file>.json configuration.
 #   STORAGE_ENGINE         Set to a non-empty string to use the <topology>/<storage_engine>.json configuration (e.g. STORAGE_ENGINE=inmemory).
 #   REQUIRE_API_VERSION    Set to a non-empty string to set the requireApiVersion parameter. Currently only supported for standalone servers.
 #   DISABLE_TEST_COMMANDS  Set to a non-empty string to use the <topology>/disableTestCommands.json configuration (e.g. DISABLE_TEST_COMMANDS=1).
-#   MONGODB_VERSION        Set to a MongoDB version to use for download-mongodb.sh. Defaults to "latest".
-#   MONGODB_DOWNLOAD_URL   Set to a MongoDB download URL to use for download-mongodb.sh.
-#   ORCHESTRATION_FILE     Set to a non-empty string to use the <topology>/<orchestration_file>.json configuration.
 #   SKIP_CRYPT_SHARED      Set to a non-empty string to skip downloading crypt_shared
-#   MONGODB_BINARIES       Set to a non-empty string to set the path to the MONGODB_BINARIES for mongo orchestration.
-#   PYTHON                 Set to a non-empty string to set the Python binary to use.
+#   MONGODB_BINARIES       Set the path to the MONGODB_BINARIES for mongo orchestration.
+#   LOAD_BALANCER          Set to a non-empty string to enable load balancer. Only supported for sharded clusters.
+#   PYTHON                 Set the Python binary to use.
 #   INSTALL_LEGACY_SHELL   Set to a non-empty string to install the legacy mongo shell.
+#   TLS_CERT_KEY_FILE      Set a .pem file to be used as the tlsCertificateKeyFile option in mongo-orchestration
+#   TLS_PEM_KEY_FILE       Set a .pem file that contains the TLS certificate and key for the server
+#   TLS_CA_FILE            Set a .pem file that contains the root certificate chain for the server
 
 # See https://stackoverflow.com/questions/35006457/choosing-between-0-and-bash-source/35006505#35006505
 # Why we need this syntax when sh is not aliased to bash (this script must be able to be called from sh)

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ There are two options for running a MongoDB server configuration.
 One is to use [docker](./.evergreen/docker/README.md).
 The other is to run `./evergreen/run-orchestration.sh` locally.
 For convenience, you can run `make run-server` and `make stop-server` to start and stop the server(s).
+
 For example:
 
 ```bash
@@ -94,13 +95,12 @@ TOPOLOGY=replica_set MONGODB_VERSION=7.0 make run-server
 
 See (run-orchestration.sh)[./evergreen/run-orchestration.sh] for the available environment variables.
 
-In order to use custom certificates in your server, copy the client certificate file to
-`$MONGO_ORCHESTRATION_HOME/lib/client.pem` (where `MONGO_ORCHESTRATION_HOME`
-defaults to `$DRIVERS_TOOLS/.evergreen/orchestration`), e.g.
+In order to use custom certificates in your server, set the following environment variables:
 
 ```bash
-# Replace Mongo Orchestration's client certificate.
-cp ${PROJECT_DIRECTORY}/test/certificates/client.pem ${MONGO_ORCHESTRATION_HOME}/lib/client.pem
+export TLS_CERT_KEY_FILE=<path-to>/client.pem
+export TLS_PEM_KEY_FILE=<path-to>/server.pem
+export TLS_CA_FILE=<path-to>/ca.pem
 ```
 
 ## Linters and Formatters


### PR DESCRIPTION
Tested with https://github.com/mongodb/mongo-python-driver/pull/2159 using the new flags, 
and with the Go driver using just this branch: https://spruce.mongodb.com/version/67be4ed44371980007ea1060/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC