### PR TITLE
DRIVERS-3119 Enhanced cleanup and file permissions handling

### DIFF
--- a/.evergreen/auth_aws/teardown.sh
+++ b/.evergreen/auth_aws/teardown.sh
@@ -10,6 +10,7 @@ pushd $SCRIPT_DIR
 # If we've gotten credentials, ensure the instance profile is set.
 if [ -f secrets-export.sh ]; then
   . ./activate-authawsvenv.sh
+  source secrets-export.sh
   python ./lib/aws_assign_instance_profile.py
 fi
 

--- a/.evergreen/clean.sh
+++ b/.evergreen/clean.sh
@@ -1,19 +1,15 @@
 #!/usr/bin/env bash
-set -eux
+set -eu
 
 SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
 . $SCRIPT_DIR/handle-paths.sh
 
+python3 $SCRIPT_DIR/orchestration/drivers_orchestration.py clean
 
 pushd $DRIVERS_TOOLS > /dev/null
-rm -rf $MONGODB_BINARIES
-rm -rf ./mongodb mo-expansion* mongo_crypt_v1* uri.txt
 find . -type f -name '*.log' -exec rm {} \;
 rm -rf "$${TMPDIR:-$${TEMP:-$${TMP:-/tmp}}}"/mongo*
-
-if [ "${1:-}" == "all" ]; then
-  find . -type f -name '*.env' -exec rm {} \;
-  find . -type f -name '*result.json' -exec rm {} \;
-fi
+find . -type f -name '*.env' -exec rm {} \;
+find . -type f -name '*results.json' -exec rm {} \;
 
 popd > /dev/null

--- a/.evergreen/clean.sh
+++ b/.evergreen/clean.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eu
+set -eux
 
 SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
 . $SCRIPT_DIR/handle-paths.sh

--- a/.evergreen/clean.sh
+++ b/.evergreen/clean.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -eu
+
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+. $SCRIPT_DIR/handle-paths.sh
+
+
+pushd $DRIVERS_TOOLS > /dev/null
+rm -rf $MONGODB_BINARIES
+rm -rf ./mongodb mo-expansion* mongo_crypt_v1* uri.txt
+find . -type f -name '*.log' -exec rm {} \;
+rm -rf "$${TMPDIR:-$${TEMP:-$${TMP:-/tmp}}}"/mongo*
+
+if [ "${1:-}" == "all" ]; then
+  find . -type f -name '*.env' -exec rm {} \;
+  find . -type f -name '*result.json' -exec rm {} \;
+fi
+
+popd > /dev/null

--- a/.evergreen/mongodl.py
+++ b/.evergreen/mongodl.py
@@ -1001,7 +1001,7 @@ def _expand_tgz(
                 strip_components,
                 mem.isdir(),
                 lambda: cast("IO[bytes]", tf.extractfile(mem)),  # noqa: B023
-                mem.mode,
+                mem.mode | 0o222,  # make sure file is writable
                 test=test,
             )
     return n_extracted

--- a/.evergreen/mongodl.py
+++ b/.evergreen/mongodl.py
@@ -1021,7 +1021,7 @@ def _expand_zip(
                 strip_components,
                 item.filename.endswith("/"),  ## Equivalent to: item.is_dir(),
                 lambda: zf.open(item, "r"),  # noqa: B023
-                0o555,
+                0o777,
                 test=test,
             )
     return n_extracted

--- a/.evergreen/mongodl.py
+++ b/.evergreen/mongodl.py
@@ -1021,7 +1021,7 @@ def _expand_zip(
                 strip_components,
                 item.filename.endswith("/"),  ## Equivalent to: item.is_dir(),
                 lambda: zf.open(item, "r"),  # noqa: B023
-                0o655,
+                0o555,
                 test=test,
             )
     return n_extracted

--- a/.evergreen/orchestration/drivers_orchestration.py
+++ b/.evergreen/orchestration/drivers_orchestration.py
@@ -459,7 +459,7 @@ def start(opts):
     command = f"{sys_executable} -m mongo_orchestration.server"
 
     # Handle Windows-specific concerns.
-    if PLATFORM != "win32":
+    if PLATFORM == "win32":
         # Copy default client certificate.
         src = DRIVERS_TOOLS / ".evergreen/x509gen/client.pem"
         dst = mo_home / "lib/client.pem"

--- a/.evergreen/orchestration/drivers_orchestration.py
+++ b/.evergreen/orchestration/drivers_orchestration.py
@@ -205,7 +205,7 @@ def run_command(cmd: str, **kwargs):
             stdout=subprocess.PIPE,
             **kwargs,
         )
-        LOGGER.debug(proc.stdout)
+        LOGGER.info(proc.stdout)
     except subprocess.CalledProcessError as e:
         LOGGER.error(e.output)
         LOGGER.error(str(e))

--- a/.evergreen/orchestration/drivers_orchestration.py
+++ b/.evergreen/orchestration/drivers_orchestration.py
@@ -220,7 +220,7 @@ def run(opts):
     mdb_binaries = Path(opts.mongodb_binaries)
     env = os.environ.copy()
     env["MONGODB_BINARIES"] = mdb_binaries.as_posix()
-    run_command("./.evergreen/clean.sh", env=env, cwd=DRIVERS_TOOLS)
+    run_command("bash ./.evergreen/clean.sh", env=env, cwd=DRIVERS_TOOLS)
 
     # NOTE: in general, we need to normalize paths to account for cygwin/Windows.
     mdb_binaries_str = normalize_path(mdb_binaries)

--- a/.evergreen/orchestration/drivers_orchestration.py
+++ b/.evergreen/orchestration/drivers_orchestration.py
@@ -220,7 +220,7 @@ def run(opts):
     mdb_binaries = Path(opts.mongodb_binaries)
     env = os.environ.copy()
     env["MONGODB_BINARIES"] = mdb_binaries.as_posix()
-    run_command("bash ./.evergreen/clean.sh", env=env, cwd=DRIVERS_TOOLS)
+    run_command("./.evergreen/clean.sh", env=env, cwd=DRIVERS_TOOLS)
 
     # NOTE: in general, we need to normalize paths to account for cygwin/Windows.
     mdb_binaries_str = normalize_path(mdb_binaries)

--- a/.evergreen/orchestration/drivers_orchestration.py
+++ b/.evergreen/orchestration/drivers_orchestration.py
@@ -36,9 +36,9 @@ CRYPT_NAME_MAP = {
 }
 
 # Top level files
-URI_TXT = DRIVERS_TOOLS / "uri.txt"
-MO_EXPANSION_SH = DRIVERS_TOOLS / "mo-expansion.sh"
-MO_EXPANSION_YML = DRIVERS_TOOLS / "mo-expansion.yml"
+URI_TXT = Path("uri.txt")
+MO_EXPANSION_SH = Path("mo-expansion.sh")
+MO_EXPANSION_YML = Path("mo-expansion.yml")
 
 
 def get_options():

--- a/.evergreen/orchestration/drivers_orchestration.py
+++ b/.evergreen/orchestration/drivers_orchestration.py
@@ -22,22 +22,30 @@ import urllib.request
 from datetime import datetime
 from pathlib import Path
 
-from mongodl import main as mongodl
-from mongosh_dl import main as mongosh_dl
-
 # Get global values.
 HERE = Path(__file__).absolute().parent
 EVG_PATH = HERE.parent
 DRIVERS_TOOLS = EVG_PATH.parent
 LOGGER = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format="%(levelname)-8s %(message)s")
+PLATFORM = sys.platform.lower()
+CRYPT_NAME_MAP = {
+    "win32": "mongo_crypt_v1.dll",
+    "darwin": "mongo_crypt_v1.dylib",
+    "linux": "mongo_crypt_v1.so",
+}
+
+# Top level files
+URI_TXT = DRIVERS_TOOLS / "uri.txt"
+MO_EXPANSION_SH = DRIVERS_TOOLS / "mo-expansion.sh"
+MO_EXPANSION_YML = DRIVERS_TOOLS / "mo-expansion.yml"
 
 
 def get_options():
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
-    parser.add_argument("command", choices=["run", "start", "stop"])
+    parser.add_argument("command", choices=["run", "start", "stop", "clean"])
     parser.add_argument(
         "--verbose", "-v", action="store_true", help="Whether to log at the DEBUG level"
     )
@@ -188,7 +196,7 @@ def handle_docker_config(data):
 
 
 def normalize_path(path: Path | str) -> str:
-    if os.name != "nt":
+    if PLATFORM != "win32":
         return str(path)
     path = Path(path).as_posix()
     return re.sub("/cygdrive/(.*?)(/)", r"\1://", path, count=1)
@@ -213,22 +221,33 @@ def run_command(cmd: str, **kwargs):
     LOGGER.debug(f"Running command {cmd}... done.")
 
 
-def run(opts):
-    LOGGER.info("Running orchestration...")
-
-    # Clean up previous files.
+def clean_run(opts):
     mdb_binaries = Path(opts.mongodb_binaries)
-    env = os.environ.copy()
-    env["MONGODB_BINARIES"] = mdb_binaries.as_posix()
-    run_command("bash ./.evergreen/clean.sh", env=env, cwd=DRIVERS_TOOLS)
+    mdb_binaries_str = normalize_path(mdb_binaries)
+    shutil.rmtree(mdb_binaries_str, ignore_errors=True)
+
+    mongodb_dir = DRIVERS_TOOLS / "mongodb"
+    if mongodb_dir.exists():
+        shutil.rmtree(normalize_path(mongodb_dir), ignore_errors=True)
+
+    for path in [URI_TXT, MO_EXPANSION_SH, MO_EXPANSION_YML]:
+        path.unlink(missing_ok=True)
+
+    crypt_path = DRIVERS_TOOLS / CRYPT_NAME_MAP[PLATFORM]
+    crypt_path.unlink(missing_ok=True)
+
+
+def run(opts):
+    # Deferred import so we can run as a script without the cli installed.
+    from mongodl import main as mongodl
+    from mongosh_dl import main as mongosh_dl
+
+    LOGGER.info("Running orchestration...")
+    clean_run(opts)
 
     # NOTE: in general, we need to normalize paths to account for cygwin/Windows.
+    mdb_binaries = Path(opts.mongodb_binaries)
     mdb_binaries_str = normalize_path(mdb_binaries)
-    expansion_yaml = Path("mo-expansion.yml")
-    expansion_yaml.unlink(missing_ok=True)
-    expansion_sh = Path("mo-expansion.sh")
-    expansion_sh.unlink(missing_ok=True)
-    uri_txt = DRIVERS_TOOLS / "uri.txt"
 
     # The evergreen directory to path.
     os.environ["PATH"] = f"{EVG_PATH}:{os.environ['PATH']}"
@@ -275,16 +294,17 @@ def run(opts):
         LOGGER.info("Downloading crypt_shared...")
         mongodl(shlex.split(args))
         LOGGER.info("Downloading crypt_shared... done.")
-        crypt_shared_path = None
-        expected = [f"mongo_crypt_v1.{ext}" for ext in ["dll", "so", "dylib"]]
-        for fname in os.listdir(mdb_binaries):
-            if fname in expected:
-                shutil.move(mdb_binaries / fname, DRIVERS_TOOLS)
-                crypt_shared_path = DRIVERS_TOOLS / fname
-        assert crypt_shared_path is not None
+        crypt_shared_path = mdb_binaries / CRYPT_NAME_MAP[PLATFORM]
+        if crypt_shared_path.exists():
+            shutil.move(crypt_shared_path, DRIVERS_TOOLS)
+            crypt_shared_path = DRIVERS_TOOLS / crypt_shared_path.name
+        else:
+            raise RuntimeError(
+                f"Could not find expected crypt_shared_path: {crypt_shared_path}"
+            )
         crypt_text = f'CRYPT_SHARED_LIB_PATH: "{normalize_path(crypt_shared_path)}"'
-        expansion_yaml.write_text(crypt_text)
-        expansion_sh.write_text(crypt_text.replace(": ", "="))
+        MO_EXPANSION_YML.write_text(crypt_text)
+        MO_EXPANSION_SH.write_text(crypt_text.replace(": ", "="))
 
     # Download mongosh
     args = f"--out {mdb_binaries_str} --strip-path-components 2 --retries 5"
@@ -372,9 +392,11 @@ def run(opts):
 
     # Handle the cluster uri.
     uri = resp.get("mongodb_auth_uri", resp["mongodb_uri"])
-    expansion_yaml.touch()
-    expansion_yaml.write_text(expansion_yaml.read_text() + f'\nMONGODB_URI: "{uri}"')
-    uri_txt.write_text(uri)
+    MO_EXPANSION_YML.touch()
+    MO_EXPANSION_YML.write_text(
+        MO_EXPANSION_YML.read_text() + f'\nMONGODB_URI: "{uri}"'
+    )
+    URI_TXT.write_text(uri)
     LOGGER.info(f"Cluster URI: {uri}")
 
     # Write the results file.
@@ -402,6 +424,19 @@ def run(opts):
     LOGGER.info("Running orchestration... done.")
 
 
+def clean_start(opts):
+    mo_home = Path(opts.mongo_orchestration_home)
+    for fname in [
+        "out.log",
+        "server.log",
+        "orchestration.config",
+        "config.json",
+        "server.pid",
+    ]:
+        if (mo_home / fname).exists():
+            (mo_home / fname).unlink()
+
+
 def start(opts):
     # Start mongo-orchestration
 
@@ -411,9 +446,7 @@ def start(opts):
         stop()
 
     # Clean up previous files.
-    for fname in ["out.log", "server.log", "orchestration.config", "config.json"]:
-        if (mo_home / fname).exists():
-            (mo_home / fname).unlink()
+    clean_start(opts)
 
     # Set up the mongo orchestration config.
     os.makedirs(mo_home / "lib", exist_ok=True)
@@ -426,7 +459,7 @@ def start(opts):
     command = f"{sys_executable} -m mongo_orchestration.server"
 
     # Handle Windows-specific concerns.
-    if os.name == "nt":
+    if PLATFORM != "win32":
         # Copy default client certificate.
         src = DRIVERS_TOOLS / ".evergreen/x509gen/client.pem"
         dst = mo_home / "lib/client.pem"
@@ -503,12 +536,14 @@ def stop():
 def main():
     opts = get_options()
     if opts.command == "run":
-        stop()
         run(opts)
     elif opts.command == "start":
         start(opts)
     elif opts.command == "stop":
         stop()
+    elif opts.command == "clean":
+        clean_run(opts)
+        clean_start(opts)
 
 
 if __name__ == "__main__":

--- a/.evergreen/tests/test-cli.sh
+++ b/.evergreen/tests/test-cli.sh
@@ -32,7 +32,6 @@ fi
 export PATH="${DOWNLOAD_DIR}/bin:$PATH"
 if [ "${OS:-}" != "Windows_NT" ]; then
   ./mongosh-dl --version 2.1.1 --out ${DOWNLOAD_DIR} --strip-path-components 1 --retries 5
-  chmod +x ./mongodl_test/bin/mongosh
   ./mongodl_test/bin/mongosh --version
 else
   ./mongosh-dl --version 2.1.1 --out ${DOWNLOAD_DIR} --strip-path-components 1 --retries 5

--- a/.evergreen/tests/test-cli.sh
+++ b/.evergreen/tests/test-cli.sh
@@ -8,6 +8,9 @@ SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
 
 pushd $SCRIPT_DIR/..
 
+# Ensure we can run clean before the cli is installed.
+make clean
+
 bash install-cli.sh .
 DOWNLOAD_DIR=mongodl_test
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,7 +60,6 @@ jobs:
       - id: test-mongodb
         name: "Test GitHub Action"
         run: |
-          chmod +x mongodb/bin/mongosh
           URI=$(cat uri.txt)
           ARGS=""
           if [ ${{ matrix.ssl }} == "ssl" ]; then

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ all:
 
 clean:
 	@echo "Cleaning files..."
-	.evergreen/clean.sh all
+	.evergreen/clean.sh
 
-run-server: clean
+run-server:
 	@echo "Running server..."
 	.evergreen/run-orchestration.sh
 

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,7 @@ all:
 
 clean:
 	@echo "Cleaning files..."
-	rm -rf ./mongodb .env results.json mo-expansion*
-	rm -rf "$${TMPDIR:-$${TEMP:-$${TMP:-/tmp}}}"/mongo*
+	.evergreen/clean.sh all
 
 run-server: clean
 	@echo "Running server..."


### PR DESCRIPTION
Usability improvements for `run-orchestration.sh` - files should have the right permissions and be cleaned up properly between runs.

Tested with Go driver: https://spruce.mongodb.com/version/67c092578d250f0007a0c5ec/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

And C driver: https://spruce.mongodb.com/version/67c096758d250f0007a0e4c6/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC