### PR TITLE
PYTHON-5131 Migrate off of Ubuntu 20.04 GitHub Actions Runners

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         os:
           - "ubuntu-latest"
-          - "ubuntu-20.04"
+          - "ubuntu-22.04"
           - "windows-latest"
           - "macos-latest"
         mongodb-version:


### PR DESCRIPTION
"The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025"