### PR TITLE
DRIVERS-3117 periodically remove old Azure resources

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -652,6 +652,18 @@ tasks:
             file: ".evergreen/compile.sh"
             buildtool: "cmake"
         - func: "upload build"
+
+    - name: delete_old_azure_resources
+      commands:
+        - command: ec2.assume_role
+          params:
+            role_arn: ${aws_test_secrets_role}
+        - command: subprocess.exec
+          params:
+            binary: bash
+            args:
+              - ${DRIVERS_TOOLS}/.evergreen/csfle/azurekms/delete_old_azure_resources.sh
+            
 # }}}
 
 
@@ -1546,6 +1558,12 @@ buildvariants:
   display_name: "Serverless ${os-requires-50}"
   tasks:
     - serverless_task_group
+
+- name: delete_old_azure_resources
+  display_name: "Delete old Azure resources"
+  run_on: rhel80-small
+  tasks:
+    - name: delete_old_azure_resources
 
       # Platform notes
       # i386 builds of OpenSSL or Cyrus SASL are not available

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1562,6 +1562,7 @@ buildvariants:
 - name: delete_old_azure_resources
   display_name: "Delete old Azure resources"
   run_on: rhel80-small
+  cron: '@daily'
   tasks:
     - name: delete_old_azure_resources
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -663,7 +663,7 @@ tasks:
             binary: bash
             args:
               - ${DRIVERS_TOOLS}/.evergreen/csfle/azurekms/delete_old_azure_resources.sh
-            
+
 # }}}
 
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1563,6 +1563,7 @@ buildvariants:
   display_name: "Delete old Azure resources"
   run_on: rhel80-small
   cron: '@daily'
+  patchable: false
   tasks:
     - name: delete_old_azure_resources
 

--- a/.evergreen/csfle/azurekms/delete_old_azure_resources.py
+++ b/.evergreen/csfle/azurekms/delete_old_azure_resources.py
@@ -33,10 +33,13 @@ def main():
     vm_names = []
     for vm in cmclient.virtual_machines.list(resource_group_name):
         try:
-            now = datetime.datetime.now(tz=datetime.timezone.utc)
-            delta = now - vm.time_created
-            if delta < datetime.timedelta(hours=2):
-                print(f"{vm.name} is less than 2 hours old. Age is: {delta} ... skipping")
+            # now = datetime.datetime.now(tz=datetime.timezone.utc)
+            # delta = now - vm.time_created
+            # if delta < datetime.timedelta(hours=2):
+            #     print(f"{vm.name} is less than 2 hours old. Age is: {delta} ... skipping")
+            #     continue
+            if "KEVINALBS" not in vm.name:
+                print(f"{vm.name} is not eligible for test deletion ... skipping")
                 continue
             vm_names.append(vm.name)
         except Exception as e:

--- a/.evergreen/csfle/azurekms/delete_old_azure_resources.py
+++ b/.evergreen/csfle/azurekms/delete_old_azure_resources.py
@@ -33,13 +33,10 @@ def main():
     vm_names = []
     for vm in cmclient.virtual_machines.list(resource_group_name):
         try:
-            # now = datetime.datetime.now(tz=datetime.timezone.utc)
-            # delta = now - vm.time_created
-            # if delta < datetime.timedelta(hours=2):
-            #     print(f"{vm.name} is less than 2 hours old. Age is: {delta} ... skipping")
-            #     continue
-            if "KEVINALBS" not in vm.name:
-                print(f"{vm.name} is not eligible for test deletion ... skipping")
+            now = datetime.datetime.now(tz=datetime.timezone.utc)
+            delta = now - vm.time_created
+            if delta < datetime.timedelta(hours=2):
+                print(f"{vm.name} is less than 2 hours old. Age is: {delta} ... skipping")
                 continue
             vm_names.append(vm.name)
         except Exception as e:

--- a/.evergreen/csfle/azurekms/delete_old_azure_resources.py
+++ b/.evergreen/csfle/azurekms/delete_old_azure_resources.py
@@ -1,0 +1,111 @@
+"""
+Delete old Azure Virtual Machines and related orphaned resources.
+
+Run with the shell script: delete_old_azure_resources.sh
+"""
+
+from azure.identity import DefaultAzureCredential
+from azure.mgmt.compute import ComputeManagementClient
+from azure.mgmt.network import NetworkManagementClient
+import datetime
+import os
+import argparse
+import sys
+
+
+def main():
+    # Parse args:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    # Create clients:
+    sub_id = os.getenv("AZURE_SUBSCRIPTION_ID")
+    resource_group_name = os.getenv("AZURE_RESOURCE_GROUP")
+    cmclient = ComputeManagementClient(
+        credential=DefaultAzureCredential(), subscription_id=sub_id
+    )
+    nmclient = NetworkManagementClient(
+        credential=DefaultAzureCredential(), subscription_id=sub_id
+    )
+
+    # Delete old Virtual Machines:
+    vm_names = []
+    for vm in cmclient.virtual_machines.list(resource_group_name):
+        try:
+            now = datetime.datetime.now(tz=datetime.timezone.utc)
+            delta = now - vm.time_created
+            if delta < datetime.timedelta(hours=2):
+                print(f"{vm.name} is less than 2 hours old. Age is: {delta} ... skipping")
+                continue
+            vm_names.append(vm.name)
+        except Exception as e:
+            print(f"Exception occurred: {e}")
+    print(f"Detected old Virtual Machines: {vm_names}")
+    if args.dry_run:
+        print("Dry run detected. Not deleting.")
+    else:
+        for vm_name in vm_names:
+            try:
+                print(f"Deleting Virtual Machine '{vm_name}' ...")
+                cmclient.virtual_machines.begin_delete(
+                    resource_group_name, vm_name
+                ).result()
+                print(f"Deleting Virtual Machine '{vm_name}' ... done")
+            except Exception as e:
+                print(f"Exception occurred: {e}")
+
+    # Get list of all Virtual Machine names to detect orphaned resources:
+    all_vm_names = []  # Example: `vmname-RUBY-10561`
+    for vm in cmclient.virtual_machines.list(resource_group_name):
+        all_vm_names.append(vm.name)
+
+    # Delete orphaned NSGs:
+    orphan_nsg_names = []
+    for nsg in nmclient.network_security_groups.list(resource_group_name):
+        is_orphan = True
+        for vm_name in all_vm_names:
+            if vm_name + "-NSG" == nsg.name:
+                is_orphan = False
+                break
+        if is_orphan:
+            orphan_nsg_names.append(nsg.name)
+    print(f"Detected orphaned NSGs: {orphan_nsg_names}")
+    if args.dry_run:
+        print("Dry run detected. Not deleting.")
+    else:
+        for nsg_name in orphan_nsg_names:
+            try:
+                print(f"Deleting orphaned NSG '{nsg_name}' ...")
+                nmclient.network_security_groups.begin_delete(
+                    resource_group_name, nsg_name).result()
+                print(f"Deleting orphaned NSG '{nsg_name}' ... done")
+            except Exception as e:
+                print(f"Exception occurred: {e}")
+
+    # Delete orphaned IPs:
+    orphan_ip_names = []
+    for ip in nmclient.public_ip_addresses.list(resource_group_name):
+        is_orphan = True
+        for vm_name in all_vm_names:
+            if vm_name + "-PUBLIC-IP" == ip.name:
+                is_orphan = False
+                break
+        if is_orphan:
+            orphan_ip_names.append(ip.name)
+    print(f"Detected orphaned IPs: {orphan_ip_names}")
+    if args.dry_run:
+        print("Dry run detected. Not deleting.")
+    else:
+        for ip_name in orphan_ip_names:
+            try:
+                print(f"Deleting orphaned IP '{ip_name}' ...")
+                nmclient.public_ip_addresses.begin_delete(
+                    resource_group_name, ip_name
+                ).result()
+                print(f"Deleting orphaned IP '{ip_name}' ... done")
+            except Exception as e:
+                print(f"Exception occurred: {e}")
+
+if __name__ == "__main__":
+    main()

--- a/.evergreen/csfle/azurekms/delete_old_azure_resources.py
+++ b/.evergreen/csfle/azurekms/delete_old_azure_resources.py
@@ -4,13 +4,13 @@ Delete old Azure Virtual Machines and related orphaned resources.
 Run with the shell script: delete_old_azure_resources.sh
 """
 
+import argparse
+import datetime
+import os
+
 from azure.identity import DefaultAzureCredential
 from azure.mgmt.compute import ComputeManagementClient
 from azure.mgmt.network import NetworkManagementClient
-import datetime
-import os
-import argparse
-import sys
 
 
 def main():
@@ -36,7 +36,9 @@ def main():
             now = datetime.datetime.now(tz=datetime.timezone.utc)
             delta = now - vm.time_created
             if delta < datetime.timedelta(hours=2):
-                print(f"{vm.name} is less than 2 hours old. Age is: {delta} ... skipping")
+                print(
+                    f"{vm.name} is less than 2 hours old. Age is: {delta} ... skipping"
+                )
                 continue
             vm_names.append(vm.name)
         except Exception as e:
@@ -78,7 +80,8 @@ def main():
             try:
                 print(f"Deleting orphaned NSG '{nsg_name}' ...")
                 nmclient.network_security_groups.begin_delete(
-                    resource_group_name, nsg_name).result()
+                    resource_group_name, nsg_name
+                ).result()
                 print(f"Deleting orphaned NSG '{nsg_name}' ... done")
             except Exception as e:
                 print(f"Exception occurred: {e}")
@@ -106,6 +109,7 @@ def main():
                 print(f"Deleting orphaned IP '{ip_name}' ... done")
             except Exception as e:
                 print(f"Exception occurred: {e}")
+
 
 if __name__ == "__main__":
     main()

--- a/.evergreen/csfle/azurekms/delete_old_azure_resources.sh
+++ b/.evergreen/csfle/azurekms/delete_old_azure_resources.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# Delete old Azure Virtual Machines and related orphaned resources.
+
+set -o errexit
+set -o nounset
+
+# Get absolute path to drivers-evergreen-tools:
+{
+    SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+    . "$SCRIPT_DIR/../../handle-paths.sh"
+}
+
+# Create virtualenv with Azure dependencies installed:
+{
+    . "$DRIVERS_TOOLS/.evergreen/venv-utils.sh"
+    if [[ -d azure_deletion_venv ]]; then
+        venvactivate azure_deletion_venv
+    else
+        . "$DRIVERS_TOOLS/.evergreen/find-python3.sh"
+        PYTHON=$(ensure_python3)
+        echo "Creating virtual environment 'azure_deletion_venv'..."
+        venvcreate "${PYTHON:?}" azure_deletion_venv
+        python -m pip install azure-identity
+        python -m pip install azure-mgmt-compute
+        python -m pip install azure-mgmt-network
+        echo "Creating virtual environment 'azure_deletion_venv'... done."
+    fi
+}
+
+# Delete resources for Azure KMS testing (DRIVERS-2411):
+{
+    "$DRIVERS_TOOLS/.evergreen/secrets_handling/setup-secrets.sh" drivers/azurekms
+    # shellcheck source=/dev/null
+    source secrets-export.sh
+    export AZURE_SUBSCRIPTION_ID="$AZUREKMS_SUBSCRIPTION"
+    export AZURE_RESOURCE_GROUP="$AZUREKMS_RESOURCEGROUP"
+    export AZURE_CLIENT_SECRET="$AZUREKMS_SECRET"
+    export AZURE_CLIENT_ID="$AZUREKMS_CLIENTID"
+    export AZURE_TENANT_ID="$AZUREKMS_TENANTID"
+    python "$DRIVERS_TOOLS/.evergreen/csfle/azurekms/delete_old_azure_resources.py"
+    rm secrets-export.sh
+}
+
+# Delete resources for Azure OIDC testing (DRIVERS-2415):
+{
+    "$DRIVERS_TOOLS/.evergreen/secrets_handling/setup-secrets.sh" drivers/azureoidc
+    # shellcheck source=/dev/null
+    source secrets-export.sh
+    export AZURE_SUBSCRIPTION_ID="$AZUREOIDC_SUBSCRIPTION"
+    export AZURE_RESOURCE_GROUP="$AZUREOIDC_RESOURCEGROUP"
+    export AZURE_CLIENT_SECRET="$AZUREOIDC_SECRET"
+    export AZURE_CLIENT_ID="$AZUREOIDC_CLIENTID"
+    export AZURE_TENANT_ID="$AZUREOIDC_TENANTID"
+    python "$DRIVERS_TOOLS/.evergreen/csfle/azurekms/delete_old_azure_resources.py"
+    rm secrets-export.sh
+}


### PR DESCRIPTION
# Summary
Add a task to periodically delete leftover Azure resources from OIDC and KMS tasks.

# Background & Motivation

Alerts were recently triggered due to leftover Azure resources created for testing.

Evergreen task groups for Azure clean-up resources in [teardown](https://github.com/mongodb/mongo-rust-driver/blob/2b35455e90217e04b6d85c2799d5bb741c428b5b/.evergreen/config.yml#L472-L483). However, this appears unreliable. For example, [this Rust OIDC task](https://spruce.mongodb.com/task/mongo*rust_driver_oidc_linux_oidc_auth_test_azure_latest_patch_2b35455e90217e04b6d85c2799d5bb741c428b5b_67bd0047e6df5c0007ab8f84_25_02_24_23_27*06/logs?execution=0) logs:
```
<2025/02/24 18:29:43.330> Heartbeat received signal to abort task.
```

I expect the task was aborted before storing the VM name as an expansion:
```
[...]/.evergreen/auth_oidc/azure/delete-vm.sh: line 11: AZUREOIDC_VMNAME: unbound variable
```

# Testing
A patch was run with temporary criteria to delete VMs containing the name "KEVINALBS". The [logs](https://spruce.mongodb.com/task/drivers_tools_delete_old_azure_resources_delete_old_azure_resources_patch_cf90abd3231e42a12c6198cf3bb605be5413b48d_67c8bc413b95230007dceef8_25_03_05_21_04_02/logs?execution=0&sortBy=STATUS&sortDir=ASC) list the deleted resources:
```
Detected old Virtual Machines: ['vmname-KEVINALBS-17254']
Deleting Virtual Machine 'vmname-KEVINALBS-17254' ...
Deleting Virtual Machine 'vmname-KEVINALBS-17254' ... done
Detected orphaned NSGs: ['vmname-KEVINALBS-17254-NSG']
Deleting orphaned NSG 'vmname-KEVINALBS-17254-NSG' ...
Deleting orphaned NSG 'vmname-KEVINALBS-17254-NSG' ... done
Detected orphaned IPs: ['vmname-KEVINALBS-17254-PUBLIC-IP']
Deleting orphaned IP 'vmname-KEVINALBS-17254-PUBLIC-IP' ...
Deleting orphaned IP 'vmname-KEVINALBS-17254-PUBLIC-IP' ... done
```

To test on Evergreen, credentials were added in AWS Secrets Manager:
- Added `AZUREKMS_SUBSCRIPTION` to the secrets `drivers/azurekms` and `drivers/azureoidc` 
- Added `AZUREOIDC_RESOURCEGROUP` to `drivers/azurekms`

`cron: '@daily'` is added to trigger periodic builds with Evergreen's [cron feature](https://docs.devprod.prod.corp.mongodb.com/evergreen/Project-Configuration/Controlling-when-tasks-run#cron)
