### PR TITLE
PYTHON-5195 Allow OCSP server to be run as a daemon

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -559,6 +559,13 @@ functions:
         binary: bash
         args: [src/.evergreen/tests/test-cli.sh]
 
+  "run ocsp test":
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: bash
+        args: [src/.evergreen/tests/test-ocsp.sh]
+
   "teardown assets":
     - command: subprocess.exec
       params:
@@ -1035,6 +1042,11 @@ tasks:
       commands:
         - func: "run cli test full"
 
+    - name: "test-ocsp"
+      tags: ["pr"]
+      commands:
+        - func: "run ocsp test"
+
     - name: "test-cli-partial"
       tags: ["pr"]
       commands:
@@ -1485,6 +1497,7 @@ buildvariants:
           - "test-install-binaries"
           - "test-csfle"
           - "test-cli-full"
+          - "test-ocsp"
           - "test-8.0-standalone-require-api"
 
 - matrix_name: "tests-os-requires-50"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1043,7 +1043,6 @@ tasks:
         - func: "run cli test full"
 
     - name: "test-ocsp"
-      tags: ["pr"]
       commands:
         - func: "run ocsp test"
 

--- a/.evergreen/ocsp/mock-ocsp-responder-requirements.txt
+++ b/.evergreen/ocsp/mock-ocsp-responder-requirements.txt
@@ -4,5 +4,6 @@ flask==2.2.5
 itsdangerous==2.1.2
 Jinja2==3.1.5
 MarkupSafe==2.1.4
-git+https://github.com/wbond/oscrypto.git@d5f3437
+oscrypto==1.3.0
+waitress==3.0.2
 Werkzeug==3.0.6

--- a/.evergreen/ocsp/ocsp_mock.py
+++ b/.evergreen/ocsp/ocsp_mock.py
@@ -11,6 +11,7 @@ import sys
 sys.path.append(os.path.join(os.getcwd(), "src", "third_party", "mock_ocsp_responder"))
 
 import mock_ocsp_responder
+from waitress import serve
 
 
 def main():
@@ -22,7 +23,7 @@ def main():
     )
 
     parser.add_argument(
-        "-b", "--bind_ip", type=str, default=None, help="IP to listen on"
+        "-b", "--bind_ip", type=str, default="127.0.0.1", help="IP to listen on"
     )
 
     parser.add_argument(
@@ -76,9 +77,7 @@ def main():
         next_update_seconds=args.next_update_seconds,
     )
 
-    mock_ocsp_responder.init(port=args.port, debug=args.verbose, host=args.bind_ip)
-
-    print("Mock OCSP Responder is running on port %s" % (str(args.port)))
+    serve(mock_ocsp_responder.app, host=args.bind_ip, port=args.port)
 
 
 if __name__ == "__main__":

--- a/.evergreen/ocsp/ocsp_mock.py
+++ b/.evergreen/ocsp/ocsp_mock.py
@@ -78,10 +78,6 @@ def main():
 
     mock_ocsp_responder.init(port=args.port, debug=args.verbose, host=args.bind_ip)
 
-    # Write the pid file.
-    with open(os.path.join(os.getcwd(), "ocsp.pid"), "w") as fid:
-        fid.write(str(os.getpid()))
-
     print("Mock OCSP Responder is running on port %s" % (str(args.port)))
 
 

--- a/.evergreen/ocsp/setup.sh
+++ b/.evergreen/ocsp/setup.sh
@@ -60,7 +60,7 @@ if [ "$(uname -s)" != "Darwin" ]; then
   COMMAND="nohup $COMMAND"
 fi
 
-python ocsp_mock.py \
+$COMMAND ocsp_mock.py \
   --ca_file $CA_FILE \
   --ocsp_responder_cert $CERT \
   --ocsp_responder_key $KEY \

--- a/.evergreen/ocsp/setup.sh
+++ b/.evergreen/ocsp/setup.sh
@@ -18,7 +18,11 @@ for VARNAME in "${VARLIST[@]}"; do
   [[ -z "${!VARNAME:-}" ]] && echo "ERROR: $VARNAME not set" && exit 1;
 done
 
+bash teardown.sh
+
 . ./activate-ocspvenv.sh
+
+echo "Starting OCSP server ${OCSP_ALGORITHM}-${SERVER_TYPE}..."
 
 CA_FILE="${OCSP_ALGORITHM}/ca.pem"
 ARGS="-p 8100 -v"
@@ -48,8 +52,26 @@ case $SERVER_TYPE in
     ;;
 esac
 
+COMMAND="python"
+if [ "$(uname -s)" != "Darwin" ]; then
+  # On linux and windows host, we need to use nohup to daemonize the process
+  # and prevent the task from hanging.
+  # The macos hosts do not support nohup.
+  COMMAND="nohup $COMMAND"
+fi
+
 python ocsp_mock.py \
   --ca_file $CA_FILE \
   --ocsp_responder_cert $CERT \
   --ocsp_responder_key $KEY \
-  $ARGS
+  $ARGS > ocsp_mock_server.log 2>&1 &
+echo "$!" > ocsp.pid
+
+tail -f ocsp_mock_server.log &
+log_pid="$!"
+
+# Wait for server to start.
+grep -q "Debugger is active" <(tail -f ocsp_mock_server.log)
+kill $log_pid
+
+echo "Starting OCSP server ${OCSP_ALGORITHM}-${SERVER_TYPE}... done."

--- a/.evergreen/ocsp/setup.sh
+++ b/.evergreen/ocsp/setup.sh
@@ -67,11 +67,7 @@ $COMMAND ocsp_mock.py \
   $ARGS > ocsp_mock_server.log 2>&1 &
 echo "$!" > ocsp.pid
 
-tail -f ocsp_mock_server.log &
-log_pid="$!"
-
-# Wait for server to start.
-grep -q "Debugger is active" <(tail -f ocsp_mock_server.log)
-kill $log_pid
+sleep 1
+cat ocsp_mock_server.log
 
 echo "Starting OCSP server ${OCSP_ALGORITHM}-${SERVER_TYPE}... done."

--- a/.evergreen/ocsp/setup.sh
+++ b/.evergreen/ocsp/setup.sh
@@ -52,7 +52,7 @@ case $SERVER_TYPE in
     ;;
 esac
 
-COMMAND="python"
+COMMAND="python -u"
 if [ "$(uname -s)" != "Darwin" ]; then
   # On linux and windows host, we need to use nohup to daemonize the process
   # and prevent the task from hanging.

--- a/.evergreen/ocsp/teardown.sh
+++ b/.evergreen/ocsp/teardown.sh
@@ -7,7 +7,9 @@ SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
 . $SCRIPT_DIR/../handle-paths.sh
 pushd $SCRIPT_DIR
 if [ -f "ocsp.pid" ]; then
-  < ocsp.pid xargs kill -9 || true
+  echo "Killing ocsp server..."
+  < ocsp.pid xargs kill -15 || true
   rm ocsp.pid
+  echo "Killing ocsp server...done."
 fi
 popd

--- a/.evergreen/tests/test-ocsp.sh
+++ b/.evergreen/tests/test-ocsp.sh
@@ -9,13 +9,16 @@ SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
 if [[ $(uname -s) = "Linux" ]]; then
   ORCHESTRATION_FILE="ecdsa-basic-tls-ocsp-mustStaple.json"
   OCSP_ALGORITHM="ecdsa"
+  SERVER_TYPE="valid-delegate"
 else
   ORCHESTRATION_FILE="rsa-basic-tls-ocsp-disableStapling.json"
   OCSP_ALGORITHM="rsa"
+  SERVER_TYPE="valid"
 fi
 
 export ORCHESTRATION_FILE
 export OCSP_ALGORITHM
+export SERVER_TYPE
 
 # # Start a MongoDB server with ocsp enabled.
 SSL="ssl" make -C ${DRIVERS_TOOLS} run-server
@@ -23,14 +26,14 @@ SSL="ssl" make -C ${DRIVERS_TOOLS} run-server
 pushd $SCRIPT_DIR/../ocsp
 
 # # Start the ocsp server.
-SERVER_TYPE="valid" bash ./setup.sh
+bash ./setup.sh
 
 # Connect to the MongoDB server.
 echo "Connecting to server..."
 TLS_OPTS=("--tls --tlsCertificateKeyFile \"${DRIVERS_TOOLS}/.evergreen/ocsp/${OCSP_ALGORITHM}/server.pem\"")
 TLS_OPTS+=("--tlsCAFile \"${DRIVERS_TOOLS}/.evergreen/ocsp/${OCSP_ALGORITHM}/ca.pem\"")
-URI="mongodb://localhost:27017/&serverSelectionTimeoutMS=20000"
-$MONGODB_BINARIES/mongosh $URI "${TLS_OPTS[@]}" --eval "db.runCommand({\"ping\":1})"
+# shellcheck disable=SC2068
+$MONGODB_BINARIES/mongosh ${TLS_OPTS[@]} --eval "db.runCommand({\"ping\":1})"
 echo "Connecting to server... done."
 
 bash ./teardown.sh

--- a/.evergreen/tests/test-ocsp.sh
+++ b/.evergreen/tests/test-ocsp.sh
@@ -9,22 +9,22 @@ SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
 
 if [[ "$(uname -s)" == CYGWIN* ]]; then
   ORCHESTRATION_FILE="rsa-basic-tls-ocsp-disableStapling.json"
-  SERVER_TYPE="revoked"
+  OCSP_SERVER_TYPE="revoked"
   URI_OPTIONS="tls=true&tlsInsecure=true"
   OCSP_ALGORITHM="rsa"
 elif [[ $(uname -s) = "Darwin" ]]; then
   ORCHESTRATION_FILE="rsa-basic-tls-ocsp-disableStapling.json"
-  SERVER_TYPE="valid"
+  OCSP_SERVER_TYPE="valid"
   URI_OPTIONS="tls=true"
   OCSP_ALGORITHM="rsa"
 else
   ORCHESTRATION_FILE="ecdsa-basic-tls-ocsp-mustStaple.json"
-  SERVER_TYPE="valid-delegate"
+  OCSP_SERVER_TYPE="valid-delegate"
   URI_OPTIONS="tls=true"
   OCSP_ALGORITHM="ecdsa"
 fi
 export ORCHESTRATION_FILE
-export SERVER_TYPE
+export OCSP_SERVER_TYPE
 export OCSP_ALGORITHM
 
 # Start a MongoDB server with ocsp enabled.

--- a/.evergreen/tests/test-ocsp.sh
+++ b/.evergreen/tests/test-ocsp.sh
@@ -6,25 +6,15 @@ set -eu
 SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
 . $SCRIPT_DIR/../handle-paths.sh
 
-
-if [[ "$(uname -s)" == CYGWIN* ]]; then
-  ORCHESTRATION_FILE="rsa-basic-tls-ocsp-disableStapling.json"
-  OCSP_SERVER_TYPE="revoked"
-  URI_OPTIONS="tls=true&tlsInsecure=true"
-  OCSP_ALGORITHM="rsa"
-elif [[ $(uname -s) = "Darwin" ]]; then
-  ORCHESTRATION_FILE="rsa-basic-tls-ocsp-disableStapling.json"
-  OCSP_SERVER_TYPE="valid"
-  URI_OPTIONS="tls=true"
-  OCSP_ALGORITHM="rsa"
-else
+if [[ $(uname -s) = "Linux" ]]; then
   ORCHESTRATION_FILE="ecdsa-basic-tls-ocsp-mustStaple.json"
-  OCSP_SERVER_TYPE="valid-delegate"
-  URI_OPTIONS="tls=true"
   OCSP_ALGORITHM="ecdsa"
+else
+  ORCHESTRATION_FILE="rsa-basic-tls-ocsp-disableStapling.json"
+  OCSP_ALGORITHM="rsa"
 fi
+
 export ORCHESTRATION_FILE
-export OCSP_SERVER_TYPE
 export OCSP_ALGORITHM
 
 # Start a MongoDB server with ocsp enabled.
@@ -33,7 +23,7 @@ SSL="ssl" make -C ${DRIVERS_TOOLS} run-server
 pushd $SCRIPT_DIR/../ocsp
 
 # Start the ocsp server.
-bash ./setup.sh
+SERVER_TYPE="valid" bash ./setup.sh
 
 # Connect to the MongoDB server.
 echo "Connecting to server..."

--- a/.evergreen/tests/test-ocsp.sh
+++ b/.evergreen/tests/test-ocsp.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# Test aws setup function for different inputs.
+set -eu
+
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+. $SCRIPT_DIR/../handle-paths.sh
+
+
+if [[ "$(uname -s)" == CYGWIN* ]]; then
+  ORCHESTRATION_FILE="rsa-basic-tls-ocsp-disableStapling.json"
+  SERVER_TYPE="revoked"
+  URI_OPTIONS="tls=true&tlsInsecure=true"
+  OCSP_ALGORITHM="rsa"
+elif [[ $(uname -s) = "Darwin" ]]; then
+  ORCHESTRATION_FILE="rsa-basic-tls-ocsp-disableStapling.json"
+  SERVER_TYPE="valid"
+  URI_OPTIONS="tls=true"
+  OCSP_ALGORITHM="rsa"
+else
+  ORCHESTRATION_FILE="ecdsa-basic-tls-ocsp-mustStaple.json"
+  SERVER_TYPE="valid-delegate"
+  URI_OPTIONS="tls=true"
+  OCSP_ALGORITHM="ecdsa"
+fi
+export ORCHESTRATION_FILE
+export SERVER_TYPE
+export OCSP_ALGORITHM
+
+# Start a MongoDB server with ocsp enabled.
+SSL="ssl" make -C ${DRIVERS_TOOLS} run-server
+
+pushd $SCRIPT_DIR/../ocsp
+
+# Start the ocsp server.
+bash ./setup.sh
+
+# Connect to the MongoDB server.
+echo "Connecting to server..."
+TLS_OPTS=("--tls --tlsCertificateKeyFile \"${DRIVERS_TOOLS}/.evergreen/ocsp/${OCSP_ALGORITHM}/server.pem\"")
+TLS_OPTS+=("--tlsCAFile \"${DRIVERS_TOOLS}/.evergreen/ocsp/${OCSP_ALGORITHM}/ca.pem\"")
+$MONGODB_BINARIES/mongosh "mongodb://localhost:27017/&${URI_OPTIONS}" "${TLS_OPTS[@]}" --eval "db.runCommand({\"ping\":1})"
+echo "Connecting to server... done."
+
+bash ./teardown.sh
+
+popd
+
+make -C ${DRIVERS_TOOLS} stop-server
+make -C ${DRIVERS_TOOLS} test

--- a/.evergreen/tests/test-ocsp.sh
+++ b/.evergreen/tests/test-ocsp.sh
@@ -32,8 +32,9 @@ bash ./setup.sh
 echo "Connecting to server..."
 TLS_OPTS=("--tls --tlsCertificateKeyFile \"${DRIVERS_TOOLS}/.evergreen/ocsp/${OCSP_ALGORITHM}/server.pem\"")
 TLS_OPTS+=("--tlsCAFile \"${DRIVERS_TOOLS}/.evergreen/ocsp/${OCSP_ALGORITHM}/ca.pem\"")
+URI="mongodb://localhost/?serverSelectionTimeoutMS=10000"
 # shellcheck disable=SC2068
-$MONGODB_BINARIES/mongosh ${TLS_OPTS[@]} --eval "db.runCommand({\"ping\":1})"
+$MONGODB_BINARIES/mongosh $URI ${TLS_OPTS[@]} --eval "db.runCommand({\"ping\":1})"
 echo "Connecting to server... done."
 
 bash ./teardown.sh

--- a/.evergreen/tests/test-ocsp.sh
+++ b/.evergreen/tests/test-ocsp.sh
@@ -17,19 +17,20 @@ fi
 export ORCHESTRATION_FILE
 export OCSP_ALGORITHM
 
-# Start a MongoDB server with ocsp enabled.
+# # Start a MongoDB server with ocsp enabled.
 SSL="ssl" make -C ${DRIVERS_TOOLS} run-server
 
 pushd $SCRIPT_DIR/../ocsp
 
-# Start the ocsp server.
+# # Start the ocsp server.
 SERVER_TYPE="valid" bash ./setup.sh
 
 # Connect to the MongoDB server.
 echo "Connecting to server..."
 TLS_OPTS=("--tls --tlsCertificateKeyFile \"${DRIVERS_TOOLS}/.evergreen/ocsp/${OCSP_ALGORITHM}/server.pem\"")
 TLS_OPTS+=("--tlsCAFile \"${DRIVERS_TOOLS}/.evergreen/ocsp/${OCSP_ALGORITHM}/ca.pem\"")
-$MONGODB_BINARIES/mongosh "mongodb://localhost:27017" "${TLS_OPTS[@]}" --eval "db.runCommand({\"ping\":1})"
+URI="mongodb://localhost:27017/&serverSelectionTimeoutMS=20000"
+$MONGODB_BINARIES/mongosh $URI "${TLS_OPTS[@]}" --eval "db.runCommand({\"ping\":1})"
 echo "Connecting to server... done."
 
 bash ./teardown.sh

--- a/.evergreen/tests/test-ocsp.sh
+++ b/.evergreen/tests/test-ocsp.sh
@@ -29,7 +29,7 @@ SERVER_TYPE="valid" bash ./setup.sh
 echo "Connecting to server..."
 TLS_OPTS=("--tls --tlsCertificateKeyFile \"${DRIVERS_TOOLS}/.evergreen/ocsp/${OCSP_ALGORITHM}/server.pem\"")
 TLS_OPTS+=("--tlsCAFile \"${DRIVERS_TOOLS}/.evergreen/ocsp/${OCSP_ALGORITHM}/ca.pem\"")
-$MONGODB_BINARIES/mongosh "mongodb://localhost:27017/&${URI_OPTIONS}" "${TLS_OPTS[@]}" --eval "db.runCommand({\"ping\":1})"
+$MONGODB_BINARIES/mongosh "mongodb://localhost:27017" "${TLS_OPTS[@]}" --eval "db.runCommand({\"ping\":1})"
 echo "Connecting to server... done."
 
 bash ./teardown.sh


### PR DESCRIPTION
Tested with https://github.com/mongodb/mongo-python-driver/pull/2190: https://spruce.mongodb.com/version/67cc94d4b26dff000739c152/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

and the C driver: https://spruce.mongodb.com/version/67ced2d64d80c40007a73649/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

Uses `waitress` to create a production flask server that can be run as a daemon on all platforms.
Adds tests for OCSP server on Mac, Windows, and RHEL.
