### PR TITLE
JAVA-5811: Quote MONGODB_URI variable.

### DIFF
--- a/.evergreen/auth_aws/aws_tester.py
+++ b/.evergreen/auth_aws/aws_tester.py
@@ -258,7 +258,7 @@ def handle_creds(creds: dict):
             if key in ["USER", "PASS", "SESSION_TOKEN"]:
                 value = quote_plus(value)  # noqa: PLW2901
             fid.write(f"export {key}={value}\n")
-        fid.write(f"export MONGODB_URI=\"{MONGODB_URI}\"\n")
+        fid.write(f'export MONGODB_URI="{MONGODB_URI}"\n')
 
 
 def main():

--- a/.evergreen/auth_aws/aws_tester.py
+++ b/.evergreen/auth_aws/aws_tester.py
@@ -258,7 +258,7 @@ def handle_creds(creds: dict):
             if key in ["USER", "PASS", "SESSION_TOKEN"]:
                 value = quote_plus(value)  # noqa: PLW2901
             fid.write(f"export {key}={value}\n")
-        fid.write(f"export MONGODB_URI={MONGODB_URI}\n")
+        fid.write(f"export MONGODB_URI=\"{MONGODB_URI}\"\n")
 
 
 def main():


### PR DESCRIPTION
Related to #622

The Java drivers aws assume role test started failing. It turns out that as `&` has special meaning in the shell the `MONGODB_URI` needed to be quoted, so it can be exported.

Patch: https://spruce.mongodb.com/version/67cee1a70374ea0007bcf0d1/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC


