### PR TITLE
User newer oscrypto to fix detection of later OpenSSL versions

### DIFF
--- a/.evergreen/ocsp/mock-ocsp-responder-requirements.txt
+++ b/.evergreen/ocsp/mock-ocsp-responder-requirements.txt
@@ -4,6 +4,7 @@ flask==2.2.5
 itsdangerous==2.1.2
 Jinja2==3.1.6
 MarkupSafe==2.1.4
-oscrypto==1.3.0
+# Necessary fix for newer OpenSSL versions (see: https://github.com/wbond/oscrypto/issues/78)
+git+https://github.com/wbond/oscrypto.git@d5f3437
 waitress==3.0.2
 Werkzeug==3.0.6


### PR DESCRIPTION
This was previously added in https://github.com/mongodb-labs/drivers-evergreen-tools/pull/452 but inadvertently reverted in https://github.com/mongodb-labs/drivers-evergreen-tools/pull/626