### PR TITLE
PYTHON-5196 Use consistent secrets file name in oidc tests

### DIFF
--- a/.evergreen/auth_oidc/azure/remote-scripts/run-self-test.sh
+++ b/.evergreen/auth_oidc/azure/remote-scripts/run-self-test.sh
@@ -3,6 +3,9 @@ set -o errexit
 set -o pipefail
 
 source env.sh
+# Copy the env.sh file to secrets-export.sh, but leave env.sh
+# for backwards compatibility.
+cp env.sh secrets-export.sh
 pushd ./drivers-evergreen-tools/.evergreen/auth_oidc
 . ./activate-authoidcvenv.sh
 


### PR DESCRIPTION
Passing build: https://spruce.mongodb.com/task/mongo_python_driver_auth_oidc_ubuntu_22_test_auth_oidc_azure_patch_a548f7a3d45f8827e88e8f2c060ffb1045e5883e_67d1d4965ed4c20007970cf8_25_03_12_18_38_24/logs?execution=0&sortBy=STATUS&sortDir=ASC