### PR TITLE
PYTHON-5217 Add helper scripts and test for atlas data lake

### DIFF
--- a/.evergreen/atlas_data_lake/pull-mongohouse-image.sh
+++ b/.evergreen/atlas_data_lake/pull-mongohouse-image.sh
@@ -8,7 +8,9 @@ SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
 . $SCRIPT_DIR/../handle-paths.sh
 pushd $SCRIPT_DIR
 REPO="904697982180.dkr.ecr.us-east-1.amazonaws.com/atlas-query-engine-test"
-. ../secrets_handling/setup-secrets.sh drivers/adl
+if [ ! -f secrets-export.sh ]; then
+  . ../secrets_handling/setup-secrets.sh drivers/adl
+fi
 source secrets-export.sh
 unset AWS_SESSION_TOKEN
 aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $REPO

--- a/.evergreen/atlas_data_lake/run-mongohouse-image.sh
+++ b/.evergreen/atlas_data_lake/run-mongohouse-image.sh
@@ -11,4 +11,9 @@ SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
 IMAGE=904697982180.dkr.ecr.us-east-1.amazonaws.com/atlas-query-engine-test
 USE_TTY=""
 test -t 1 && USE_TTY="-t"
-docker run -d -p 27017:27017 -v "$DRIVERS_TOOLS/.evergreen/atlas_data_lake:/src" -i $USE_TTY $IMAGE --config ./testdata/config/external/drivers/config.yaml
+if command -v podman &> /dev/null; then
+    DOCKER="podman --storage-opt ignore_chown_errors=true"
+else
+    DOCKER=docker
+fi
+$DOCKER run -d -p 27017:27017 --platform linux/amd64 --name atlas-data-lake -v "$DRIVERS_TOOLS/.evergreen/atlas_data_lake:/src" -i $USE_TTY $IMAGE --config ./testdata/config/external/drivers/config.yaml

--- a/.evergreen/atlas_data_lake/setup.sh
+++ b/.evergreen/atlas_data_lake/setup.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#
+# This script sets Atlas Data Lake tests.
+#
+set -eu
+
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+. $SCRIPT_DIR/../handle-paths.sh
+
+bash $SCRIPT_DIR/pull-mongohouse-image.sh
+bash $SCRIPT_DIR/run-mongohouse-image.sh

--- a/.evergreen/atlas_data_lake/teardown.sh
+++ b/.evergreen/atlas_data_lake/teardown.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#
+# This script tears down Atlas Data Lake tests.
+#
+set -eu
+
+if command -v podman &> /dev/null; then
+    DOCKER="podman --storage-opt ignore_chown_errors=true"
+else
+    DOCKER=docker
+fi
+$DOCKER kill atlas-data-lake || true
+$DOCKER rm atlas-data-lake

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1441,14 +1441,6 @@ buildvariants:
   tasks:
     - ".releng" # Run all tasks with the "releng" tag
 
-# Tests relating to docker images
-- name: tests-docker
-  display_name: Docker
-  run_on:
-    - ubuntu2204-small
-  tasks:
-    - ".docker"  # Run all tasks with the "docker" tag
-
 - name: tests-misc
   display_name: Other tests
   run_on:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1056,7 +1056,7 @@ tasks:
         - func: "run cli test full"
 
     - name: "test-ocsp"
-      tags: ["ocsp"]
+      tags: ["pr", "ocsp"]
       commands:
         - func: "run ocsp test"
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -520,6 +520,14 @@ functions:
         include_expansions_in_env: [AWS_SECRET_ACCESS_KEY, AWS_ACCESS_KEY_ID, AWS_SESSION_TOKEN]
         args: [src/.evergreen/tests/test-aws.sh]
 
+  "run data lake test":
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: bash
+        include_expansions_in_env: [AWS_SECRET_ACCESS_KEY, AWS_ACCESS_KEY_ID, AWS_SESSION_TOKEN]
+        args: [src/.evergreen/tests/test-data-lake.sh]
+
   "run csfle test":
     - command: ec2.assume_role
       params:
@@ -1037,12 +1045,18 @@ tasks:
       commands:
         - func: "run aws test"
 
+    - name: "test-atlas-data-lake"
+      tags: ["pr", "data_lake"]
+      commands:
+        - func: "run data lake test"
+
     - name: "test-cli-full"
       tags: ["pr"]
       commands:
         - func: "run cli test full"
 
     - name: "test-ocsp"
+      tags: ["ocsp"]
       commands:
         - func: "run ocsp test"
 
@@ -1435,12 +1449,15 @@ buildvariants:
   tasks:
     - ".docker"  # Run all tasks with the "docker" tag
 
-- name: tests-aws
-  display_name: Auth AWS
+- name: tests-misc
+  display_name: Other tests
   run_on:
     - ubuntu2204-small
   tasks:
     - ".aws"
+    - ".data_lake"
+    - ".ocsp"
+    - ".docker"
 
 - name: tests-oidc
   display_name: Auth OIDC

--- a/.evergreen/docker/run-server.sh
+++ b/.evergreen/docker/run-server.sh
@@ -31,7 +31,9 @@ fi
 pushd $DRIVERS_TOOLS
 cp .gitignore .dockerignore
 USER="--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)"
-$DOCKER build $PLATFORM -t $NAME -f $SCRIPT_DIR/$IMAGE/Dockerfile $USER .
+ARGS="$PLATFORM -t $NAME -f $SCRIPT_DIR/$IMAGE/Dockerfile $USER ."
+# Allow a single failure due to transient issues with apt-get.
+$DOCKER build $ARGS || $DOCKER build $ARGS
 popd
 
 # Handle environment variables.

--- a/.evergreen/test-results.json
+++ b/.evergreen/test-results.json
@@ -1,1 +1,0 @@
-{"results": [{ "status": "FAIL", "test_file": "Build", "log_raw": "No test-results.json found was created"  } ]}

--- a/.evergreen/test-results.json
+++ b/.evergreen/test-results.json
@@ -1,0 +1,1 @@
+{"results": [{ "status": "FAIL", "test_file": "Build", "log_raw": "No test-results.json found was created"  } ]}

--- a/.evergreen/tests/test-data-lake.sh
+++ b/.evergreen/tests/test-data-lake.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Test aws setup function for different inputs.
+set -eu
+
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+. $SCRIPT_DIR/../handle-paths.sh
+
+pushd $SCRIPT_DIR/..
+DOWNLOAD_DIR=dl_test
+bash install-cli.sh .
+export PATH="${DOWNLOAD_DIR}/bin:$PATH"
+./mongosh-dl --version 2.1.1 --out ${DOWNLOAD_DIR} --strip-path-components 1 --retries 5
+popd
+
+bash $SCRIPT_DIR/../setup.sh
+
+pushd $SCRIPT_DIR/../atlas_data_lake
+
+bash ./setup.sh
+source secrets-export.sh
+mongosh "mongodb://$ADL_USERNAME:$ADL_PASSWORD@localhost:27017" --eval "db.runCommand({\"ping\":1})"
+bash ./teardown.sh
+
+popd
+
+rm -rf $SCRIPT_DIR/../$DOWNLOAD_DIR
+
+make -C ${DRIVERS_TOOLS} test

--- a/.evergreen/tests/test-data-lake.sh
+++ b/.evergreen/tests/test-data-lake.sh
@@ -11,6 +11,10 @@ DOWNLOAD_DIR=dl_test
 bash install-cli.sh .
 export PATH="${DOWNLOAD_DIR}/bin:$PATH"
 ./mongosh-dl --version 2.1.1 --out ${DOWNLOAD_DIR} --strip-path-components 1 --retries 5
+set -x
+echo "PATH: $PATH"
+ls $DOWNLOAD_DIR
+exit 1
 popd
 
 bash $SCRIPT_DIR/../setup.sh

--- a/.evergreen/tests/test-data-lake.sh
+++ b/.evergreen/tests/test-data-lake.sh
@@ -11,7 +11,9 @@ DOWNLOAD_DIR=dl_test
 bash install-cli.sh .
 export PATH="${DOWNLOAD_DIR}/bin:$PATH"
 ./mongosh-dl --version 2.1.1 --out ${DOWNLOAD_DIR}/bin --strip-path-components 2 --retries 5
-
+set -x
+ls ${DOWNLOAD_DIR}
+ls ${DOWNLOAD_DIR}/bin
 popd
 
 bash $SCRIPT_DIR/../setup.sh

--- a/.evergreen/tests/test-data-lake.sh
+++ b/.evergreen/tests/test-data-lake.sh
@@ -7,28 +7,18 @@ SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
 . $SCRIPT_DIR/../handle-paths.sh
 
 pushd $SCRIPT_DIR/..
-DOWNLOAD_DIR=dl_test
+DOWNLOAD_DIR=$SCRIPT_DIR/dl_test
 bash install-cli.sh .
-export PATH="${DOWNLOAD_DIR}/bin:$PATH"
 ./mongosh-dl --version 2.1.1 --out ${DOWNLOAD_DIR}/bin --strip-path-components 2 --retries 5
-set -x
-ls -ltr ${DOWNLOAD_DIR}
-ls -ltr ${DOWNLOAD_DIR}/bin
-which mongosh
-exit 1
 popd
-
-bash $SCRIPT_DIR/../setup.sh
 
 pushd $SCRIPT_DIR/../atlas_data_lake
-
 bash ./setup.sh
 source secrets-export.sh
-mongosh "mongodb://$ADL_USERNAME:$ADL_PASSWORD@localhost:27017" --eval "db.runCommand({\"ping\":1})"
+${DOWNLOAD_DIR}/bin/mongosh "mongodb://$ADL_USERNAME:$ADL_PASSWORD@localhost:27017" --eval "db.runCommand({\"ping\":1})"
 bash ./teardown.sh
-
 popd
 
-rm -rf $SCRIPT_DIR/../$DOWNLOAD_DIR
+rm -rf "${SCRIPT_DIR:?}/${DOWNLOAD_DIR}"
 
 make -C ${DRIVERS_TOOLS} test

--- a/.evergreen/tests/test-data-lake.sh
+++ b/.evergreen/tests/test-data-lake.sh
@@ -10,7 +10,7 @@ pushd $SCRIPT_DIR/..
 DOWNLOAD_DIR=dl_test
 bash install-cli.sh .
 export PATH="${DOWNLOAD_DIR}/bin:$PATH"
-./mongosh-dl --version 2.1.1 --out ${DOWNLOAD_DIR} --strip-path-components 2 --retries 5
+./mongosh-dl --version 2.1.1 --out ${DOWNLOAD_DIR}/bin --strip-path-components 2 --retries 5
 
 popd
 

--- a/.evergreen/tests/test-data-lake.sh
+++ b/.evergreen/tests/test-data-lake.sh
@@ -10,11 +10,8 @@ pushd $SCRIPT_DIR/..
 DOWNLOAD_DIR=dl_test
 bash install-cli.sh .
 export PATH="${DOWNLOAD_DIR}/bin:$PATH"
-./mongosh-dl --version 2.1.1 --out ${DOWNLOAD_DIR} --strip-path-components 1 --retries 5
-set -x
-echo "PATH: $PATH"
-ls $DOWNLOAD_DIR
-exit 1
+./mongosh-dl --version 2.1.1 --out ${DOWNLOAD_DIR} --strip-path-components 2 --retries 5
+
 popd
 
 bash $SCRIPT_DIR/../setup.sh

--- a/.evergreen/tests/test-data-lake.sh
+++ b/.evergreen/tests/test-data-lake.sh
@@ -12,8 +12,10 @@ bash install-cli.sh .
 export PATH="${DOWNLOAD_DIR}/bin:$PATH"
 ./mongosh-dl --version 2.1.1 --out ${DOWNLOAD_DIR}/bin --strip-path-components 2 --retries 5
 set -x
-ls ${DOWNLOAD_DIR}
-ls ${DOWNLOAD_DIR}/bin
+ls -ltr ${DOWNLOAD_DIR}
+ls -ltr ${DOWNLOAD_DIR}/bin
+which mongosh
+exit 1
 popd
 
 bash $SCRIPT_DIR/../setup.sh

--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,7 @@ test-env.sh
 # Temporary files created during operation.
 /uri.txt
 /results.json
+/test-results.json
 /mongodb
 node_index.tab
 mongodb-binaries.tgz


### PR DESCRIPTION
Tested with https://github.com/mongodb/mongo-python-driver/pull/2209.  Passing build: https://spruce.mongodb.com/version/67d98f6b606c1f0007fa2ec1/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC