### PR TITLE
DRIVERS-3032 Fix handling of python used by UV

### DIFF
--- a/.evergreen/install-cli.sh
+++ b/.evergreen/install-cli.sh
@@ -41,6 +41,20 @@ if ! command -v uv >/dev/null; then
   esac
 fi
 
+if [ -z "${UV_PYTHON:-}" ]; then
+   . ./find-python3.sh
+
+  echo "Ensuring python binary..."
+  UV_PYTHON="$(ensure_python3 2>/dev/null)"
+  if [ -z "${UV_PYTHON}" ]; then
+    # For debug purposes
+    find_python3
+    exit 1
+  fi
+  echo "Ensuring python binary... done."
+fi
+export UV_PYTHON
+
 if command -V uv 2>/dev/null; then
   # Ensure there is a venv available for backward compatibility.
   uv venv venv
@@ -50,20 +64,8 @@ else
 
   # Create and activate `venv` via `venvcreate` or `venvactivate`.
   if [ ! -d "$SCRIPT_DIR/venv" ]; then
-
-    . ./find-python3.sh
-
-    echo "Ensuring python binary..."
-    PYTHON="$(ensure_python3 2>/dev/null)"
-    if [ -z "${PYTHON}" ]; then
-      # For debug purposes
-      find_python3
-      exit 1
-    fi
-    echo "Ensuring python binary... done."
-
     echo "Creating virtual environment 'venv'..."
-    venvcreate "${PYTHON:?}" venv
+    venvcreate "${UV_PYTHON:?}" venv
     echo "Creating virtual environment 'venv'... done."
   else
     venvactivate venv
@@ -77,12 +79,6 @@ else
 fi
 
 [[ -d venv ]] # venv should exist by this point.
-
-# Store paths to binaries for use outside of current working directory.
-echo "UV_PYTHON=$UV_PYTHON"
-python_binary="$(uv run --no-project python -c 'import sys;print(sys.executable)')"
-echo "OKAY=${python_binary}"
-exit 1
 
 pushd "$TARGET_DIR" > /dev/null
 
@@ -104,7 +100,7 @@ if [ "Windows_NT" == "${OS:-}" ]; then
   done
   rm -rf $TMP_DIR
 else
-  UV_TOOL_BIN_DIR=$(pwd) uv tool install -q ${EXTRA_ARGS} --python "${python_binary}" --with certifi --force --editable .
+  UV_TOOL_BIN_DIR=$(pwd) uv tool install -q ${EXTRA_ARGS} --with certifi --force --editable .
 fi
 
 popd > /dev/null

--- a/.evergreen/install-cli.sh
+++ b/.evergreen/install-cli.sh
@@ -41,6 +41,7 @@ if ! command -v uv >/dev/null; then
   esac
 fi
 
+# Only ensure a Python binary when not already specified for uv.
 if [ -z "${UV_PYTHON:-}" ]; then
    . ./find-python3.sh
 

--- a/.evergreen/install-cli.sh
+++ b/.evergreen/install-cli.sh
@@ -79,6 +79,8 @@ fi
 [[ -d venv ]] # venv should exist by this point.
 
 # Store paths to binaries for use outside of current working directory.
+echo "UV_PYTHON=$UV_PYTHON"
+exit 1
 python_binary="$(uv run --no-project python -c 'import sys;print(sys.executable)')"
 
 pushd "$TARGET_DIR" > /dev/null

--- a/.evergreen/install-cli.sh
+++ b/.evergreen/install-cli.sh
@@ -80,8 +80,9 @@ fi
 
 # Store paths to binaries for use outside of current working directory.
 echo "UV_PYTHON=$UV_PYTHON"
-exit 1
 python_binary="$(uv run --no-project python -c 'import sys;print(sys.executable)')"
+echo "OKAY=${python_binary}"
+exit 1
 
 pushd "$TARGET_DIR" > /dev/null
 

--- a/.evergreen/run-orchestration.sh
+++ b/.evergreen/run-orchestration.sh
@@ -28,9 +28,5 @@ set -eu
 SCRIPT_DIR=$(dirname ${BASH_SOURCE:-$0})
 . $SCRIPT_DIR/handle-paths.sh
 
-echo "HELLO: $UV_PYTHON"
-exit 1
 bash $SCRIPT_DIR/orchestration/setup.sh
-echo "HELLO: $UV_PYTHON"
-exit 1
 $SCRIPT_DIR/orchestration/drivers-orchestration run "$@"

--- a/.evergreen/run-orchestration.sh
+++ b/.evergreen/run-orchestration.sh
@@ -29,4 +29,6 @@ SCRIPT_DIR=$(dirname ${BASH_SOURCE:-$0})
 . $SCRIPT_DIR/handle-paths.sh
 
 bash $SCRIPT_DIR/orchestration/setup.sh
+echo "HELLO: $UV_PYTHON"
+exit 1
 $SCRIPT_DIR/orchestration/drivers-orchestration run "$@"

--- a/.evergreen/run-orchestration.sh
+++ b/.evergreen/run-orchestration.sh
@@ -28,6 +28,8 @@ set -eu
 SCRIPT_DIR=$(dirname ${BASH_SOURCE:-$0})
 . $SCRIPT_DIR/handle-paths.sh
 
+echo "HELLO: $UV_PYTHON"
+exit 1
 bash $SCRIPT_DIR/orchestration/setup.sh
 echo "HELLO: $UV_PYTHON"
 exit 1

--- a/.evergreen/setup.sh
+++ b/.evergreen/setup.sh
@@ -30,6 +30,7 @@ EOF
 # Set the python binary to use.
 DRIVERS_TOOLS_PYTHON="$(ensure_python3 2>/dev/null)"
 echo "DRIVERS_TOOLS_PYTHON=$DRIVERS_TOOLS_PYTHON" >> $DRIVERS_TOOLS/.env
+echo "UV_PYTHON=$DRIVERS_TOOLS_PYTHON" >> $DRIVERS_TOOLS/.env
 
 # Install the clis in this folder.
 bash $SCRIPT_DIR/install-cli.sh $SCRIPT_DIR


### PR DESCRIPTION
Set `UV_PYTHON` to ensure proper handling of python version used by uv.

Python build: https://spruce.mongodb.com/version/67df43c9d002970007b1e750/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC
C driver build: https://spruce.mongodb.com/version/67e16af4593ae00007d7bc52/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC
Python build for Amazon2 tests: https://spruce.mongodb.com/version/67e175f5d6d198000775282e/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC (4.0 failures are expected, I should have only scheduled 4.2-7.0).

Failing build: https://spruce.mongodb.com/task/mongo_python_driver_test_amazon2_python3.10_test_4.0_replica_set_noauth_ssl_sync_async_patch_1145c9de543bb5748a61dbf338385ff2ff6330c6_67e02ff8212e8700072c416d_25_03_23_16_00_10?execution=0&sortBy=STATUS&sortDir=ASC

Traceback:

```
[2025/03/23 11:01:51.065] uv is /data/mci/c81d9a3237da94f562a46ef7f29086a7/drivers-tools/.bin/uv
[2025/03/23 11:01:53.590] Downloading cpython-3.13.2-linux-aarch64-gnu (16.8MiB)
[2025/03/23 11:01:53.726]  Downloaded cpython-3.13.2-linux-aarch64-gnu
[2025/03/23 11:01:53.726] Using CPython 3.13.2
[2025/03/23 11:01:53.769] Creating virtual environment at: venv
[2025/03/23 11:01:53.769] Activate with: source venv/bin/activate
[2025/03/23 11:01:53.769] error: Querying Python at `/data/mci/c81d9a3237da94f562a46ef7f29086a7/drivers-tools/.local/uv-tool/drivers-orchestration/bin/python3` failed with exit status exit status: 1
[2025/03/23 11:01:53.769] [stderr]
[2025/03/23 11:01:53.769] Could not find platform independent libraries <prefix>
[2025/03/23 11:01:53.769] Could not find platform dependent libraries <exec_prefix>
[2025/03/23 11:01:53.769] Fatal Python error: Failed to import encodings module
[2025/03/23 11:01:53.769] Python runtime state: core initialized
[2025/03/23 11:01:53.769] ModuleNotFoundError: No module named 'encodings'
[2025/03/23 11:01:53.769] Current thread 0x0000ffffa3e96010 (most recent call first):
[2025/03/23 11:01:53.769]   <no Python frame>
[2025/03/23 11:01:53.770] ERROR    None
[2025/03/23 11:01:53.770] ERROR    Command '['bash', '/data/mci/c81d9a3237da94f562a46ef7f29086a7/drivers-tools/.evergreen/run-orchestration.sh', '--ssl']' returned non-zero exit status 2.
[2025/03/23 11:01:53.782] error: Recipe `run-server` failed on line 77 with exit code 2
[2025/03/23 11:01:53.782] Command 'subprocess.exec' in function 'run server' (step 1.1 of 2) failed: process encountered problem: exit code 2.
```

