### PR TITLE
DRIVERS-3141 Fix handling of OIDC teardown on Linux hosts

### DIFF
--- a/.evergreen/auth_oidc/teardown.sh
+++ b/.evergreen/auth_oidc/teardown.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -o errexit
+set -eu
 
 SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
 . $SCRIPT_DIR/../handle-paths.sh
@@ -13,6 +13,10 @@ export DRIVERS_ATLAS_PUBLIC_API_KEY=$OIDC_ATLAS_PUBLIC_API_KEY
 export DRIVERS_ATLAS_PRIVATE_API_KEY=$OIDC_ATLAS_PRIVATE_API_KEY
 export DRIVERS_ATLAS_GROUP_ID=$OIDC_ATLAS_GROUP_ID
 
-bash ../atlas/teardown-atlas-cluster.sh
+if [ -n "${OIDC_IS_LOCAL:-}" ]; then
+  echo "No teardown required!"
+else
+  bash ../atlas/teardown-atlas-cluster.sh
+fi
 
 popd


### PR DESCRIPTION
Passing build in PyMongo: https://spruce.mongodb.com/version/67e2eeab7f515f00071ef695/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

MacOS: 

```
[2025/03/25 13:13:53.003] Deleting Atlas Cluster...
[2025/03/25 13:13:53.003] {}
[2025/03/25 13:13:53.003] Deleting Atlas Cluster... done.
```

Windows:

```
[2025/03/25 13:13:10.078] Deleting Atlas Cluster...
[2025/03/25 13:13:10.078] {}
[2025/03/25 13:13:10.078] Deleting Atlas Cluster... done.
```

Ubuntu:

```
[2025/03/25 13:01:25.925] No teardown required!
```