### PR TITLE
DRIVERS-3111 Use atlas-qa by default

### DIFF
--- a/.evergreen/atlas/README.md
+++ b/.evergreen/atlas/README.md
@@ -5,7 +5,7 @@ The scripts in this folder are used to setup and teardown Atlas clusters.
 ## Prerequisites
 
 See [Secrets Handling](../secrets_handling/README.md) for details on how to access the secrets
-from the `drivers/atlas-dev` or `drivers/atlas` vault.
+from the `drivers/atlas-qa`, `drivers/atlas-dev` or `drivers/atlas` vault.
 
 ## Usage
 
@@ -48,5 +48,5 @@ An example task group running on a Linux EVG host might look like:
 If other OSes are needed, use the `setup-secrets.sh` script in this directory with the full `ec2.assume_role`
 method described in [Secrets Handling](../secrets_handling/README.md).
 
-By default, it will use the `drivers/atlas-dev` credentials for Cloud Dev.  You can pass `atlas` to
-either `setup-secrets.sh` or `setup.sh` to use a Prod environment instead.
+By default, it will use the `drivers/atlas-qa` credentials for Cloud QA.  You can pass `atlas` or `atlas-dev` to
+either `setup-secrets.sh` or `setup.sh` to use a Prod or Dev environment instead.

--- a/.evergreen/atlas/atlas-utils.sh
+++ b/.evergreen/atlas/atlas-utils.sh
@@ -28,6 +28,7 @@ create_deployment ()
   ATLAS_BASE_URL=${ATLAS_BASE_URL:-"https://account-dev.mongodb.com/api/atlas/v1.0"}
   TYPE=${DEPLOYMENT_TYPE:-"clusters"}
   echo "Creating new Atlas Deployment in Group $ATLAS_GROUP_ID..." 1>&2
+  echo "Using Atlas base url: $ATLAS_BASE_URL" 1>&2
   RESP=$(curl -sS -L \
     --digest -u "${ATLAS_PUBLIC_API_KEY}:${ATLAS_PRIVATE_API_KEY}" \
     -d "${DEPLOYMENT_DATA}" \

--- a/.evergreen/atlas/setup-secrets.sh
+++ b/.evergreen/atlas/setup-secrets.sh
@@ -5,6 +5,6 @@ set -eu
 SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
 . $SCRIPT_DIR/../handle-paths.sh
 pushd $SCRIPT_DIR
-VAULT_NAME="${1:-atlas-dev}"
+VAULT_NAME="${1:-atlas-qa}"
 . $SCRIPT_DIR/../secrets_handling/setup-secrets.sh drivers/$VAULT_NAME
 popd

--- a/.evergreen/aws_lambda/README.md
+++ b/.evergreen/aws_lambda/README.md
@@ -3,4 +3,4 @@
 See the [FaaS Automated Testing specification](https://github.com/mongodb/specifications/blob/master/source/faas-automated-testing/faas-automated-testing.rst) for details.
 
 See [Secrets Handling README](../secrets-handling/README.md) for details on how to access the secrets
-from the `drivers/atlas-dev` vault.
+from the `drivers/atlas-qa` vault.

--- a/.evergreen/secrets_handling/README.md
+++ b/.evergreen/secrets_handling/README.md
@@ -17,6 +17,7 @@ The `setup-secrets.sh` script in this folder can be used for other vaults such a
 | drivers/adl               | Used in [`atlas_data_lake`](../atlas_data_lake/README.md) for Atlas Data Lake testing. |
 | drivers/atlas             | Can be manually used in conjunction with [`atlas`](../atlas/README.md) to launch an atlas cluster in the prod environment. |
 | drivers/atlas-dev         | Used in [`atlas`](../atlas/README.md) to launch an atlas cluster in the dev environment. |
+| drivers/atlas-qa         | Used in [`atlas`](../atlas/README.md) to launch an atlas cluster in the qa environment. |
 | drivers/atlas_connect     | Has the URIs used in the Atlas Connect Drivers tests. |
 | drivers/aws_auth          | Used in [`auth_aws`](../auth_aws/README.md)  for AWS Auth testing. |
 | drives/azurekms           | Used in [`csfle/azurekms`](../csfle/azurekms/README.md) for Azure KMS testing. |


### PR DESCRIPTION
Passing build: https://spruce.mongodb.com/version/67e55a9f4f2ca00007d66b63/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

"Using Atlas base url: https://cloud-qa.mongodb.com/api/atlas/v1.0"

This does not affect serverless builds, which still use `atlas-dev`:

"Using Atlas base url: https://account-dev.mongodb.com/api/atlas/v1.0"