### PR TITLE
filter out mongosh draft releases when determining latest

### DIFF
--- a/.evergreen/mongosh_dl.py
+++ b/.evergreen/mongosh_dl.py
@@ -50,6 +50,8 @@ def _get_latest_version():
     for item in data:
         if item["prerelease"]:
             continue
+        if "draft" in item and item["draft"]:
+            continue
         return item["tag_name"].replace("v", "").strip()
 
 

--- a/.evergreen/mongosh_dl.py
+++ b/.evergreen/mongosh_dl.py
@@ -50,7 +50,7 @@ def _get_latest_version():
     for item in data:
         if item["prerelease"]:
             continue
-        if "draft" in item and item["draft"]:
+        if item.get("draft"):
             continue
         return item["tag_name"].replace("v", "").strip()
 


### PR DESCRIPTION
https://mongodb.slack.com/archives/CUHC9R8J0/p1744138986132869

https://spruce.mongodb.com/task/mongo_node_driver_next_macos_14_arm64_test_rapid_server_46cb56def4cc3b87c8430af24b73aeb8386f9ea0_25_04_08_16_20_47/logs?execution=0&sortBy=STATUS&sortDir=ASC

A perhaps super transient problem, mongosh temporarily had a 2.5.0 release before needing to reset to fix an issue with the release process. Our CI task was lucky enough to fetch that version number as latest but find no corresponding zip to download. We suspect this could be avoided if we also filtered for draft releases but I'm not sure if that information would be included in the response so I check for the presence of the key first.

https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#list-releases

> Information about published releases are available to everyone. Only users with push access will receive listings for draft releases.

Is there any auth inherited from the environment? 

It is also possible this fell through to the git tag version detection, which would also result in the missing zip download. 

This isn't urgent or causing a problem (since the 2.5.0 release has been reverted). Curious what others think about how we can better stablize the download here? 