### PR TITLE
DRIVERS-3055 Fix docker teardown

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -345,6 +345,12 @@ functions:
           ENTRYPOINT: /root/test-entrypoint.sh
         args:
           - ${DRIVERS_TOOLS}/.evergreen/docker/run-server.sh
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: bash
+        args:
+          - ${DRIVERS_TOOLS}/.evergreen/docker/teardown.sh
     - command: shell.exec
       type: test
       params:

--- a/.evergreen/docker/teardown.sh
+++ b/.evergreen/docker/teardown.sh
@@ -21,7 +21,7 @@ fi
 $DOCKER rm "$($DOCKER ps -a -q)" &> /dev/null || true
 
 # Remove all images.
-$DOCKER rmi -f "$($DOCKER -a -q)" &> /dev/null || true
+$DOCKER rmi -f "$($DOCKER images -a -q)" &> /dev/null || true
 
 # Remove all generated files in this subfolder.
 pushd $SCRIPT_DIR > /dev/null


### PR DESCRIPTION
Addresses the error seen during teardown: `unknown shorthand flag: 'a' in -a`.