### PR TITLE
DRIVERS-3032 Clean up handling of CLIs

### DIFF
--- a/.evergreen/install-cli.sh
+++ b/.evergreen/install-cli.sh
@@ -43,7 +43,7 @@ if [ "${DOCKER_RUNNING:-}" == "true" ]; then
 fi
 
 # If uv is not on path, try see if it is available from the Python toolchain.
-if ! command -v uv 1>&2>/dev/null; then
+if ! command -v uv &>/dev/null; then
   export PATH
   case "${OSTYPE:?}" in
   cygwin)
@@ -59,14 +59,15 @@ if ! command -v uv 1>&2>/dev/null; then
 fi
 
 # If there is still no uv, we will install it to $DRIVERS_TOOLS/.bin.
-if ! command -V uv 1>&2>/dev/null; then
+if ! command -V uv &>/dev/null; then
+  . ./venv-utils.sh
   _venv_dir=$(mktemp -d)
   if [ "Windows_NT" = "${OS:-}" ]; then
     _venv_dir=$(cygpath -m $_venv_dir)
   fi
   _install_dir=${DRIVERS_TOOLS}/.bin
   echo "Installing uv using pip..."
-  createvirtualenv "$DRIVERS_TOOLS_PYTHON" $_venv_dir
+  venvcreate "$DRIVERS_TOOLS_PYTHON" $_venv_dir
   # Install uv into the newly created venv.
   UV_UNMANAGED_INSTALL=1 python -m pip install -q --force-reinstall uv
   _suffix=""
@@ -81,7 +82,7 @@ if ! command -V uv 1>&2>/dev/null; then
 fi
 
 # uv should be on the path at this point.
-if ! command -V uv 1>&2>/dev/null; then
+if ! command -V uv &>dev/null; then
   echo "Could not install uv!"
   exit 1
 fi

--- a/.evergreen/install-cli.sh
+++ b/.evergreen/install-cli.sh
@@ -108,7 +108,7 @@ fi
 if [ "Windows_NT" == "${OS:-}" ]; then
   TMP_DIR=$(cygpath -m "$(mktemp -d)")
   PATH="$SCRIPT_DIR/venv/Scripts:$PATH"
-  UV_TOOL_BIN_DIR=${TMP_DIR} uv tool install ${EXTRA_ARGS} --with certifi --force --editable .
+  UV_TOOL_BIN_DIR=${TMP_DIR} uv tool install -q ${EXTRA_ARGS} --with certifi --force --editable .
   filenames=$(ls ${TMP_DIR})
   for filename in $filenames; do
     mv $TMP_DIR/$filename "$1/${filename//.exe/}"

--- a/.evergreen/install-cli.sh
+++ b/.evergreen/install-cli.sh
@@ -75,9 +75,11 @@ if ! command -V uv &>/dev/null; then
     _suffix=".exe"
   fi
   # Symlink uv and uvx binaries.
+  mkdir -p $_install_dir
   ln -s "$(which uv)" $_install_dir/uv${_suffix}
   ln -s "$(which uvx)" $_install_dir/uvx${_suffix}
   echo "Installed to ${_install_dir}"
+  deactivate
   echo "Installing uv using pip... done."
 fi
 

--- a/.evergreen/install-cli.sh
+++ b/.evergreen/install-cli.sh
@@ -13,7 +13,7 @@ TARGET_DIR="${1:?"must give a target directory!"}"
 SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
 . $SCRIPT_DIR/handle-paths.sh
 
-pushd $SCRIPT_DIR > /dev/null
+pushd $SCRIPT_DIR >/dev/null
 
 # First ensure we have a python binary.
 if [ -z "${DRIVERS_TOOLS_PYTHON:-}" ]; then
@@ -84,17 +84,17 @@ if ! command -V uv &>/dev/null; then
 fi
 
 # uv should be on the path at this point.
-if ! command -V uv &>dev/null; then
+if ! command -V uv &>/dev/null; then
   echo "Could not install uv!"
   exit 1
 fi
 
 # Ensure there is a venv available in the script dir for backward compatibility.
-uv venv venv 2> /dev/null
+uv venv venv &>/dev/null
 [[ -d venv ]]
 
-popd > /dev/null
-pushd "$TARGET_DIR" > /dev/null
+popd >/dev/null
+pushd "$TARGET_DIR" >/dev/null
 
 # Add support for MongoDB 3.6, which was dropped in pymongo 4.11.
 EXTRA_ARGS=""
@@ -117,4 +117,4 @@ else
   UV_TOOL_BIN_DIR=$(pwd) uv tool install -q ${EXTRA_ARGS} --with certifi --force --editable .
 fi
 
-popd > /dev/null
+popd >/dev/null

--- a/.evergreen/install-cli.sh
+++ b/.evergreen/install-cli.sh
@@ -35,6 +35,7 @@ export UV_PYTHON=$DRIVERS_TOOLS_PYTHON
 # Ensure uv is writing assets to a contained location.
 export UV_CACHE_DIR=${DRIVERS_TOOLS}/.local/uv-cache
 export UV_TOOL_DIR=${DRIVERS_TOOLS}/.local/uv-tool
+export UV_UNMANAGED_INSTALL="1"
 
 if [ "${DOCKER_RUNNING:-}" == "true" ]; then
   _root_dir=$(mktemp -d)
@@ -65,16 +66,16 @@ if ! command -V uv &>/dev/null; then
   if [ "Windows_NT" = "${OS:-}" ]; then
     _venv_dir=$(cygpath -m $_venv_dir)
   fi
-  _install_dir=${DRIVERS_TOOLS}/.bin
   echo "Installing uv using pip..."
   venvcreate "$DRIVERS_TOOLS_PYTHON" $_venv_dir
   # Install uv into the newly created venv.
-  UV_UNMANAGED_INSTALL=1 python -m pip install -q --force-reinstall uv
+  python -m pip install -q --force-reinstall uv
   _suffix=""
   if [ "Windows_NT" = "${OS:-}" ]; then
     _suffix=".exe"
   fi
   # Symlink uv and uvx binaries.
+  _install_dir=${DRIVERS_TOOLS}/.bin
   mkdir -p $_install_dir
   ln -s "$(which uv)" $_install_dir/uv${_suffix}
   ln -s "$(which uvx)" $_install_dir/uvx${_suffix}

--- a/.evergreen/orchestration/setup.sh
+++ b/.evergreen/orchestration/setup.sh
@@ -6,5 +6,6 @@ set -o errexit
 SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
 . $SCRIPT_DIR/../handle-paths.sh
 
-# Install the clis in this folder.
+# Install the clis in this folder and the parent folder.
+bash $SCRIPT_DIR/../install-cli.sh $SCRIPT_DIR/..
 bash $SCRIPT_DIR/../install-cli.sh $SCRIPT_DIR

--- a/.evergreen/run-orchestration.sh
+++ b/.evergreen/run-orchestration.sh
@@ -29,5 +29,7 @@ set -eu
 SCRIPT_DIR=$(dirname ${BASH_SOURCE:-$0})
 . $SCRIPT_DIR/handle-paths.sh
 
+# Ensure the CLIs are up to date.
 bash $SCRIPT_DIR/orchestration/setup.sh
+
 $SCRIPT_DIR/orchestration/drivers-orchestration run "$@"

--- a/.evergreen/setup.sh
+++ b/.evergreen/setup.sh
@@ -30,10 +30,6 @@ EOF
 # Set the python binary to use.
 DRIVERS_TOOLS_PYTHON="$(ensure_python3 2>/dev/null)"
 echo "DRIVERS_TOOLS_PYTHON=$DRIVERS_TOOLS_PYTHON" >> $DRIVERS_TOOLS/.env
-echo "UV_PYTHON=$DRIVERS_TOOLS_PYTHON" >> $DRIVERS_TOOLS/.env
 
-# Install the clis in this folder.
-bash $SCRIPT_DIR/install-cli.sh $SCRIPT_DIR
-
-# Set up the orchestration folder.
+# Set up the orchestration folder, which also installs CLIs in this folder.
 bash $SCRIPT_DIR/orchestration/setup.sh

--- a/.evergreen/start-orchestration.sh
+++ b/.evergreen/start-orchestration.sh
@@ -9,5 +9,7 @@ set -o errexit  # Exit the script with error if any of the commands fail
 SCRIPT_DIR=$(dirname ${BASH_SOURCE:-$0})
 . $SCRIPT_DIR/handle-paths.sh
 
+# Ensure the CLIs are up to date.
 bash $SCRIPT_DIR/orchestration/setup.sh
+
 $SCRIPT_DIR/orchestration/drivers-orchestration start

--- a/.evergreen/stop-orchestration.sh
+++ b/.evergreen/stop-orchestration.sh
@@ -9,5 +9,7 @@ set -o errexit  # Exit the script with error if any of the commands fail
 SCRIPT_DIR=$(dirname ${BASH_SOURCE:-$0})
 . $SCRIPT_DIR/handle-paths.sh
 
+# Ensure the CLIs are up to date.
 bash $SCRIPT_DIR/orchestration/setup.sh
+
 $SCRIPT_DIR/orchestration/drivers-orchestration stop

--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ runs:
   steps:
     - id: "add-python"
       name: "Install supported version of python"
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      uses: actions/setup-python@v5
       with:
         python-version: '3.13'
     - id: "add-pip-path"

--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ runs:
   steps:
     - id: "add-python"
       name: "Install supported version of python"
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: '3.13'
     - id: "add-pip-path"


### PR DESCRIPTION
- Addresses usability concerns seen while using the CLI locally.  You shouldn't have to run `.evergreen/setup.sh` before running `make run-server`.
- Cleans up logs emitted in CI.
- Isolates usage of uv to install-cli.sh.
- Fixes toolchain location of uv on Windows.

c patch build: https://spruce.mongodb.com/version/680edfb217e4d700073bba98/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

node patch build: https://spruce.mongodb.com/version/680ee28a8032920007db565e/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC
