### PR TITLE
DRIVERS-3188 Remove reliance on Evergreen instance profile credentials for remaining tasks

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1138,7 +1138,7 @@ task_groups:
       - command: subprocess.exec
         params:
           binary: "bash"
-          include_expansions_in_env: ["SERVERLESS_ATLAS_PASSWORD", "SERVERLESS_ATLAS_USER", AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN]
+          include_expansions_in_env: ["SERVERLESS_ATLAS_PASSWORD", "SERVERLESS_ATLAS_USER"]
           args:
             - ${DRIVERS_TOOLS}/.evergreen/serverless/setup.sh
     teardown_group:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1164,6 +1164,7 @@ task_groups:
       - command: subprocess.exec
         params:
           binary: bash
+          include_expansions_in_env: [AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN]
           env:
             CLUSTER_PREFIX: dbx-drivers-tools
           args:
@@ -1197,6 +1198,7 @@ task_groups:
       - command: shell.exec
         params:
           shell: bash
+          include_expansions_in_env: [AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN]
           script: |
             set -o errexit
             # ensure HEAD points to current commit
@@ -1229,6 +1231,7 @@ task_groups:
       - command: shell.exec
         params:
           shell: bash
+          include_expansions_in_env: [AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN]
           script: |
             set -o errexit
             # ensure HEAD points to current commit
@@ -1261,6 +1264,7 @@ task_groups:
       - command: subprocess.exec
         params:
           binary: bash
+          include_expansions_in_env: [AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN]
           args:
             - ${DRIVERS_TOOLS}/.evergreen/auth_oidc/azure_func/setup.sh
     teardown_group:
@@ -1287,6 +1291,7 @@ task_groups:
       - command: subprocess.exec
         params:
           binary: bash
+          include_expansions_in_env: [AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN]
           args:
             - ${DRIVERS_TOOLS}/.evergreen/auth_oidc/k8s/setup.sh
     teardown_group:
@@ -1313,6 +1318,7 @@ task_groups:
       - command: subprocess.exec
         params:
           binary: bash
+          include_expansions_in_env: [AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN]
           args:
             - ${DRIVERS_TOOLS}/.evergreen/auth_oidc/k8s/setup.sh
             - local

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -704,6 +704,7 @@ tasks:
         - command: subprocess.exec
           params:
             binary: bash
+            include_expansions_in_env: [AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN]
             args:
               - ${DRIVERS_TOOLS}/.evergreen/csfle/azurekms/delete_old_azure_resources.sh
 
@@ -1137,7 +1138,7 @@ task_groups:
       - command: subprocess.exec
         params:
           binary: "bash"
-          include_expansions_in_env: ["SERVERLESS_ATLAS_PASSWORD", "SERVERLESS_ATLAS_USER"]
+          include_expansions_in_env: ["SERVERLESS_ATLAS_PASSWORD", "SERVERLESS_ATLAS_USER", AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN]
           args:
             - ${DRIVERS_TOOLS}/.evergreen/serverless/setup.sh
     teardown_group:


### PR DESCRIPTION

Patch build: https://spruce.mongodb.com/version/6840ee95c1b5aa000723f40c/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

The serverless failure can be ignored, I'm removing serverless testing as part of [DRIVERS-3202](https://jira.mongodb.org/browse/DRIVERS-3202) in a follow up PR.