### PR TITLE
DRIVERS-3208 Option to avoid docker login for local testing

### DIFF
--- a/.evergreen/docker/run-server.sh
+++ b/.evergreen/docker/run-server.sh
@@ -66,6 +66,11 @@ ARGS+=" -e REQUIRE_API_VERSION=$REQUIRE_API_VERSION"
 ARGS+=" -e DISABLE_TEST_COMMANDS=$DISABLE_TEST_COMMANDS"
 ARGS+=" -e MONGODB_DOWNLOAD_URL=$MONGODB_DOWNLOAD_URL"
 
+# Use the ECR pull-through registry for Ubuntu images when running in CI.
+if [[ "$IMAGE" =~ ^ubuntu.* ]] && [[ -n "${CI:-}" ]]; then
+    ARGS+=" -e IMAGE_NAME=901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/$IMAGE"
+fi
+
 # Expose the required ports.
 if [ "$TOPOLOGY" == "server" ]; then
     ARGS+=" -p 27017:27017"

--- a/.evergreen/docker/ubuntu20.04/Dockerfile
+++ b/.evergreen/docker/ubuntu20.04/Dockerfile
@@ -1,4 +1,5 @@
-FROM 901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/ubuntu:20.04
+ARG IMAGE_NAME=ubuntu:20.04
+FROM $IMAGE_NAME
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
   apt-get -qq update && apt-get -qq -y install --no-install-recommends \


### PR DESCRIPTION
Tested locally:

```bash
$ bash run-server.sh
~/workspace/drivers-evergreen-tools ~/workspace/drivers-evergreen-tools/.evergreen/docker
[+] Building 7.7s (7/10)                                                                           docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                               0.0s
 => => transferring dockerfile: 1.04kB                                                                             0.0s
 => [internal] load metadata for docker.io/library/ubuntu:20.04                                                    1.0s
...
```

```bash
$ CI=1 bash run-server.sh
~/workspace/drivers-evergreen-tools/.evergreen/docker ~/workspace/drivers-evergreen-tools/.evergreen/docker
Traceback (most recent call last):
  File "/Users/steve.silvester/workspace/drivers-evergreen-tools/.evergreen/docker/login.py", line 20, in <module>
    ExternalId=os.environ["AWS_EXTERNAL_ID"],
               ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "<frozen os>", line 716, in __getitem__
KeyError: 'AWS_EXTERNAL_ID'
```