### PR TITLE
INTPYTHON-641 Fix docker login to prefer podman

### DIFF
--- a/.evergreen/docker/login.py
+++ b/.evergreen/docker/login.py
@@ -37,7 +37,7 @@ ecr_client.close()
 token = resp["authorizationData"][0]["authorizationToken"]
 _, _, token = base64.b64decode(token).partition(b":")
 
-docker = shutil.which("docker") or shutil.which("podman")
+docker = shutil.which("podman") or shutil.which("docker")
 if "podman" in docker:
     docker = f"sudo {docker}"
 


### PR DESCRIPTION
This addresses failures seen in [ai-ml-pipeline-testing](https://spruce.mongodb.com/task/ai_ml_pipeline_testing_test_pymongo_voyageai_rhel_test_pymongo_voyageai_local_patch_573242238993df7988c446ccf4fc4f95161b15ef_686413f704006c0007a9ab5d_25_07_01_16_59_36/logs?execution=1) due to mixing docker and podman:

```
[2025/07/01 12:10:48.150] Emulate Docker CLI using podman. Create /etc/containers/nodocker to quiet msg.
...
[2025/07/01 12:10:48.150] DEBUG    Using command: 'sudo /usr/bin/podman run --rm -d --name mongodb_atlas_local -p 27017:27017 --health-cmd '/usr/local/bin/runner healthcheck' -P 901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/mongodb/mongodb-atlas-local:latest'
[2025/07/01 12:10:48.225] Trying to pull 901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/mongodb/mongodb-atlas-local:latest...
[2025/07/01 12:10:48.246] Error: initializing source docker://901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/mongodb/mongodb-atlas-local:latest: reading manifest latest in 901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/mongodb/mongodb-atlas-local: authentication required
```

