### PR TITLE
Fix openssl version check to handle 3.x

### DIFF
--- a/.evergreen/mongosh_dl.py
+++ b/.evergreen/mongosh_dl.py
@@ -99,7 +99,7 @@ def _download(
         suffix = ".tgz"
         if sys.platform == "linux" and arch in ["x64", "arm64"]:
             openssl = subprocess.check_output(["openssl", "version"])
-            if "3.0" in openssl.decode("utf-8"):
+            if "3." in openssl.decode("utf-8"):
                 suffix = "-openssl3.tgz"
             elif re.match("1.1.1[e-w] ", openssl.decode("utf-8")):
                 suffix = "-openssl11.tgz"


### PR DESCRIPTION
Some of the hosts were updated to OpenSSL 3.1, which broke this logic.