### PR TITLE
Increase GitHub Actions timeout

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
   tests:
     name: "Tests"
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 5
+    timeout-minutes: 10
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
We were seeing timeouts on Windows, 5 minutes was not enough.