### PR TITLE
Fix Azure resource deletion

### DIFF
--- a/.evergreen/csfle/azurekms/delete_old_azure_resources.sh
+++ b/.evergreen/csfle/azurekms/delete_old_azure_resources.sh
@@ -21,7 +21,7 @@ set -o nounset
         PYTHON=$(ensure_python3)
         echo "Creating virtual environment 'azure_deletion_venv'..."
         venvcreate "${PYTHON:?}" azure_deletion_venv
-        python -m pip install -r requirements.txt
+        python -m pip install -r "$DRIVERS_TOOLS/.evergreen/csfle/azurekms/requirements.txt"
         echo "Creating virtual environment 'azure_deletion_venv'... done."
     fi
 }

--- a/.evergreen/csfle/azurekms/delete_old_azure_resources.sh
+++ b/.evergreen/csfle/azurekms/delete_old_azure_resources.sh
@@ -21,7 +21,7 @@ set -o nounset
         PYTHON=$(ensure_python3)
         echo "Creating virtual environment 'azure_deletion_venv'..."
         venvcreate "${PYTHON:?}" azure_deletion_venv
-        pythom -m pip install -r requirements.txt
+        python -m pip install -r requirements.txt
         echo "Creating virtual environment 'azure_deletion_venv'... done."
     fi
 }


### PR DESCRIPTION
Follow-up to https://github.com/mongodb-labs/drivers-evergreen-tools/pull/666 to fix the `delete_old_azure_resources` task ([example](https://spruce.mongodb.com/task/drivers_tools_delete_old_azure_resources_delete_old_azure_resources_688568825d4e6b00074ba745_25_07_26_23_45_06/logs?execution=0)):

```
line 24: pythom: command not found
```

Verified with this [patch build](https://spruce.mongodb.com/version/688a62c401270600072a9727) (includes a temporary change to make the task patchable).