### PR TITLE
DRIVERS-3238 Fix Azure VM source list

### DIFF
--- a/.evergreen/csfle/azurekms/remote-scripts/setup-azure-vm.sh
+++ b/.evergreen/csfle/azurekms/remote-scripts/setup-azure-vm.sh
@@ -5,9 +5,7 @@ set -o pipefail
 
 if grep -qs "bullseye" /etc/os-release; then
     echo "Overwrite repositories to fix DRIVERS-3238 ... begin"
-    echo "deb http://deb.debian.org/debian bullseye main" | sudo tee /etc/apt/sources.list
-    echo "deb http://deb.debian.org/debian-security bullseye-security main" | sudo tee -a /etc/apt/sources.list
-    echo "deb http://deb.debian.org/debian bullseye-updates main" | sudo tee -a /etc/apt/sources.list
+    cat /etc/apt/sources.list | grep -v bullseye-backports | sudo tee /etc/apt/sources.list 
     echo "Overwrite repositories to fix DRIVERS-3238 ... end"
 fi
 

--- a/.evergreen/csfle/azurekms/remote-scripts/setup-azure-vm.sh
+++ b/.evergreen/csfle/azurekms/remote-scripts/setup-azure-vm.sh
@@ -3,6 +3,14 @@ set -o errexit
 set -o pipefail
 # Do not error on unset variables. run-orchestration.sh accesses unset variables.
 
+if grep -qs "bullseye" /etc/os-release; then
+    echo "Overwrite repositories to fix DRIVERS-3238 ... begin"
+    echo "deb http://deb.debian.org/debian bullseye main" | sudo tee /etc/apt/sources.list
+    echo "deb http://deb.debian.org/debian-security bullseye-security main" | sudo tee -a /etc/apt/sources.list
+    echo "deb http://deb.debian.org/debian bullseye-updates main" | sudo tee -a /etc/apt/sources.list
+    echo "Overwrite repositories to fix DRIVERS-3238 ... end"
+fi
+
 echo "Installing dependencies ... begin"
 # Skip the "Processing triggers for man-db" step.
 echo "set man-db/auto-update false" | sudo debconf-communicate

--- a/.evergreen/csfle/azurekms/remote-scripts/setup-azure-vm.sh
+++ b/.evergreen/csfle/azurekms/remote-scripts/setup-azure-vm.sh
@@ -5,7 +5,7 @@ set -o pipefail
 
 if grep -qs "bullseye" /etc/os-release; then
     echo "Overwrite repositories to fix DRIVERS-3238 ... begin"
-    cat /etc/apt/sources.list | grep -v bullseye-backports | sudo tee /etc/apt/sources.list 
+    cat /etc/apt/sources.list | grep -v bullseye-backports | sudo tee /etc/apt/sources.list
     echo "Overwrite repositories to fix DRIVERS-3238 ... end"
 fi
 


### PR DESCRIPTION
Remove `bullseye-backports` to fix observed failures with Azure VMs:

```
E: The repository 'http://debian-archive.trafficmanager.net/debian bullseye-backports Release' does not have a Release file.
```

Fixes `test-oidc-azure`: https://spruce.mongodb.com/version/688d03d7dc00fb0007683d9f
Fixes the C driver task `testazurekms-task`: https://spruce.mongodb.com/version/688d0079f2350700075c8071

# Background & Motivation

This is a known issue on the Azure VM image. See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1109866.

On an Azure VM created with `debian-11:11:0.20221020.1174`, `/etc/apt/sources.list` contains:
```
deb http://debian-archive.trafficmanager.net/debian bullseye main
deb-src http://debian-archive.trafficmanager.net/debian bullseye main
deb http://debian-archive.trafficmanager.net/debian-security bullseye-security main
deb-src http://debian-archive.trafficmanager.net/debian-security bullseye-security main
deb http://debian-archive.trafficmanager.net/debian bullseye-updates main
deb-src http://debian-archive.trafficmanager.net/debian bullseye-updates main
deb http://debian-archive.trafficmanager.net/debian bullseye-backports main
deb-src http://debian-archive.trafficmanager.net/debian bullseye-backports main
```

`trafficmanager.net` is listed on https://www.debian.org/mirror/list, and I expect is related to [Azure Traffic Manager](https://learn.microsoft.com/en-us/azure/traffic-manager/traffic-manager-overview).

Comparing a Docker container running `debian:11`, `/etc/apt/sources.list` does not contain a `bullseye-backports`:
```
# deb http://snapshot.debian.org/archive/debian/20240812T000000Z bullseye main
deb http://deb.debian.org/debian bullseye main
# deb http://snapshot.debian.org/archive/debian-security/20240812T000000Z bullseye-security main
deb http://deb.debian.org/debian-security bullseye-security main
# deb http://snapshot.debian.org/archive/debian/20240812T000000Z bullseye-updates main
deb http://deb.debian.org/debian bullseye-updates main
```

This PR removes `bullseye-backports` from the Azure VM.