### PR TITLE
move `-v` flag from `docker build` to `docker run`

### DIFF
--- a/.evergreen/auth_oidc/start_local_server.sh
+++ b/.evergreen/auth_oidc/start_local_server.sh
@@ -65,7 +65,7 @@ PLATFORM="--platform linux/amd64"
 cp .gitignore .dockerignore
 USER="--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)"
 $DOCKER build $PLATFORM -t drivers-evergreen-tools -f $SCRIPT_DIR/../docker/ubuntu20.04/Dockerfile $USER .
-$DOCKER build $PLATFORM -t oidc-test $VOL -f $SCRIPT_DIR/Dockerfile $USER .
+$DOCKER build $PLATFORM -t oidc-test -f $SCRIPT_DIR/Dockerfile $USER .
 popd
 
-$DOCKER run --rm -i $USE_TTY $ENV -p 27017:27017 -p 27018:27018 oidc-test $ENTRYPOINT
+$DOCKER run --rm -i $USE_TTY $ENV $VOL -p 27017:27017 -p 27018:27018 oidc-test $ENTRYPOINT


### PR DESCRIPTION
To fix an observed error when running `start_local_server.sh` with `AWS_PROFILE` exported:
```bash
# AWS_PROFILE set previously
export AWS_PROFILE        
.evergreen/auth_oidc/start_local_server.sh
```

Results in:
```
unknown shorthand flag: 'v' in -v
```