### PR TITLE
Try to avoid "find: The environment is too large for exec()"

### DIFF
--- a/.evergreen/install-cli.sh
+++ b/.evergreen/install-cli.sh
@@ -137,7 +137,7 @@ uv tool install "${uv_install_args[@]:?}" .
 (
   for name_exe in *.exe; do
     # Skip files which do not exist or are not executable.
-    [[ -x "${f:?}" ]] || continue
+    [[ -x "${name_exe:?}" ]] || continue
     # Strip ".exe" at end of filename.
     name="${name_exe%".exe"}"
     # Only create a symlink if the symlink doesn't already exist.


### PR DESCRIPTION
Followup to https://github.com/mongodb-labs/drivers-evergreen-tools/pull/678, which replaced the prior "rename `blah.exe` to `blah`" routines with a call to `find -exec ln -s` (symlink instead of rename). However, on Windows distros, this command seems to spuriously fail with the following error:

```
find: The environment is too large for exec().
```

Per `find` [docs](https://www.gnu.org/software/findutils/manual/html_node/find_html/Error-Messages-From-xargs.html):

> This message means that you have so many environment variables set (or such large values for them) that there is no room within the system-imposed limits on program command line argument length to invoke any program. This is an unlikely situation and is more likely result of an attempt to test the limits of xargs, or break it. Please try unsetting some environment variables, or exiting the current shell. You can also use ‘xargs --show-limits’ to understand the relevant sizes.

Although I am not entirely sure what is causing this error (too many env vars? an env var (probably `PATH`) that is too big?), this PR implements two workarounds to mitigate both possibilities:

- check for redundancy before adding a new entry to `PATH` using Bash's built-in [POSIX extended regex](https://www.gnu.org/software/bash/manual/html_node/Conditional-Constructs.html#index-_005b_005b) support, and
- use Bash [filename expansion](https://www.gnu.org/software/bash/manual/html_node/Filename-Expansion.html) (aka globbing) instead of `find` to lookup `blah.exe` candidates.

An additional check before `ln -s` is included to prevent the following error:

```
ln: 'mongodl.exe' and 'mongodl' are the same file
```