### PR TITLE
DRIVERS-3094: allow specification of target architecture to download x86_64 binaries on servers that do not support arm64

### DIFF
--- a/.evergreen/orchestration/drivers_orchestration.py
+++ b/.evergreen/orchestration/drivers_orchestration.py
@@ -387,7 +387,7 @@ def run(opts):
         default_args += " -q"
     elif opts.verbose:
         default_args += " -v"
-    
+
     if opts.arch:
         default_args += f" --arch={opts.arch}"
 


### PR DESCRIPTION
A new option, `--arch`, has been added to run-orchestration.py that allows users to specify the target architecture to use for server binaries.