### PR TITLE
always stop mongo orchestration in drivers-orchestarion.py

### DIFF
--- a/.evergreen/orchestration/drivers_orchestration.py
+++ b/.evergreen/orchestration/drivers_orchestration.py
@@ -477,6 +477,8 @@ def run(opts):
         orch_file = Path(mo_home / "config.json")
         orch_file.write_text(json.dumps(data, indent=2))
 
+        # Stop orchestration, if it is running, to prevent issues launching it again.
+        stop(opts)
         # Start the orchestration.
         start(opts)
 


### PR DESCRIPTION
Consecutive runs of drivers-orchestation.py fail after the first because mongo-orchestration is already running.  This PR updates drivers-orchestration to stop mongo-orchestration, if it is running, before attempting to launch it again.