### PR TITLE
DRIVERS-3131: Provide AWS scripts with no URI credentials

### DIFF
--- a/.evergreen/auth_aws/aws_tester.py
+++ b/.evergreen/auth_aws/aws_tester.py
@@ -174,7 +174,12 @@ def setup_regular():
     )
     create_user(CONFIG[get_key("iam_auth_ecs_account_arn")], kwargs)
 
-    return dict(USER=kwargs["username"], PASS=kwargs["password"])
+    return dict(
+        USER=kwargs["username"],
+        PASS=kwargs["password"],
+        AWS_ACCESS_KEY_ID=kwargs["username"],
+        AWS_SECRET_ACCESS_KEY=kwargs["password"],
+    )
 
 
 def setup_env_creds():

--- a/.evergreen/tests/test-aws.sh
+++ b/.evergreen/tests/test-aws.sh
@@ -46,6 +46,9 @@ bash aws_setup.sh --nouri regular
 cat test-env.sh | grep -q USER
 cat test-env.sh | grep -q PASS
 cat test-env.sh | grep -v -q SESSION_TOKEN
+cat test-env.sh | grep -q AWS_ACCESS_KEY_ID
+cat test-env.sh | grep -q AWS_SECRET_ACCESS_KEY
+cat test-env.sh | grep -v -q AWS_SESSION_TOKEN
 # Ensure there is no password in the URI.
 cat test-env.sh | grep MONGODB_URI | grep -v -q "@"
 rm test-env.sh


### PR DESCRIPTION
Adds a --nouri option to aws_tester.py to prevent credentials from being put in the MONGODB_URI. Adds tests.

Node run: https://spruce.mongodb.com/version/68dbea54eb794e0007f7a2fe/tasks?page=0&sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC&variant=%5Eubuntu2004-test-mongodb-aws%24