### PR TITLE
DRIVERS-3302 Fix OIDC Atlas Teardown

### DIFF
--- a/.evergreen/auth_oidc/gcp/teardown.sh
+++ b/.evergreen/auth_oidc/gcp/teardown.sh
@@ -20,6 +20,4 @@ bash ../../atlas/teardown-atlas-cluster.sh
 
 popd
 
-if [ -n "$delete_failed" ]; then
-  exit 1
-fi
+[[ "${delete_success:?}" == "1" ]]

--- a/.evergreen/auth_oidc/gcp/teardown.sh
+++ b/.evergreen/auth_oidc/gcp/teardown.sh
@@ -10,10 +10,7 @@ pushd $SCRIPT_DIR
 source ./secrets-export.sh
 
 # Tear down the VM.  Do not let a failure prevent tearing down the cluster.
-delete_failed=""
-bash $DRIVERS_TOOLS/.evergreen/csfle/gcpkms/delete-instance.sh || {
-  delete_failed="1"
-}
+bash "$DRIVERS_TOOLS/.evergreen/csfle/gcpkms/delete-instance.sh" && delete_success="1" || delete_success="0"
 
 # Tear down the Atlas Cluster
 export DRIVERS_ATLAS_PUBLIC_API_KEY=$OIDC_ATLAS_PUBLIC_API_KEY

--- a/.evergreen/auth_oidc/gcp/teardown.sh
+++ b/.evergreen/auth_oidc/gcp/teardown.sh
@@ -9,8 +9,11 @@ pushd $SCRIPT_DIR
 # Source the secrets.
 source ./secrets-export.sh
 
-# Tear down the VM.
-bash $DRIVERS_TOOLS/.evergreen/csfle/gcpkms/delete-instance.sh
+# Tear down the VM.  Do not let a failure prevent tearing down the cluster.
+delete_failed=""
+bash $DRIVERS_TOOLS/.evergreen/csfle/gcpkms/delete-instance.sh || {
+  delete_failed="1"
+}
 
 # Tear down the Atlas Cluster
 export DRIVERS_ATLAS_PUBLIC_API_KEY=$OIDC_ATLAS_PUBLIC_API_KEY
@@ -19,3 +22,7 @@ export DRIVERS_ATLAS_GROUP_ID=$OIDC_ATLAS_GROUP_ID
 bash ../../atlas/teardown-atlas-cluster.sh
 
 popd
+
+if [ -n "$delete_failed" ]; then
+  exit 1
+fi

--- a/.evergreen/auth_oidc/k8s/setup.sh
+++ b/.evergreen/auth_oidc/k8s/setup.sh
@@ -25,7 +25,7 @@ pushd $SCRIPT_DIR
 # Handle secrets from vault.
 . ./setup-secrets.sh
 
-# Add preliminary variables.
+# Add preliminary variables. Unconditionally used by teardown.sh.
 cat <<EOF >> "secrets-export.sh"
 export OIDC_SERVER_TYPE=atlas
 export OIDC_ADMIN_USER=$OIDC_ATLAS_USER

--- a/.evergreen/auth_oidc/k8s/setup.sh
+++ b/.evergreen/auth_oidc/k8s/setup.sh
@@ -25,6 +25,13 @@ pushd $SCRIPT_DIR
 # Handle secrets from vault.
 . ./setup-secrets.sh
 
+# Add preliminary variables.
+cat <<EOF >> "secrets-export.sh"
+export OIDC_SERVER_TYPE=atlas
+export OIDC_ADMIN_USER=$OIDC_ATLAS_USER
+export OIDC_ADMIN_PWD=$OIDC_ATLAS_PASSWORD
+EOF
+
 ########################
 # Start an Atlas Cluster
 
@@ -95,11 +102,8 @@ create_deployment
 URI=$(check_deployment)
 
 cat <<EOF >> "secrets-export.sh"
-export OIDC_SERVER_TYPE=atlas
 export MONGODB_URI="$URI"
 export MONGODB_URI_SINGLE="$URI/?authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:k8s&authSource=%24external"
-export OIDC_ADMIN_USER=$OIDC_ATLAS_USER
-export OIDC_ADMIN_PWD=$OIDC_ATLAS_PASSWORD
 EOF
 
 popd


### PR DESCRIPTION
Testing with https://spruce.mongodb.com/version/68de7f4418e7c300072048d3/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

GKE test failure is unrelated, the cluster was torn down properly.
