### PR TITLE
DRIVERS-2924 get GCP and Azure access tokens

### DIFF
--- a/.evergreen/csfle/requirements-in-legacy.txt
+++ b/.evergreen/csfle/requirements-in-legacy.txt
@@ -1,2 +1,4 @@
--r requirements-in.txt
+boto3~=1.35.0
+git+https://github.com/mongodb-forks/PyKMIP.git
+sqlalchemy<2.0.0 # sqlalchemy.exc.InvalidRequestError: Implicitly combining column managed_objects.uid with column crypto_objects.uid under attribute 'unique_identifier'
 cryptography<3.4

--- a/.evergreen/csfle/requirements-in.txt
+++ b/.evergreen/csfle/requirements-in.txt
@@ -1,4 +1,3 @@
 boto3~=1.35.0
 git+https://github.com/mongodb-forks/PyKMIP.git
-sqlalchemy<2.0.0 # sqlalchemy.exc.InvalidRequestError: Implicitly combining column managed_objects.uid with column crypto_objects.uid under attribute 'unique_identifier'
 cryptography>=45.0.0

--- a/.evergreen/csfle/requirements-in.txt
+++ b/.evergreen/csfle/requirements-in.txt
@@ -1,3 +1,4 @@
 boto3~=1.35.0
 git+https://github.com/mongodb-forks/PyKMIP.git
 sqlalchemy<2.0.0 # sqlalchemy.exc.InvalidRequestError: Implicitly combining column managed_objects.uid with column crypto_objects.uid under attribute 'unique_identifier'
+cryptography>=45.0.0

--- a/.evergreen/csfle/requirements-in.txt
+++ b/.evergreen/csfle/requirements-in.txt
@@ -1,3 +1,3 @@
 boto3~=1.35.0
 git+https://github.com/mongodb-forks/PyKMIP.git
-sqlalchemy<2.0.0" # sqlalchemy.exc.InvalidRequestError: Implicitly combining column managed_objects.uid with column crypto_objects.uid under attribute 'unique_identifier'
+sqlalchemy<2.0.0 # sqlalchemy.exc.InvalidRequestError: Implicitly combining column managed_objects.uid with column crypto_objects.uid under attribute 'unique_identifier'

--- a/.evergreen/csfle/requirements-legacy.txt
+++ b/.evergreen/csfle/requirements-legacy.txt
@@ -5,7 +5,7 @@
 #    pip-compile --output-file=requirements-legacy.txt requirements-in-legacy.txt
 #
 boto3==1.35.99
-    # via -r requirements-in.txt
+    # via -r requirements-in-legacy.txt
 botocore==1.35.99
     # via
     #   boto3
@@ -31,7 +31,7 @@ jmespath==1.0.1
 pycparser==2.22
     # via cffi
 pykmip @ git+https://github.com/mongodb-forks/PyKMIP.git
-    # via -r requirements-in.txt
+    # via -r requirements-in-legacy.txt
 python-dateutil==2.9.0.post0
     # via botocore
 requests==2.32.4
@@ -45,7 +45,7 @@ six==1.17.0
     #   python-dateutil
 sqlalchemy==1.4.54
     # via
-    #   -r requirements-in.txt
+    #   -r requirements-in-legacy.txt
     #   pykmip
 urllib3==1.26.20
     # via

--- a/.evergreen/csfle/requirements.txt
+++ b/.evergreen/csfle/requirements.txt
@@ -17,7 +17,9 @@ cffi==1.17.1
 charset-normalizer==3.4.2
     # via requests
 cryptography==45.0.5
-    # via pykmip
+    # via
+    #   -r requirements-in.txt
+    #   pykmip
 enum-compat==0.0.3
     # via pykmip
 idna==3.10

--- a/.evergreen/csfle/set-temp-creds.sh
+++ b/.evergreen/csfle/set-temp-creds.sh
@@ -23,6 +23,8 @@
 
 set +o xtrace # Disable tracing.
 
+echo "set-temp-creds.sh is legacy. Please use setup-secrets.sh instead"
+
 get_creds() {
     $PYTHON - << 'EOF'
 import sys

--- a/.evergreen/csfle/set-temp-creds.sh
+++ b/.evergreen/csfle/set-temp-creds.sh
@@ -23,7 +23,7 @@
 
 set +o xtrace # Disable tracing.
 
-echo "set-temp-creds.sh is legacy. Please use setup-secrets.sh instead"
+echo "DRIVERS-3433: set-temp-creds.sh is deprecated, use setup-secrets.sh instead" 1>&2
 
 get_creds() {
     $PYTHON - << 'EOF'

--- a/.evergreen/csfle/setup_secrets.py
+++ b/.evergreen/csfle/setup_secrets.py
@@ -3,9 +3,16 @@
 Set up encryption secrets.
 """
 
+import base64
+import json
 import os
+import time
+import urllib.parse
+import urllib.request
 
 import boto3
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
 
 os.environ["AWS_ACCESS_KEY_ID"] = os.environ["FLE_AWS_KEY"]
 os.environ["AWS_SECRET_ACCESS_KEY"] = os.environ["FLE_AWS_SECRET"]
@@ -15,6 +22,103 @@ os.environ["AWS_SESSION_TOKEN"] = ""
 print("Getting CSFLE temp creds")
 client = boto3.client("sts")
 credentials = client.get_session_token()["Credentials"]
+
+azure_access_token = None
+print("Getting Azure access token")
+if all(
+    key in os.environ
+    for key in ["FLE_AZURE_CLIENTID", "FLE_AZURE_CLIENTSECRET", "FLE_AZURE_TENANTID"]
+):
+    # See: https://github.com/mongodb/libmongocrypt/blob/6d6bc38254a07bd47dbd0e665cffd67adf8746a9/kms-message/src/kms_azure_request.c#L37
+    tenant_id = os.environ["FLE_AZURE_TENANTID"]
+    client_id = os.environ["FLE_AZURE_CLIENTID"]
+    client_secret = os.environ["FLE_AZURE_CLIENTSECRET"]
+
+    url = f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
+    body = urllib.parse.urlencode(
+        {
+            "grant_type": "client_credentials",
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "scope": "https://vault.azure.net/.default",
+        }
+    ).encode()
+
+    req = urllib.request.Request(
+        url,
+        data=body,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+
+    with urllib.request.urlopen(req) as resp:
+        azure_access_token = json.loads(resp.read())["access_token"]
+    print("Getting Azure access token...done")
+else:
+    print("Getting Azure access token...skipped: missing environment variables")
+
+gcp_access_token = None
+print("Getting GCP access token")
+if all(key in os.environ for key in ["FLE_GCP_EMAIL", "FLE_GCP_PRIVATEKEY"]):
+    # See: https://github.com/mongodb/libmongocrypt/blob/6d6bc38254a07bd47dbd0e665cffd67adf8746a9/kms-message/src/kms_gcp_request.c#L28
+    email = os.environ["FLE_GCP_EMAIL"]
+    private_key = os.environ["FLE_GCP_PRIVATEKEY"]
+    scope = "https://www.googleapis.com/auth/cloudkms"
+
+    now = int(time.time())
+
+    def b64url(data: bytes) -> str:
+        return base64.urlsafe_b64encode(data).decode()
+
+    # Build JWT header + payload:
+    header = b64url(json.dumps({"alg": "RS256", "typ": "JWT"}).encode())
+    payload = b64url(
+        json.dumps(
+            {
+                "iss": email,
+                "scope": scope,
+                "aud": "https://oauth2.googleapis.com/token",
+                "iat": now,
+                "exp": now + 3600,
+            }
+        ).encode()
+    )
+
+    signing_input = f"{header}.{payload}".encode()
+
+    # Sign with private key:
+    key = serialization.load_pem_private_key(
+        (
+            "-----BEGIN PRIVATE KEY-----\n"
+            + private_key
+            + "\n-----END PRIVATE KEY-----\n"
+        ).encode(),
+        password=None,
+    )
+    signature = key.sign(signing_input, padding.PKCS1v15(), hashes.SHA256())
+    jwt = f"{header}.{payload}.{b64url(signature)}"
+
+    # Exchange JWT for access token:
+    body = urllib.parse.urlencode(
+        {
+            "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+            "assertion": jwt,
+        }
+    ).encode()
+
+    req = urllib.request.Request(
+        "https://oauth2.googleapis.com/token",
+        data=body,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+
+    with urllib.request.urlopen(req) as resp:
+        gcp_access_token = json.loads(resp.read())["access_token"]
+    print("Getting GCP access token...done")
+else:
+    print("Getting GCP access token...skipped: missing environment variables")
+
 
 with open("secrets-export.sh", "ab") as fid:
     fid.write(
@@ -26,6 +130,12 @@ with open("secrets-export.sh", "ab") as fid:
     fid.write(
         f'\nexport CSFLE_AWS_TEMP_SESSION_TOKEN="{credentials["SessionToken"]}"'.encode()
     )
+    if azure_access_token:
+        fid.write(f'\nexport CSFLE_AZURE_ACCESS_TOKEN="{azure_access_token}"'.encode())
+
+    if gcp_access_token:
+        fid.write(f'\nexport CSFLE_GCP_ACCESS_TOKEN="{gcp_access_token}"'.encode())
+
     for key in [
         "AWS_ACCESS_KEY_ID",
         "AWS_SECRET_ACCESS_KEY",


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Please ensure that the title of the PR is in the following form:
[JIRA TICKET]: Issue Title
-->

DRIVERS-2924

## Summary

<!-- What is this PR introducing? If context is already provided from the JIRA ticket, still place it in the Pull Request as you should not make the reviewer do digging for a basic summary. -->

Extend `setup_secrets.py` to get access tokens for GCP and Azure. The access tokens are stored alongside other secrets with the names:
- `CSFLE_GCP_ACCESS_TOKEN`
- `CSFLE_AZURE_ACCESS_TOKEN`

## Changes in this PR

<!-- What changes did you make to the code? What new APIs (public or private) were added, removed, or edited to generate the desired outcome explained in the above summary? -->

To avoid breaking existing use, `accessToken`s are only obtained if necessary environment variables are set.

[csfle/set-temp-creds.sh](https://github.com/mongodb-labs/drivers-evergreen-tools/blob/2fd7b4626c6671ad67e799db788edac2ba407a06/.evergreen/csfle/set-temp-creds.sh) is not updated. It is [documented as "legacy"](https://github.com/mongodb-labs/drivers-evergreen-tools/tree/2fd7b4626c6671ad67e799db788edac2ba407a06/.evergreen/csfle#legacy-usage). This PR adds a message to suggest users migrate to `setup_secrets.sh`. The only remaining user of this script appears to be the [Ruby driver](https://github.com/mongodb/mongo-ruby-driver/blob/f8b7ed5c34d821db205cec5a7f0b7bf35da447d3/.evergreen/run-tests.sh#L237).

The HTTP requests are similar to those made by libmongocrypt ([Azure](https://github.com/mongodb/libmongocrypt/blob/6d6bc38254a07bd47dbd0e665cffd67adf8746a9/kms-message/src/kms_azure_request.c#L37), [GCP](https://github.com/mongodb/libmongocrypt/blob/6d6bc38254a07bd47dbd0e665cffd67adf8746a9/kms-message/src/kms_gcp_request.c#L28)). One difference: libmongocrypt requests GCP tokens with a 5 minute expiration, but `setup_secrets.py` requests a one hour expiration (the [documented](https://developers.google.com/identity/protocols/oauth2/service-account#httprest) "maximum of 1 hour") to avoid expiration during a driver test run.

## Test Plan

<!-- How did you test the code? If you added unit tests, you can say that. If you didn’t introduce unit tests, explain why. All code should be tested in some way – so please list what your validation strategy was. -->

The `test-csfle` test tasks output the expected logs ([example](https://parsley.corp.mongodb.com/evergreen/drivers_tools_tests_all__os_fully_featured~macos_14_auth~auth_ssl~nossl_test_csfle_patch_2fd7b4626c6671ad67e799db788edac2ba407a06_69bc0c53b377e5000702a763_26_03_19_14_46_44/0/task?bookmarks=0,643&shareLine=79)):
```
[2026/03/19 10:47:31.006] Getting CSFLE temp creds
[2026/03/19 10:47:31.006] Getting Azure access token
[2026/03/19 10:47:31.006] Getting Azure access token...done
[2026/03/19 10:47:31.006] Getting GCP access token
[2026/03/19 10:47:31.006] Getting GCP access token...done
[2026/03/19 10:47:31.006] Getting CSFLE temp creds...done
```

Using the accessTokens is tested in C driver in: https://github.com/mongodb/mongo-c-driver/pull/2253

## Checklist

<!-- Do not delete the items provided on this checklist -->

### Checklist for Author

- [x] Does the title of the PR reference a JIRA Ticket?
- [x] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [x] Is all relevant documentation (README or docstring) updated?

### Checklist for Reviewer

- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?
