### PR TITLE
DRIVERS-2920 add KMS HTTP proxy server

### DIFF
--- a/.evergreen/csfle/await-servers.sh
+++ b/.evergreen/csfle/await-servers.sh
@@ -44,6 +44,7 @@ await_server "HTTP" 9001
 await_server "HTTP" 9002
 await_server "KMS Failpoint" 9003
 await_server "HTTP Proxy" 9004
+await_server "HTTP Proxy TLS" 9005
 await_server "Azure" 8080
 await_server "KMIP" 5698
 

--- a/.evergreen/csfle/await-servers.sh
+++ b/.evergreen/csfle/await-servers.sh
@@ -43,6 +43,7 @@ await_server "HTTP" 9000
 await_server "HTTP" 9001
 await_server "HTTP" 9002
 await_server "KMS Failpoint" 9003
+await_server "HTTP Proxy" 9004
 await_server "Azure" 8080
 await_server "KMIP" 5698
 

--- a/.evergreen/csfle/kms_http_proxy.py
+++ b/.evergreen/csfle/kms_http_proxy.py
@@ -2,10 +2,10 @@
 """Minimal HTTPS CONNECT proxy with a /metrics endpoint.
 
 Plain HTTP (no inbound TLS):
-    python3 kms_http_proxy.py [--host 127.0.0.1] [--port 8080]
+    python3 kms_http_proxy.py [--host 127.0.0.1] [--port 9004]
 
-    $ curl --proxy 127.0.0.1:8080 -sS -o /dev/null https://example.com
-    $ curl http://127.0.0.1:8080/metrics
+    $ curl --proxy 127.0.0.1:9004 -sS -o /dev/null https://example.com
+    $ curl http://127.0.0.1:9004/metrics
 
 TLS on the inbound connection (clients must connect over HTTPS):
     python3 kms_http_proxy.py --port 8443 --ca_file ca.pem --cert_file server.pem
@@ -160,9 +160,14 @@ def _tunnel(a: socket.socket, b: socket.socket) -> None:
 def main() -> int:
     p = argparse.ArgumentParser()
     p.add_argument("--host", default="127.0.0.1")
-    p.add_argument("--port", type=int, default=8080)
+    p.add_argument("--port", type=int, default=9004)
     p.add_argument("--ca_file", type=str, default=None, help="TLS CA PEM file")
-    p.add_argument("--cert_file", type=str, default=None, help="TLS server PEM file (required with --ca_file)")
+    p.add_argument(
+        "--cert_file",
+        type=str,
+        default=None,
+        help="TLS server PEM file (required with --ca_file)",
+    )
     args = p.parse_args()
 
     if bool(args.ca_file) != bool(args.cert_file):

--- a/.evergreen/csfle/kms_http_proxy.py
+++ b/.evergreen/csfle/kms_http_proxy.py
@@ -4,10 +4,12 @@
 Run:
     python3 kms_http_proxy.py [--host 127.0.0.1] [--port 8080]
 
-Then point the test at it:
-    export MONGOC_TEST_KMS_PROXY_HOST=127.0.0.1
-    export MONGOC_TEST_KMS_PROXY_PORT=8080
-    ./test-libmongoc -l '/client_side_encryption/kms/connect_callback/*'
+To test:
+
+    $ curl --proxy 127.0.0.1:8080 -sS -o /dev/null https://example.com
+    $ curl http://127.0.0.1:8080/metrics
+    connect_count 1
+    connect_target example.com:443
 
 Behavior:
   - CONNECT host:port HTTP/1.1  -> opens a TCP tunnel, returns 200, then

--- a/.evergreen/csfle/kms_http_proxy.py
+++ b/.evergreen/csfle/kms_http_proxy.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 """Minimal HTTPS CONNECT proxy with a /metrics endpoint.
 
-Used by the KMS connect-callback test in test-mongoc-client-side-encryption.c.
-
 Run:
     python3 kms_http_proxy.py [--host 127.0.0.1] [--port 8080]
 

--- a/.evergreen/csfle/kms_http_proxy.py
+++ b/.evergreen/csfle/kms_http_proxy.py
@@ -1,25 +1,26 @@
 #!/usr/bin/env python3
 """Minimal HTTPS CONNECT proxy with a /metrics endpoint.
 
-Run:
+Plain HTTP (no inbound TLS):
     python3 kms_http_proxy.py [--host 127.0.0.1] [--port 8080]
-
-To test:
 
     $ curl --proxy 127.0.0.1:8080 -sS -o /dev/null https://example.com
     $ curl http://127.0.0.1:8080/metrics
-    connect_count 1
-    connect_target example.com:443
+
+TLS on the inbound connection (clients must connect over HTTPS):
+    python3 kms_http_proxy.py --port 8443 --ca_file ca.pem --cert_file server.pem
+
+    $ curl --proxy-cacert ca.pem --proxy https://127.0.0.1:8443 -sS -o /dev/null https://example.com
+    $ curl -k https://127.0.0.1:8443/metrics
 
 Behavior:
   - CONNECT host:port HTTP/1.1  -> opens a TCP tunnel, returns 200, then
                                    blindly proxies bytes both directions.
-  - GET /metrics                -> returns "connect_count <N>\n" so callers
+  - GET /metrics                -> returns "connect_count <N>\\n" so callers
                                    can verify a CONNECT was observed.
-  - Any other request           -> 405.
+  - Any other request           -> 404.
 
-No auth, no TLS on the inbound side, no concurrency limits. This is for
-local testing only.
+No auth, no concurrency limits. For local testing only.
 """
 
 from __future__ import annotations
@@ -27,6 +28,7 @@ from __future__ import annotations
 import argparse
 import select
 import socket
+import ssl
 import sys
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -138,11 +140,27 @@ def main() -> int:
     p = argparse.ArgumentParser()
     p.add_argument("--host", default="127.0.0.1")
     p.add_argument("--port", type=int, default=8080)
+    p.add_argument("--ca_file", type=str, default=None, help="TLS CA PEM file")
+    p.add_argument("--cert_file", type=str, default=None, help="TLS server PEM file (required with --ca_file)")
     args = p.parse_args()
 
+    if bool(args.ca_file) != bool(args.cert_file):
+        p.error("--ca_file and --cert_file must be given together")
+
     server = ThreadingHTTPServer((args.host, args.port), ProxyHandler)
+
+    if args.ca_file:
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        context.load_verify_locations(args.ca_file)
+        context.load_cert_chain(args.cert_file)
+        context.verify_mode = ssl.CERT_NONE
+        server.socket = context.wrap_socket(server.socket, server_side=True)
+        scheme = "https"
+    else:
+        scheme = "http"
+
     sys.stderr.write(f"KMS HTTP proxy listening on {args.host}:{args.port}\n")
-    sys.stderr.write(f"  metrics:   http://{args.host}:{args.port}/metrics\n")
+    sys.stderr.write(f"  metrics:   {scheme}://{args.host}:{args.port}/metrics\n")
     try:
         server.serve_forever()
     except KeyboardInterrupt:

--- a/.evergreen/csfle/kms_http_proxy.py
+++ b/.evergreen/csfle/kms_http_proxy.py
@@ -18,6 +18,7 @@ Behavior:
                                    blindly proxies bytes both directions.
   - GET /metrics                -> returns "connect_count <N>\\n" so callers
                                    can verify a CONNECT was observed.
+  - POST /reset                 -> resets the connection count to 0.
   - Any other request           -> 404.
 
 No auth, no concurrency limits. For local testing only.
@@ -48,6 +49,13 @@ def _bump_connect(target: str) -> None:
 def _snapshot_metrics() -> tuple[int, list[str]]:
     with _counter_lock:
         return _connect_count, list(_connect_targets)
+
+
+def _reset_metrics() -> None:
+    global _connect_count, _connect_targets
+    with _counter_lock:
+        _connect_count = 0
+        _connect_targets = []
 
 
 class ProxyHandler(BaseHTTPRequestHandler):
@@ -108,6 +116,19 @@ class ProxyHandler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
 
+    # ---- POST /reset ------------------------------------------------------
+    def do_POST(self) -> None:
+        if self.path != "/reset":
+            self.send_error(404, "only /reset is exposed")
+            return
+        _reset_metrics()
+        body = b"connect_count 0\n"
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
 
 def _tunnel(a: socket.socket, b: socket.socket) -> None:
     """Pipe bytes between two sockets until either side closes."""
@@ -161,6 +182,7 @@ def main() -> int:
 
     sys.stderr.write(f"KMS HTTP proxy listening on {args.host}:{args.port}\n")
     sys.stderr.write(f"  metrics:   {scheme}://{args.host}:{args.port}/metrics\n")
+    sys.stderr.write(f"  reset:     {scheme}://{args.host}:{args.port}/reset\n")
     try:
         server.serve_forever()
     except KeyboardInterrupt:

--- a/.evergreen/csfle/kms_http_proxy.py
+++ b/.evergreen/csfle/kms_http_proxy.py
@@ -29,7 +29,6 @@ import sys
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
-
 _counter_lock = threading.Lock()
 _connect_count = 0
 _connect_targets: list[str] = []
@@ -49,11 +48,11 @@ def _snapshot_metrics() -> tuple[int, list[str]]:
 
 class ProxyHandler(BaseHTTPRequestHandler):
     # BaseHTTPRequestHandler logs to stderr by default; keep it but make it terse.
-    def log_message(self, fmt: str, *args) -> None:  # noqa: A003
+    def log_message(self, fmt: str, *args) -> None:
         sys.stderr.write("[proxy %s] %s\n" % (self.address_string(), fmt % args))
 
     # ---- HTTPS CONNECT ----------------------------------------------------
-    def do_CONNECT(self) -> None:  # noqa: N802
+    def do_CONNECT(self) -> None:
         # self.path is "host:port"
         target = self.path
         try:
@@ -70,7 +69,9 @@ class ProxyHandler(BaseHTTPRequestHandler):
             return
 
         _bump_connect(target)
-        self.log_message("CONNECT %s established (count=%d)", target, _snapshot_metrics()[0])
+        self.log_message(
+            "CONNECT %s established (count=%d)", target, _snapshot_metrics()[0]
+        )
 
         # 200 response with no body. BaseHTTPRequestHandler insists on a
         # Content-Length on end_headers(), but for CONNECT we just want the
@@ -89,7 +90,7 @@ class ProxyHandler(BaseHTTPRequestHandler):
             upstream.close()
 
     # ---- GET /metrics -----------------------------------------------------
-    def do_GET(self) -> None:  # noqa: N802
+    def do_GET(self) -> None:
         if self.path != "/metrics":
             self.send_error(404, "only /metrics is exposed")
             return

--- a/.evergreen/csfle/kms_http_proxy.py
+++ b/.evergreen/csfle/kms_http_proxy.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Minimal HTTPS CONNECT proxy with a /metrics endpoint.
+
+Used by the KMS connect-callback test in test-mongoc-client-side-encryption.c.
+
+Run:
+    python3 kms_http_proxy.py [--host 127.0.0.1] [--port 8080]
+
+Then point the test at it:
+    export MONGOC_TEST_KMS_PROXY_HOST=127.0.0.1
+    export MONGOC_TEST_KMS_PROXY_PORT=8080
+    ./test-libmongoc -l '/client_side_encryption/kms/connect_callback/*'
+
+Behavior:
+  - CONNECT host:port HTTP/1.1  -> opens a TCP tunnel, returns 200, then
+                                   blindly proxies bytes both directions.
+  - GET /metrics                -> returns "connect_count <N>\n" so callers
+                                   can verify a CONNECT was observed.
+  - Any other request           -> 405.
+
+No auth, no TLS on the inbound side, no concurrency limits. This is for
+local testing only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import select
+import socket
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+_counter_lock = threading.Lock()
+_connect_count = 0
+_connect_targets: list[str] = []
+
+
+def _bump_connect(target: str) -> None:
+    global _connect_count
+    with _counter_lock:
+        _connect_count += 1
+        _connect_targets.append(target)
+
+
+def _snapshot_metrics() -> tuple[int, list[str]]:
+    with _counter_lock:
+        return _connect_count, list(_connect_targets)
+
+
+class ProxyHandler(BaseHTTPRequestHandler):
+    # BaseHTTPRequestHandler logs to stderr by default; keep it but make it terse.
+    def log_message(self, fmt: str, *args) -> None:  # noqa: A003
+        sys.stderr.write("[proxy %s] %s\n" % (self.address_string(), fmt % args))
+
+    # ---- HTTPS CONNECT ----------------------------------------------------
+    def do_CONNECT(self) -> None:  # noqa: N802
+        # self.path is "host:port"
+        target = self.path
+        try:
+            host, port_s = target.rsplit(":", 1)
+            port = int(port_s)
+        except ValueError:
+            self.send_error(400, "bad CONNECT target")
+            return
+
+        try:
+            upstream = socket.create_connection((host, port), timeout=10)
+        except OSError as exc:
+            self.send_error(502, f"upstream connect failed: {exc}")
+            return
+
+        _bump_connect(target)
+        self.log_message("CONNECT %s established (count=%d)", target, _snapshot_metrics()[0])
+
+        # 200 response with no body. BaseHTTPRequestHandler insists on a
+        # Content-Length on end_headers(), but for CONNECT we just want the
+        # bare status line + blank line.
+        self.wfile.write(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+        self.wfile.flush()
+
+        client = self.connection
+        try:
+            _tunnel(client, upstream)
+        finally:
+            try:
+                upstream.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+            upstream.close()
+
+    # ---- GET /metrics -----------------------------------------------------
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path != "/metrics":
+            self.send_error(404, "only /metrics is exposed")
+            return
+        count, targets = _snapshot_metrics()
+        body_lines = [f"connect_count {count}"]
+        body_lines.extend(f"connect_target {t}" for t in targets)
+        body = ("\n".join(body_lines) + "\n").encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def _tunnel(a: socket.socket, b: socket.socket) -> None:
+    """Pipe bytes between two sockets until either side closes."""
+    sockets = [a, b]
+    while True:
+        try:
+            ready, _, errored = select.select(sockets, [], sockets, 60)
+        except (OSError, ValueError):
+            return
+        if errored:
+            return
+        if not ready:
+            # idle; let it keep waiting
+            continue
+        for s in ready:
+            peer = b if s is a else a
+            try:
+                data = s.recv(8192)
+            except OSError:
+                return
+            if not data:
+                return
+            try:
+                peer.sendall(data)
+            except OSError:
+                return
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--host", default="127.0.0.1")
+    p.add_argument("--port", type=int, default=8080)
+    args = p.parse_args()
+
+    server = ThreadingHTTPServer((args.host, args.port), ProxyHandler)
+    sys.stderr.write(f"KMS HTTP proxy listening on {args.host}:{args.port}\n")
+    sys.stderr.write(f"  metrics:   http://{args.host}:{args.port}/metrics\n")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        sys.stderr.write("shutting down\n")
+        server.shutdown()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.evergreen/csfle/start-servers.sh
+++ b/.evergreen/csfle/start-servers.sh
@@ -23,7 +23,7 @@ fi
 # Forcibly kill the process listening on the desired ports, most likely
 # left running from a previous task.
 . "$SCRIPT_DIR/../process-utils.sh"
-for port in 5698 9000 9001 9002 9004 8080; do
+for port in 5698 9000 9001 9002 9004 9005 8080; do
   killport $port 9
 done
 
@@ -84,6 +84,14 @@ echo "$!" >> kmip_pids.pid
 sleep 1
 cat http_proxy.log
 echo "Starting HTTP Proxy...done."
+
+
+echo "Starting HTTP Proxy (TLS)..."
+$COMMAND kms_http_proxy.py --port 9005 --ca_file $CSFLE_TLS_CA_FILE --cert_file $CSFLE_TLS_CERT_FILE > http_proxy_tls.log 2>&1 &
+echo "$!" >> kmip_pids.pid
+sleep 1
+cat http_proxy_tls.log
+echo "Starting HTTP Proxy (TLS)...done."
 
 echo "Starting Fake Azure IMDS..."
 $COMMAND bottle.py fake_azure:imds > fake_azure.log 2>&1 &

--- a/.evergreen/csfle/start-servers.sh
+++ b/.evergreen/csfle/start-servers.sh
@@ -23,7 +23,7 @@ fi
 # Forcibly kill the process listening on the desired ports, most likely
 # left running from a previous task.
 . "$SCRIPT_DIR/../process-utils.sh"
-for port in 5698 9000 9001 9002 8080; do
+for port in 5698 9000 9001 9002 9004 8080; do
   killport $port 9
 done
 
@@ -77,6 +77,13 @@ $COMMAND kms_failpoint_server.py --port 9003 > failpoint.log 2>&1 &
 echo "$!" >> kmip_pids.pid
 echo "Starting Failpoint Server...done."
 sleep 1
+
+echo "Starting HTTP Proxy..."
+$COMMAND kms_http_proxy.py --port 9004 > http_proxy.log 2>&1 &
+echo "$!" >> kmip_pids.pid
+sleep 1
+cat http_proxy.log
+echo "Starting HTTP Proxy...done."
 
 echo "Starting Fake Azure IMDS..."
 $COMMAND bottle.py fake_azure:imds > fake_azure.log 2>&1 &


### PR DESCRIPTION
DRIVERS-2920 will add HTTP proxy support. This PR adds a Python HTTP proxy for testing. Besides the CONNECT method there's also a GET /metrics so that drivers can verify that the proxy observed a connection