### PR TITLE
DRIVERS-3550: start-servers.sh does not reap a stale KMS failpoint server on port 9003

### DIFF
--- a/.evergreen/csfle/start-servers.sh
+++ b/.evergreen/csfle/start-servers.sh
@@ -23,7 +23,7 @@ fi
 # Forcibly kill the process listening on the desired ports, most likely
 # left running from a previous task.
 . "$SCRIPT_DIR/../process-utils.sh"
-for port in 5698 9000 9001 9002 9004 9005 8080; do
+for port in 5698 9000 9001 9002 9003 9004 9005 8080; do
   killport $port 9
 done
 


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Please ensure that the title of the PR is in the following form:
-->

DRIVERS-3550


## Summary

The loop for killing ports in start-servers.sh reaped 5698/9000/9001/9002/9004/9005/8080 but omitted 9003, the KMS failpoint server's port. This is causing evergreen failures, [e.g](https://spruce.corp.mongodb.com/task/mongo_go_driver_release_client_side_encryption_test__version~rapid_os_ssl_40~rhel87_64_test_client_side_encryption_2995aaf600). 

## Changes in this PR

Add 9003 to loop

## Test Plan

N/A

## Checklist

<!-- Do not delete the items provided on this checklist -->

### Checklist for Author

- [x] Does the title of the PR reference a JIRA Ticket?
- [x] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [x] Is all relevant documentation (README or docstring) updated?

### Checklist for Reviewer

- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?
