### PR TITLE
DRIVERS-3551: Make KMS failpoint server use x509gen cert

### DIFF
--- a/.evergreen/csfle/start-servers.sh
+++ b/.evergreen/csfle/start-servers.sh
@@ -7,15 +7,15 @@ SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
 pushd $SCRIPT_DIR
 
 if [ ! -f ./secrets-export.sh ]; then
-    echo "Please run the setup-secrets.sh script"
-    exit 1
+  echo "Please run the setup-secrets.sh script"
+  exit 1
 fi
 
 source ./secrets-export.sh
 
 if [ -z "${CSFLE_TLS_CA_FILE-}" ]; then
-    echo "Please run the setup-secrets.sh script"
-    exit 1
+  echo "Please run the setup-secrets.sh script"
+  exit 1
 fi
 
 . ./stop-servers.sh
@@ -38,64 +38,58 @@ if [ "$(uname -s)" != "Darwin" ]; then
   COMMAND="nohup $COMMAND"
 fi
 
-
 echo "Starting KMIP Server..."
 # TMPDIR is required to avoid "AF_UNIX path too long" errors.
-TMPDIR="$(dirname "$DRIVERS_TOOLS")" $COMMAND kms_kmip_server.py --ca_file $CSFLE_TLS_CA_FILE --cert_file $CSFLE_TLS_CERT_FILE --port 5698 > kms_kmip_server.log 2>&1 &
-echo "$!" > kmip_pids.pid
+TMPDIR="$(dirname "$DRIVERS_TOOLS")" $COMMAND kms_kmip_server.py --ca_file $CSFLE_TLS_CA_FILE --cert_file $CSFLE_TLS_CERT_FILE --port 5698 >kms_kmip_server.log 2>&1 &
+echo "$!" >kmip_pids.pid
 sleep 1
 cat kms_kmip_server.log
 echo "Starting KMIP Server...done."
 
-
 echo "Starting HTTP Server 1..."
-$COMMAND kms_http_server.py --ca_file $CSFLE_TLS_CA_FILE --cert_file $CSFLE_TLS_EXPIRED_FILE --port 9000 > http1.log 2>&1 &
-echo "$!" >> kmip_pids.pid
+$COMMAND kms_http_server.py --ca_file $CSFLE_TLS_CA_FILE --cert_file $CSFLE_TLS_EXPIRED_FILE --port 9000 >http1.log 2>&1 &
+echo "$!" >>kmip_pids.pid
 sleep 1
 cat http1.log
 echo "Starting HTTP Server 1...done."
 
-
 echo "Starting HTTP Server 2..."
-$COMMAND kms_http_server.py --ca_file $CSFLE_TLS_CA_FILE --cert_file $CSFLE_TLS_WRONG_HOST_FILE --port 9001 > http2.log 2>&1 &
-echo "$!" >> kmip_pids.pid
+$COMMAND kms_http_server.py --ca_file $CSFLE_TLS_CA_FILE --cert_file $CSFLE_TLS_WRONG_HOST_FILE --port 9001 >http2.log 2>&1 &
+echo "$!" >>kmip_pids.pid
 sleep 1
 cat http2.log
 echo "Starting HTTP Server 2...done."
 
-
 echo "Starting HTTP Server 3..."
-$COMMAND kms_http_server.py --ca_file $CSFLE_TLS_CA_FILE --cert_file $CSFLE_TLS_CERT_FILE --port 9002 --require_client_cert > http3.log 2>&1 &
-echo "$!" >> kmip_pids.pid
+$COMMAND kms_http_server.py --ca_file $CSFLE_TLS_CA_FILE --cert_file $CSFLE_TLS_CERT_FILE --port 9002 --require_client_cert >http3.log 2>&1 &
+echo "$!" >>kmip_pids.pid
 sleep 1
 cat http3.log
 echo "Starting HTTP Server 3...done."
 
-
 echo "Starting Failpoint Server..."
-$COMMAND kms_failpoint_server.py --port 9003 > failpoint.log 2>&1 &
-echo "$!" >> kmip_pids.pid
+env -u CSFLE_TLS_CERT_FILE -u CSFLE_TLS_CA_FILE $COMMAND kms_failpoint_server.py --port 9003 >failpoint.log 2>&1 &
+echo "$!" >>kmip_pids.pid
 echo "Starting Failpoint Server...done."
 sleep 1
 
 echo "Starting HTTP Proxy..."
-$COMMAND kms_http_proxy.py --port 9004 > http_proxy.log 2>&1 &
-echo "$!" >> kmip_pids.pid
+$COMMAND kms_http_proxy.py --port 9004 >http_proxy.log 2>&1 &
+echo "$!" >>kmip_pids.pid
 sleep 1
 cat http_proxy.log
 echo "Starting HTTP Proxy...done."
 
-
 echo "Starting HTTP Proxy (TLS)..."
-$COMMAND kms_http_proxy.py --port 9005 --ca_file $CSFLE_TLS_CA_FILE --cert_file $CSFLE_TLS_CERT_FILE > http_proxy_tls.log 2>&1 &
-echo "$!" >> kmip_pids.pid
+$COMMAND kms_http_proxy.py --port 9005 --ca_file $CSFLE_TLS_CA_FILE --cert_file $CSFLE_TLS_CERT_FILE >http_proxy_tls.log 2>&1 &
+echo "$!" >>kmip_pids.pid
 sleep 1
 cat http_proxy_tls.log
 echo "Starting HTTP Proxy (TLS)...done."
 
 echo "Starting Fake Azure IMDS..."
-$COMMAND bottle.py fake_azure:imds > fake_azure.log 2>&1 &
-echo "$!" >> kmip_pids.pid
+$COMMAND bottle.py fake_azure:imds >fake_azure.log 2>&1 &
+echo "$!" >>kmip_pids.pid
 sleep 1
 cat fake_azure.log
 echo "Starting Fake Azure IMDS...done."


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Please ensure that the title of the PR is in the following form:
[JIRA TICKET]: Issue Title
-->

DRIVERS-3551

## Summary

The failpoint server (port 9003) is the only mock KMS server in start-servers.sh
launched without an explicit --cert_file

## Changes in this PR

Unse env vars for the failpoint server launch so it uses its x509gen default.


## Test Plan

N/A

## Checklist

<!-- Do not delete the items provided on this checklist -->

### Checklist for Author

- [x] Does the title of the PR reference a JIRA Ticket?
- [x] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [x] Is all relevant documentation (README or docstring) updated?

### Checklist for Reviewer

- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?
