### PR TITLE
DRIVERS-3538: bump mongodb-runner to 6.8.2

### DIFF
--- a/.evergreen/orchestration/mongodb_runner.py
+++ b/.evergreen/orchestration/mongodb_runner.py
@@ -61,7 +61,7 @@ def _normalize_path(path: Union[Path, str]) -> str:
     return re.sub("/cygdrive/(.*?)(/)", r"\1://", path, count=1)
 
 
-_MR_VERSION = "6.7.1"
+_MR_VERSION = "6.8.2"
 
 
 def _install_mongodb_runner() -> Path:


### PR DESCRIPTION
DRIVERS-3538

Depends on https://github.com/mongodb-js/devtools-shared/pull/770 which was released 5 days ago in mongodb-runner 6.8.1

## Summary

Bumps the `mongodb-runner` version from 6.7.1 to 6.8.2.

## Changes in this PR

Updated `_MR_VERSION` in `.evergreen/orchestration/mongodb_runner.py` from `"6.7.1"` to `"6.8.2"`.

## Test Plan

No functional changes; version bump only. Validated by existing CI.

## Checklist

### Checklist for Author

- [x] Does the title of the PR reference a JIRA Ticket?
- [x] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [x] Is all relevant documentation (README or docstring) updated?

### Checklist for Reviewer

- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?