### PR TITLE
DRIVERS-3558: skip mongodb-runner on unsupported platforms

### DIFF
--- a/.evergreen/orchestration/drivers_orchestration.py
+++ b/.evergreen/orchestration/drivers_orchestration.py
@@ -25,7 +25,7 @@ from pathlib import Path, PureWindowsPath
 import psutil
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from mongodb_runner import start_mongodb_runner
+from mongodb_runner import _mongodb_runner_supported, start_mongodb_runner
 
 # Get global values.
 HERE = Path(__file__).absolute().parent
@@ -497,6 +497,13 @@ def run(opts):
     if opts.mongodb_runner and version in ("3.6", "4.0"):
         LOGGER.warning(
             "mongodb-runner does not support MongoDB < 4.2, using mongo-orchestration"
+        )
+        opts.mongodb_runner = False
+
+    if opts.mongodb_runner and not _mongodb_runner_supported():
+        LOGGER.warning(
+            "mongodb-runner is not supported on this platform; "
+            "falling back to mongo-orchestration"
         )
         opts.mongodb_runner = False
 

--- a/.evergreen/orchestration/mongodb_runner.py
+++ b/.evergreen/orchestration/mongodb_runner.py
@@ -64,13 +64,30 @@ def _normalize_path(path: Union[Path, str]) -> str:
 _MR_VERSION = "6.8.2"
 
 
-def _install_mongodb_runner() -> Path:
-    """Install mongodb-runner via npm with overrides to pin @mongodb-js/oidc-mock-provider.
+def _mongodb_runner_supported() -> bool:
+    """Return False on platforms that cannot run the current mongodb-runner."""
+    if sys.platform != "linux":
+        return True
+    osr = next(
+        (
+            Path(p)
+            for p in ("/etc/os-release", "/usr/lib/os-release")
+            if Path(p).is_file()
+        ),
+        None,
+    )
+    if osr is None:
+        return True
+    try:
+        from mongodl import infer_target_from_os_release
 
-    npx does not support npm overrides, so we manage the install manually.
-    @mongodb-js/oidc-mock-provider 0.13.8+ switched to yargs@18 (ESM-only), which
-    cannot be require()'d on Node 16. Pinning to 0.13.7 keeps it on yargs@17.
-    """
+        return infer_target_from_os_release(osr) != "rhel7"
+    except Exception:
+        return True
+
+
+def _install_mongodb_runner() -> Path:
+    """Install mongodb-runner via npm, caching the install for reuse."""
     install_dir = TMPDIR / f"mongodb-runner-{_MR_VERSION}"
     ext = ".cmd" if PLATFORM == "win32" else ""
     runner_bin = install_dir / "node_modules" / ".bin" / f"mongodb-runner{ext}"
@@ -79,7 +96,6 @@ def _install_mongodb_runner() -> Path:
             "name": "mongodb-runner-wrapper",
             "version": "1.0.0",
             "dependencies": {"mongodb-runner": _MR_VERSION},
-            "overrides": {"@mongodb-js/oidc-mock-provider": "0.13.7"},
         }
         install_dir.mkdir(parents=True, exist_ok=True)
         (install_dir / "package.json").write_text(json.dumps(pkg, indent=2))

--- a/.evergreen/orchestration/mongodb_runner.py
+++ b/.evergreen/orchestration/mongodb_runner.py
@@ -87,7 +87,7 @@ def _mongodb_runner_supported() -> bool:
 
 
 def _install_mongodb_runner() -> Path:
-    """Install mongodb-runner via npm, caching the install for reuse."""
+    """Install mongodb-runner using npm, caching the install for reuse."""
     install_dir = TMPDIR / f"mongodb-runner-{_MR_VERSION}"
     ext = ".cmd" if PLATFORM == "win32" else ""
     runner_bin = install_dir / "node_modules" / ".bin" / f"mongodb-runner{ext}"

--- a/.evergreen/orchestration/mongodb_runner.py
+++ b/.evergreen/orchestration/mongodb_runner.py
@@ -65,24 +65,31 @@ _MR_VERSION = "6.8.2"
 
 
 def _mongodb_runner_supported() -> bool:
-    """Return False on platforms that cannot run the current mongodb-runner."""
+    """Return False on platforms that cannot run the current mongodb-runner.
+
+    mongodb-runner depends on yargs@18, an ESM-only package that Node < 18
+    cannot require(). Check the actual Node version when available; RHEL7
+    (whose Node 16 is the only such platform in CI) is used as a fallback
+    signal when Node isn't on PATH yet.
+    """
+    node = shutil.which("node")
+    if node:
+        try:
+            node_ver = subprocess.check_output([node, "--version"], encoding="utf-8")
+            if int(node_ver.strip().lstrip("v").split(".")[0]) < 18:
+                return False
+        except (subprocess.CalledProcessError, ValueError):
+            pass
     if sys.platform != "linux":
         return True
-    osr = next(
-        (
-            Path(p)
-            for p in ("/etc/os-release", "/usr/lib/os-release")
-            if Path(p).is_file()
-        ),
-        None,
-    )
-    if osr is None:
-        return True
     try:
-        from mongodl import infer_target_from_os_release
+        from mongodl import infer_target
 
-        return infer_target_from_os_release(osr) != "rhel7"
-    except Exception:
+        return infer_target() != "rhel7"
+    except Exception as exc:
+        LOGGER.warning(
+            "Could not determine platform for mongodb-runner support check: %s", exc
+        )
         return True
 
 

--- a/.evergreen/tests/test-install-binaries.sh
+++ b/.evergreen/tests/test-install-binaries.sh
@@ -6,28 +6,34 @@ SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
 
 pushd $SCRIPT_DIR/..
 
+# The system python3 may be too old (or missing); find a suitable one.
+. ./find-python3.sh
+PYTHON_BINARY=$(ensure_python3 2>/dev/null)
+PATH="$(dirname $PYTHON_BINARY):$PATH"
+
 ./install-node.sh
 . ./init-node-and-npm-env.sh
-MR_INSTALL_DIR=$(mktemp -d)
-case "$(uname -s)" in
-  CYGWIN*) MR_INSTALL_DIR=$(cygpath -m "$MR_INSTALL_DIR") ;;
-esac
-trap 'rm -rf "$MR_INSTALL_DIR"' EXIT
-printf '{"name":"t","version":"1.0.0","dependencies":{"mongodb-runner":"6.7.1"},"overrides":{"@mongodb-js/oidc-mock-provider":"0.13.7"}}' > "$MR_INSTALL_DIR/package.json"
-# Use a subshell + cd so npm install uses process.cwd() instead of --prefix,
-# which avoids MSYS2/Cygwin path translation issues on Windows.
-(cd "$MR_INSTALL_DIR" && npm install --silent)
-# Invoke node directly to bypass the .bin/ POSIX shim, which can fail on
-# Windows (CRLF shebang line or missing interpreter).
-node "$MR_INSTALL_DIR/node_modules/mongodb-runner/bin/runner.js" --help
+if "$PYTHON_BINARY" -c "
+import sys
+sys.path.insert(0, 'orchestration')
+from mongodb_runner import _mongodb_runner_supported
+sys.exit(0 if _mongodb_runner_supported() else 1)
+"; then
+  RUNNER_BIN=$("$PYTHON_BINARY" -c "
+import sys
+sys.path.insert(0, 'orchestration')
+from mongodb_runner import _install_mongodb_runner, _normalize_path
+print(_normalize_path(_install_mongodb_runner()))
+")
+  "$RUNNER_BIN" --help
+else
+  echo "mongodb-runner is not supported on this platform; skipping check"
+fi
 
 source ./install-rust.sh
 rustup install stable
 
 if [ ${OS:-} != "Windows_NT" ]; then
-  # Add a suitable python3 to the path.
-  PYTHON_BINARY=$(bash -c ". $SCRIPT_DIR/../find-python3.sh && ensure_python3 2>/dev/null")
-  PATH="$(dirname $PYTHON_BINARY):$PATH"
   case $(uname -m) in
     aarch64 | x86_64 | arm64)
       . ./ensure-binary.sh gcloud

--- a/.evergreen/tests/test-install-binaries.sh
+++ b/.evergreen/tests/test-install-binaries.sh
@@ -24,7 +24,7 @@ import sys
 sys.path.insert(0, 'orchestration')
 from mongodb_runner import _install_mongodb_runner, _normalize_path
 print(_normalize_path(_install_mongodb_runner()))
-")
+" | tr -d '\r')
   "$RUNNER_BIN" --help
 else
   echo "mongodb-runner is not supported on this platform; skipping check"

--- a/.evergreen/tests/test-install-binaries.sh
+++ b/.evergreen/tests/test-install-binaries.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eu
+set -eu -o pipefail
 
 SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
 . $SCRIPT_DIR/../handle-paths.sh
@@ -9,7 +9,11 @@ pushd $SCRIPT_DIR/..
 # The system python3 may be too old (or missing); find a suitable one.
 . ./find-python3.sh
 PYTHON_BINARY=$(ensure_python3 2>/dev/null)
-PATH="$(dirname $PYTHON_BINARY):$PATH"
+if [ -z "$PYTHON_BINARY" ]; then
+  echo "No suitable python3 binary found" >&2
+  exit 1
+fi
+PATH="$(dirname "$PYTHON_BINARY"):$PATH"
 
 ./install-node.sh
 . ./init-node-and-npm-env.sh
@@ -19,13 +23,19 @@ sys.path.insert(0, 'orchestration')
 from mongodb_runner import _mongodb_runner_supported
 sys.exit(0 if _mongodb_runner_supported() else 1)
 "; then
-  RUNNER_BIN=$("$PYTHON_BINARY" -c "
+  # Invoke node directly on the installed runner.js rather than the npm .bin
+  # shim, which can fail on Windows (CRLF shebang line or missing interpreter).
+  RUNNER_JS=$("$PYTHON_BINARY" -c "
+import shutil
 import sys
 sys.path.insert(0, 'orchestration')
-from mongodb_runner import _install_mongodb_runner, _normalize_path
-print(_normalize_path(_install_mongodb_runner()))
+from mongodb_runner import _MR_VERSION, TMPDIR, _install_mongodb_runner, _normalize_path
+shutil.rmtree(TMPDIR / f'mongodb-runner-{_MR_VERSION}', ignore_errors=True)
+runner_bin = _install_mongodb_runner()
+runner_js = runner_bin.parent.parent / 'mongodb-runner' / 'bin' / 'runner.js'
+print(_normalize_path(runner_js))
 " | tr -d '\r')
-  "$RUNNER_BIN" --help
+  node "$RUNNER_JS" --help
 else
   echo "mongodb-runner is not supported on this platform; skipping check"
 fi


### PR DESCRIPTION
DRIVERS-3558

## Summary

Platforms that can't run the current mongodb-runner now fall back to mongo-orchestration automatically, rather than relying on npm overrides to work around version incompatibilities.

## Changes in this PR

- Replaces the npm overrides workaround with a platform capability check that falls back to mongo-orchestration when unsupported, checking the actual Node version rather than only distro name so the check generalizes beyond RHEL7.
- Hardens the install-binaries test script (Windows-safe invocation, clearer failure on a missing Python binary, and always exercising a fresh install).

## Test Plan

- Updated `.evergreen/tests/test-install-binaries.sh` to exercise the real install/support-check code path.
- Ran `pre-commit run` on all changed files (shellcheck, ruff, ruff-format, etc.) — all passing.
- Verified locally that the platform check and install-and-run path work end-to-end.

## Checklist

### Checklist for Author

- [x] Does the title of the PR reference a JIRA Ticket?
- [x] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [x] Is all relevant documentation (README or docstring) updated?

### Checklist for Reviewer

- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?
