### PR TITLE
bump markdown-checker to 1.3.1

### DIFF
--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -4,9 +4,17 @@ on:
   pull_request:
     branches:
       - "master"
+    paths:
+      - '**.md'
+      - '**.ipynb'
+      - '.github/workflows/markdown.yml'
   push:
     branches:
       - "master"
+    paths:
+      - '**.md'
+      - '**.ipynb'
+      - '.github/workflows/markdown.yml'
 
 concurrency:
   group: markdown-${{ github.ref }}
@@ -23,10 +31,10 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v6"
+        uses: "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
 
       - name: "Check Markdown"
-        uses: "john0isaac/action-check-markdown@274ad7e69a147c37274e1a94fb01ddb175c57bed"
+        uses: "john0isaac/action-check-markdown@c255625e4ae89924a5f39a440a22e51fcc9f5893"
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           command: check_broken_paths


### PR DESCRIPTION
Hey 👋🏼,
Thank you for using the tool.
I recently used zizmor to audit the package and fixed all the issues it flagged.

This update includes:
- Sticky comments, only one comment will be posted per command used instead of spamming the pull request with every push.
- zizmor security fixes.
- Only posting comments to pull requests for push we update summary of job and mark it as failed/succeed.
- I pinned `markdown-checker` the python package behind this tool since I saw unpinned dependencies causing lots of issues everywhere.
- Due to `pull_request: write` GitHub restrictions it's no longer required since commenting won't work unless the pull request is not from a fork. only updating the summary and GitHub annotations.

For more info check: https://markdown-checker.readthedocs.io/en/latest/howto/github-actions/

For your action setup specifically, I also:
- restricted the action to only run on changes from `.md` and `.ipynb` files.
- Update checkout action to latest.