### PR TITLE
DRIVERS-3565: Pin the npm version per Node release

### DIFF
--- a/.evergreen/install-node.sh
+++ b/.evergreen/install-node.sh
@@ -25,7 +25,7 @@ fi
 NODE_LTS_VERSION=${NODE_LTS_VERSION:-$DEFAULT_NODE_VERSION}
 
 # Pin npm per Node release to the newest npm that still supports it, so setup
-# never pulls an incompatible npm@latest.
+# never pulls an incompatible npm@latest. Do not override if it is already set.
 if [[ "$NODE_LTS_VERSION" =~ ^[0-9]+$ && "$NODE_LTS_VERSION" -lt 18 ]]; then
   NPM_VERSION=${NPM_VERSION:-9}
 elif [[ "$NODE_LTS_VERSION" =~ ^[0-9]+$ && "$NODE_LTS_VERSION" -lt 20 ]]; then

--- a/.evergreen/install-node.sh
+++ b/.evergreen/install-node.sh
@@ -24,12 +24,14 @@ if command -v ldd >/dev/null 2>&1; then
 fi
 NODE_LTS_VERSION=${NODE_LTS_VERSION:-$DEFAULT_NODE_VERSION}
 
-# If NODE_LTS_VERSION is numeric and less than 18, default to 9, if less than 20, default to 10.
-# Do not override if it is already set.
+# Pin npm per Node release to the newest npm that still supports it, so setup
+# never pulls an incompatible npm@latest.
 if [[ "$NODE_LTS_VERSION" =~ ^[0-9]+$ && "$NODE_LTS_VERSION" -lt 18 ]]; then
   NPM_VERSION=${NPM_VERSION:-9}
 elif [[ "$NODE_LTS_VERSION" =~ ^[0-9]+$ && "$NODE_LTS_VERSION" -lt 20 ]]; then
   NPM_VERSION=${NPM_VERSION:-10}
+elif [[ "$NODE_LTS_VERSION" =~ ^[0-9]+$ && "$NODE_LTS_VERSION" -lt 22 ]]; then
+  NPM_VERSION=${NPM_VERSION:-11}
 else
   NPM_VERSION=${NPM_VERSION:-latest}
 fi
@@ -157,7 +159,7 @@ echo "$NODE_LTS_VERSION" > $NODE_ARTIFACTS_PATH/node-version.txt
 echo "Installing Node.js $NODE_LTS_VERSION... done."
 
 if [[ $operating_system != "win" ]]; then
-  # Update npm to latest when we can
+  # Update npm to the newest version supported by this Node release.
   echo "Installing npm $NPM_VERSION..."
   npm install --silent --global npm@$NPM_VERSION
   hash -r


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Please ensure that the title of the PR is in the following form:
[JIRA TICKET]: Issue Title
-->

DRIVERS-3565

## Summary

<!-- What is this PR introducing? If context is already provided from the JIRA ticket, still place it in the Pull Request as you should not make the reviewer do digging for a basic summary. -->

Setting up a local MongoDB server through DET fails when the environment uses Node 20. During setup, DET upgrades npm to the "latest" version, but the newly released npm 12 no longer supports Node 20.

Release notes: https://github.com/npm/cli/releases/tag/v12.0.0

## Changes in this PR

Pin the npm version per Node release so setup never uses an incompatible "latest" release.

## Test Plan

<!-- How did you test the code? If you added unit tests, you can say that. If you didn’t introduce unit tests, explain why. All code should be tested in some way – so please list what your validation strategy was. -->

```
MONGODB_VERSION="latest" TOPOLOGY=replica_set ./run-server.sh
```

## Checklist

<!-- Do not delete the items provided on this checklist -->

### Checklist for Author

- [x] Does the title of the PR reference a JIRA Ticket?
- [x] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [x] Is all relevant documentation (README or docstring) updated?

### Checklist for Reviewer

- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?
