### PR TITLE
Add `--no-project` to oneshot `python` command

### DIFF
--- a/.evergreen/atlas/atlas-utils.sh
+++ b/.evergreen/atlas/atlas-utils.sh
@@ -83,7 +83,7 @@ check_deployment ()
         else
             PROP="['srvAddress']"
         fi
-        SRV_ADDRESS=$(uv run python -c "import json,sys;d=json.loads(sys.argv[1]);print(d${PROP})" "${RESP}")
+        SRV_ADDRESS=$(uv run --no-project python -c "import json,sys;d=json.loads(sys.argv[1]);print(d${PROP})" "${RESP}")
         # Remove trailing CR
         if [[ "$(uname -s)" == CYGWIN* ]]; then
             SRV_ADDRESS=$(echo $SRV_ADDRESS | dos2unix)


### PR DESCRIPTION
Minor followup to https://github.com/mongodb-labs/drivers-evergreen-tools/pull/808 which missed [a suggestion](https://github.com/mongodb-labs/drivers-evergreen-tools/pull/808#discussion_r3683854036).