### PR TITLE
DRIVERS-3595: Prefer docker over podman on GitHub Actions

### DIFF
--- a/.evergreen/orchestration/drivers_orchestration.py
+++ b/.evergreen/orchestration/drivers_orchestration.py
@@ -210,7 +210,11 @@ def get_options():
 @functools.lru_cache(maxsize=1)
 def get_docker_cmd():
     """Get the appropriate docker command, or None if neither daemon is available."""
-    for raw_binary in (shutil.which("podman"), shutil.which("docker")):
+    if "GITHUB_ACTION" in os.environ:
+        binaries = (shutil.which("docker"), shutil.which("podman"))
+    else:
+        binaries = (shutil.which("podman"), shutil.which("docker"))
+    for raw_binary in binaries:
         if not raw_binary:
             continue
         binary = PureWindowsPath(raw_binary).as_posix()


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/DRIVERS-3595

## Summary

Podman intermittently fails to start containers on some GitHub-hosted `ubuntu-24.04` runners, causing flaky `local-atlas` job failures. Docker is preinstalled and stable on these runners, so it's now preferred there.

## Test Plan

Verified locally that `get_docker_cmd()` prefers docker under a simulated GitHub Actions environment, and that `start_atlas` runs end-to-end successfully (container starts, health check passes via the image's own healthcheck, mongosh connects). Podman-specific behavior on Evergreen (sudo, `--health-cmd`, `podman healthcheck run`) is unaffected.

I also ran GitHub Actions three times successfully.

## Checklist

### Checklist for Author

- [x] Does the title of the PR reference a JIRA Ticket?
- [x] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [x] Is all relevant documentation (README or docstring) updated?

### Checklist for Reviewer

- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?