### PR TITLE
DRIVERS-3564: Reuse an existing --user uv install instead of reinstalling it

### DIFF
--- a/.evergreen/ensure-uv.sh
+++ b/.evergreen/ensure-uv.sh
@@ -70,19 +70,13 @@ _ensure_uv_add_user_base() {
   user_base="$("$1" -m site --user-base 2>/dev/null)" || return 0
   [ -n "$user_base" ] || return 0
 
-  # Build the prefix first and prepend it once, so "bin" keeps precedence over
-  # "Scripts" as it would with a single assignment; prepending in a loop would
-  # reverse them.
-  declare _prefix="" _dir
-  for _dir in "$user_base/bin" "$user_base/Scripts"; do
-    case ":${PATH:-}:" in
-    *":${_dir}:"*) ;;
-    *) _prefix="${_prefix}${_dir}:" ;;
-    esac
-  done
-  if [ -n "$_prefix" ]; then
-    export PATH="${_prefix}${PATH:-}"
-  fi
+  # Both are added together and only one of them exists on any given platform,
+  # so either serves as a sentinel for "already added" -- which keeps repeated
+  # calls from growing PATH without end.
+  case ":${PATH:-}:" in
+  *":$user_base/bin:"*) ;;
+  *) export PATH="$user_base/bin:$user_base/Scripts:${PATH:-}" ;;
+  esac
 }
 
 # ensure_uv

--- a/.evergreen/ensure-uv.sh
+++ b/.evergreen/ensure-uv.sh
@@ -67,7 +67,7 @@ _ensure_uv_scope_paths() {
 # A no-op if the interpreter cannot report it. Not meant to be called directly.
 _ensure_uv_add_user_base() {
   declare user_base
-  user_base="$("$1" -m site --user-base 2>/dev/null)" || return 0
+  user_base="$("${1:?}" -m site --user-base 2>/dev/null)" || return 0
   [ -n "$user_base" ] || return 0
 
   # Both are added together and only one of them exists on any given platform,

--- a/.evergreen/ensure-uv.sh
+++ b/.evergreen/ensure-uv.sh
@@ -57,6 +57,28 @@ _ensure_uv_scope_paths() {
   export UV_TOOL_DIR="${DRIVERS_TOOLS}/.local/uv-tool"
 }
 
+# _ensure_uv_add_user_base (internal)
+#
+# Prepend $1's `pip install --user` script directory to PATH, if not already
+# there. That directory is version/platform specific (~/.local/bin on Linux,
+# ~/Library/Python/X.Y/bin on macOS, %APPDATA%\Python\PythonXY\Scripts on
+# Windows), so ask the interpreter rather than assuming.
+#
+# A no-op if the interpreter cannot report it. Not meant to be called directly.
+_ensure_uv_add_user_base() {
+  declare user_base
+  user_base="$("$1" -m site --user-base 2>/dev/null)" || return 0
+  [ -n "$user_base" ] || return 0
+
+  declare _dir
+  for _dir in "$user_base/bin" "$user_base/Scripts"; do
+    case ":${PATH:-}:" in
+    *":${_dir}:"*) ;;
+    *) export PATH="${_dir}:${PATH:-}" ;;
+    esac
+  done
+}
+
 # ensure_uv
 #
 # Usage:
@@ -118,6 +140,19 @@ ensure_uv() {
     fi
   fi
 
+  # An earlier ensure_uv call may have already installed uv into the `--user`
+  # script directory. That PATH addition does not outlive the shell it ran in,
+  # and on hosts where the directory is not on the default PATH (e.g. RHEL7,
+  # where it is /root/.local/bin) every later script would otherwise pay for
+  # another pip install. Look there before reinstalling.
+  if [ -n "$py" ]; then
+    _ensure_uv_add_user_base "$py"
+    if uv --version >/dev/null 2>&1; then
+      _ensure_uv_scope_paths
+      return 0
+    fi
+  fi
+
   if [ -n "$py" ]; then
     echo "uv not found on PATH; installing with '$py -m pip install --user uv'..." >&2
 
@@ -136,15 +171,7 @@ ensure_uv() {
     PIP_BREAK_SYSTEM_PACKAGES=1 "$py" -m pip install --user -q --upgrade pip || true
     PIP_BREAK_SYSTEM_PACKAGES=1 "$py" -m pip install --user -q uv || true
 
-    # `--user` installs console scripts into a version/platform-specific
-    # directory (e.g. ~/.local/bin on Linux, ~/Library/Python/X.Y/bin on
-    # macOS, %APPDATA%\Python\PythonXY\Scripts on Windows); ask the
-    # interpreter where that is rather than assuming.
-    declare user_base
-    user_base="$("$py" -m site --user-base 2>/dev/null)" || user_base=""
-    if [ -n "$user_base" ]; then
-      export PATH="$user_base/bin:$user_base/Scripts:$PATH"
-    fi
+    _ensure_uv_add_user_base "$py"
   fi
 
   if uv --version >/dev/null 2>&1; then

--- a/.evergreen/ensure-uv.sh
+++ b/.evergreen/ensure-uv.sh
@@ -70,13 +70,19 @@ _ensure_uv_add_user_base() {
   user_base="$("$1" -m site --user-base 2>/dev/null)" || return 0
   [ -n "$user_base" ] || return 0
 
-  declare _dir
+  # Build the prefix first and prepend it once, so "bin" keeps precedence over
+  # "Scripts" as it would with a single assignment; prepending in a loop would
+  # reverse them.
+  declare _prefix="" _dir
   for _dir in "$user_base/bin" "$user_base/Scripts"; do
     case ":${PATH:-}:" in
     *":${_dir}:"*) ;;
-    *) export PATH="${_dir}:${PATH:-}" ;;
+    *) _prefix="${_prefix}${_dir}:" ;;
     esac
   done
+  if [ -n "$_prefix" ]; then
+    export PATH="${_prefix}${PATH:-}"
+  fi
 }
 
 # ensure_uv


### PR DESCRIPTION
DRIVERS-3564

## Summary

`ensure_uv` reinstalls uv on hosts where the `pip install --user` script
directory isn't on the default `PATH`, because the `PATH` it sets doesn't
outlive the shell. On rhel7 a single `test-mongodb-runner-partial` task ran
`pip install --user uv` 15 times, roughly 15–20s of a 3m11s task.

## Changes in this PR

`ensure_uv` now looks for an already-installed uv in that directory before
falling back to installing one.

## Test Plan

No unit tests exist for these shell helpers, so each branch was exercised
directly, reproducing the rhel7 condition locally:

- uv present but directory off `PATH`: reused, no install
- uv already on `PATH`: unchanged
- called repeatedl: `PATH` does not grow
- uv genuinely absent: still installs, then fails with the same actionable error

Confirmed in CI on the rhel7 variant: `installing with ... pip install --user uv`
now appears **once** per task instead of 15 times, with the 17 later invocations
resolving the existing install instead. The task ran in 2m40s vs 3m11s before.

## Checklist

### Checklist for Author

- [x] Does the title of the PR reference a JIRA Ticket?
- [x] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [x] Is all relevant documentation (README or docstring) updated?

### Checklist for Reviewer

- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?
