### PR TITLE
PYTHON-5985: install python3-pip on gcpkms/azurekms remote VMs

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -554,6 +554,13 @@ functions:
         include_expansions_in_env: [AWS_SECRET_ACCESS_KEY, AWS_ACCESS_KEY_ID, AWS_SESSION_TOKEN]
         args: [src/.evergreen/tests/test-csfle.sh]
 
+  "run remote kms provisioning test":
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: bash
+        args: [src/.evergreen/tests/test-remote-kms-provisioning.sh]
+
   "run mongodb runner test partial":
     - command: subprocess.exec
       type: test
@@ -1028,6 +1035,11 @@ tasks:
       tags: ["pr"]
       commands:
         - func: "run csfle test"
+
+    - name: "test-remote-kms-provisioning"
+      tags: ["docker", "pr"]
+      commands:
+        - func: "run remote kms provisioning test"
 
     - name: "test-legacy-versions"
       commands:

--- a/.evergreen/csfle/azurekms/create-and-setup-vm.sh
+++ b/.evergreen/csfle/azurekms/create-and-setup-vm.sh
@@ -45,8 +45,8 @@ for VARNAME in "${VARLIST[@]}"; do
 done
 
 # Set defaults.
-# If this default changes, update the base image in
-# .evergreen/tests/docker/remote-kms-provisioning.Dockerfile to match.
+# If this default changes, update the azurekms base_image in
+# .evergreen/tests/test-remote-kms-provisioning.sh to match.
 export AZUREKMS_IMAGE=${AZUREKMS_IMAGE:-"Debian:debian-11:11:0.20221020.1174"}
 
 # Login.

--- a/.evergreen/csfle/azurekms/create-and-setup-vm.sh
+++ b/.evergreen/csfle/azurekms/create-and-setup-vm.sh
@@ -45,6 +45,8 @@ for VARNAME in "${VARLIST[@]}"; do
 done
 
 # Set defaults.
+# If this default changes, update the base image in
+# .evergreen/tests/docker/remote-kms-provisioning.Dockerfile to match.
 export AZUREKMS_IMAGE=${AZUREKMS_IMAGE:-"Debian:debian-11:11:0.20221020.1174"}
 
 # Login.

--- a/.evergreen/csfle/azurekms/remote-scripts/setup-azure-vm.sh
+++ b/.evergreen/csfle/azurekms/remote-scripts/setup-azure-vm.sh
@@ -18,5 +18,5 @@ OPTIONS="-qq -y -o DPkg::Lock::Timeout=-1"
 # Dependencies for mongod: https://www.mongodb.com/docs/manual/tutorial/install-mongodb-enterprise-on-debian-tarball/
 sudo DEBIAN_FRONTEND=noninteractive apt-get $OPTIONS install libcurl4 libgssapi-krb5-2 libldap-common libwrap0 libsasl2-2 libsasl2-modules libsasl2-modules-gssapi-mit openssl liblzma5 < /dev/null > /dev/null
 # Dependencies for drivers-evergreen-tools
-sudo DEBIAN_FRONTEND=noninteractive apt-get $OPTIONS install python3 python3-venv git < /dev/null > /dev/null
+sudo DEBIAN_FRONTEND=noninteractive apt-get $OPTIONS install python3 python3-venv python3-pip git < /dev/null > /dev/null
 echo "Installing dependencies ... end"

--- a/.evergreen/csfle/gcpkms/create-and-setup-instance.sh
+++ b/.evergreen/csfle/gcpkms/create-and-setup-instance.sh
@@ -43,6 +43,8 @@ chmod 600 $GCPKMS_KEYFILE
 export GCPKMS_PROJECT=${GCPKMS_PROJECT:-"devprod-drivers"}
 export GCPKMS_ZONE=${GCPKMS_ZONE:-"us-east1-b"}
 export GCPKMS_IMAGEPROJECT=${GCPKMS_IMAGEPROJECT:-"debian-cloud"}
+# If this default changes, update the base image in
+# .evergreen/tests/docker/remote-kms-provisioning.Dockerfile to match.
 export GCPKMS_IMAGEFAMILY=${GCPKMS_IMAGEFAMILY:-"debian-11"}
 export GCPKMS_MACHINETYPE=${GCPKMS_MACHINETYPE:-"e2-micro"}
 export GCPKMS_DISKSIZE=${GCPKMS_DISKSIZE:-"20gb"}

--- a/.evergreen/csfle/gcpkms/create-and-setup-instance.sh
+++ b/.evergreen/csfle/gcpkms/create-and-setup-instance.sh
@@ -43,8 +43,8 @@ chmod 600 $GCPKMS_KEYFILE
 export GCPKMS_PROJECT=${GCPKMS_PROJECT:-"devprod-drivers"}
 export GCPKMS_ZONE=${GCPKMS_ZONE:-"us-east1-b"}
 export GCPKMS_IMAGEPROJECT=${GCPKMS_IMAGEPROJECT:-"debian-cloud"}
-# If this default changes, update the base image in
-# .evergreen/tests/docker/remote-kms-provisioning.Dockerfile to match.
+# If this default changes, update the gcpkms base_image in
+# .evergreen/tests/test-remote-kms-provisioning.sh to match.
 export GCPKMS_IMAGEFAMILY=${GCPKMS_IMAGEFAMILY:-"debian-11"}
 export GCPKMS_MACHINETYPE=${GCPKMS_MACHINETYPE:-"e2-micro"}
 export GCPKMS_DISKSIZE=${GCPKMS_DISKSIZE:-"20gb"}

--- a/.evergreen/csfle/gcpkms/remote-scripts/setup-gce-instance.sh
+++ b/.evergreen/csfle/gcpkms/remote-scripts/setup-gce-instance.sh
@@ -13,5 +13,5 @@ OPTIONS="-y -qq -o DPkg::Lock::Timeout=-1"
 # Dependencies for mongod: https://www.mongodb.com/docs/manual/tutorial/install-mongodb-enterprise-on-debian-tarball/
 sudo DEBIAN_FRONTEND=noninteractive apt-get $OPTIONS install libcurl4 libgssapi-krb5-2 libldap-common libwrap0 libsasl2-2 libsasl2-modules libsasl2-modules-gssapi-mit openssl liblzma5 < /dev/null > /dev/null
 # Dependencies for drivers-evergreen-tools
-sudo DEBIAN_FRONTEND=noninteractive apt-get $OPTIONS install python3 python3-venv git < /dev/null > /dev/null
+sudo DEBIAN_FRONTEND=noninteractive apt-get $OPTIONS install python3 python3-venv python3-pip git < /dev/null > /dev/null
 echo "Installing dependencies ... end"

--- a/.evergreen/tests/docker/remote-kms-provisioning.Dockerfile
+++ b/.evergreen/tests/docker/remote-kms-provisioning.Dockerfile
@@ -1,0 +1,10 @@
+# Mirrors the environment the gcpkms/azurekms remote-scripts actually run in:
+# a fresh Debian 11 host, reached as a non-root user with passwordless sudo.
+FROM debian:11
+# man-db ships preinstalled on the real GCE/Azure base images; the
+# remote-scripts assume it's there when they silence its update trigger.
+RUN apt-get update && apt-get install -y sudo man-db && \
+    useradd -m -s /bin/bash remote && \
+    echo "remote ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/remote
+USER remote
+WORKDIR /home/remote

--- a/.evergreen/tests/docker/remote-kms-provisioning.Dockerfile
+++ b/.evergreen/tests/docker/remote-kms-provisioning.Dockerfile
@@ -1,6 +1,8 @@
 # Mirrors the environment the gcpkms/azurekms remote-scripts actually run in:
-# a fresh Debian 11 host, reached as a non-root user with passwordless sudo.
-FROM debian:11
+# a fresh host reached as a non-root user with passwordless sudo. BASE_IMAGE
+# lets gcpkms and azurekms test against their own default VM image versions.
+ARG BASE_IMAGE=debian:11
+FROM ${BASE_IMAGE}
 # man-db ships preinstalled on the real GCE/Azure base images; the
 # remote-scripts assume it's there when they silence its update trigger.
 RUN apt-get update && apt-get install -y sudo man-db && \

--- a/.evergreen/tests/test-remote-kms-provisioning.sh
+++ b/.evergreen/tests/test-remote-kms-provisioning.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Smoke-tests that the gcpkms/azurekms remote-scripts leave a host in a state
+# where ensure_uv succeeds, without needing a real GCE/Azure VM. Runs each
+# script's dependency-install step in a container and then calls ensure_uv.
+set -eu
+
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+IMAGE=drivers-tools-remote-kms-provisioning-test
+
+docker build -q -t "$IMAGE" -f "$SCRIPT_DIR/docker/remote-kms-provisioning.Dockerfile" "$SCRIPT_DIR/docker"
+
+test_provisioning() {
+  local name="$1" script="$2"
+  echo "Testing $name provisioning ..."
+  docker run --rm -v "$ROOT_DIR:/drivers-tools:ro" "$IMAGE" bash -c "
+    set -e
+    cp -r /drivers-tools ~/drivers-tools
+    cd ~/drivers-tools
+    bash $script
+    . .evergreen/ensure-uv.sh
+    ensure_uv
+    uv --version
+  "
+  echo "Testing $name provisioning ... done."
+}
+
+test_provisioning gcpkms .evergreen/csfle/gcpkms/remote-scripts/setup-gce-instance.sh
+test_provisioning azurekms .evergreen/csfle/azurekms/remote-scripts/setup-azure-vm.sh

--- a/.evergreen/tests/test-remote-kms-provisioning.sh
+++ b/.evergreen/tests/test-remote-kms-provisioning.sh
@@ -20,12 +20,12 @@ if [ -n "${DOCKER_COMMAND:-}" ]; then
   DOCKER=$DOCKER_COMMAND
 fi
 
-$DOCKER build -q -t "$IMAGE" -f "$SCRIPT_DIR/docker/remote-kms-provisioning.Dockerfile" "$SCRIPT_DIR/docker"
-
 test_provisioning() {
-  local name="$1" script="$2"
-  echo "Testing $name provisioning ..."
-  $DOCKER run --rm -v "$ROOT_DIR:/drivers-tools:ro" "$IMAGE" bash -c "
+  local name="$1" script="$2" base_image="$3"
+  echo "Testing $name provisioning ($base_image) ..."
+  $DOCKER build -q -t "$IMAGE-$name" --build-arg BASE_IMAGE="$base_image" \
+    -f "$SCRIPT_DIR/docker/remote-kms-provisioning.Dockerfile" "$SCRIPT_DIR/docker"
+  $DOCKER run --rm -v "$ROOT_DIR:/drivers-tools:ro" "$IMAGE-$name" bash -c "
     set -e
     cp -r /drivers-tools ~/drivers-tools
     cd ~/drivers-tools
@@ -37,5 +37,7 @@ test_provisioning() {
   echo "Testing $name provisioning ... done."
 }
 
-test_provisioning gcpkms .evergreen/csfle/gcpkms/remote-scripts/setup-gce-instance.sh
-test_provisioning azurekms .evergreen/csfle/azurekms/remote-scripts/setup-azure-vm.sh
+# Keep these in sync with the defaults in create-and-setup-instance.sh
+# (GCPKMS_IMAGEFAMILY) and create-and-setup-vm.sh (AZUREKMS_IMAGE).
+test_provisioning gcpkms .evergreen/csfle/gcpkms/remote-scripts/setup-gce-instance.sh debian:11
+test_provisioning azurekms .evergreen/csfle/azurekms/remote-scripts/setup-azure-vm.sh debian:11

--- a/.evergreen/tests/test-remote-kms-provisioning.sh
+++ b/.evergreen/tests/test-remote-kms-provisioning.sh
@@ -9,12 +9,23 @@ SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 IMAGE=drivers-tools-remote-kms-provisioning-test
 
-docker build -q -t "$IMAGE" -f "$SCRIPT_DIR/docker/remote-kms-provisioning.Dockerfile" "$SCRIPT_DIR/docker"
+# Some Evergreen hosts (e.g. RHEL) only ship podman, not docker; matches the
+# engine selection in .evergreen/docker/run-server.sh.
+if command -v podman &> /dev/null; then
+  DOCKER="sudo podman --storage-opt ignore_chown_errors=true"
+else
+  DOCKER=docker
+fi
+if [ -n "${DOCKER_COMMAND:-}" ]; then
+  DOCKER=$DOCKER_COMMAND
+fi
+
+$DOCKER build -q -t "$IMAGE" -f "$SCRIPT_DIR/docker/remote-kms-provisioning.Dockerfile" "$SCRIPT_DIR/docker"
 
 test_provisioning() {
   local name="$1" script="$2"
   echo "Testing $name provisioning ..."
-  docker run --rm -v "$ROOT_DIR:/drivers-tools:ro" "$IMAGE" bash -c "
+  $DOCKER run --rm -v "$ROOT_DIR:/drivers-tools:ro" "$IMAGE" bash -c "
     set -e
     cp -r /drivers-tools ~/drivers-tools
     cd ~/drivers-tools


### PR DESCRIPTION
## Summary

DRIVERS-3564 switched `ensure_uv()` to bootstrap `uv` with `pip`, but the gcpkms/azurekms remote-VM scripts never installed `pip`. This broke downstream KMS tests, e.g. [PYTHON-5985](https://jira.mongodb.org/browse/PYTHON-5985).

## Changes in this PR

- Add `python3-pip` to `setup-gce-instance.sh` and `setup-azure-vm.sh`.
- Add a Docker-based smoke test (`test-remote-kms-provisioning`) that catches this without a real GCE/Azure VM, wired into CI.

## Test Plan

Ran the new test locally: fails with the original error when the fix is reverted, passes with it applied.

## Checklist

### Checklist for Author

- [x] Does the title of the PR reference a JIRA Ticket?
- [x] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [x] Is all relevant documentation (README or docstring) updated?
- [x] New tests are passing

### Checklist for Reviewer

- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?