### PR TITLE
DRIVERS-3564: Install uv into a virtual environment when there is no system pip

### DIFF
--- a/.evergreen/ensure-uv.sh
+++ b/.evergreen/ensure-uv.sh
@@ -57,26 +57,33 @@ _ensure_uv_scope_paths() {
   export UV_TOOL_DIR="${DRIVERS_TOOLS}/.local/uv-tool"
 }
 
-# _ensure_uv_add_user_base (internal)
+# _ensure_uv_add_path (internal)
 #
-# Prepend $1's `pip install --user` script directory to PATH, if not already
-# there. That directory is version/platform specific (~/.local/bin on Linux,
-# ~/Library/Python/X.Y/bin on macOS, %APPDATA%\Python\PythonXY\Scripts on
-# Windows), so ask the interpreter rather than assuming.
+# Prepend $1 to PATH unless it is already there, which keeps repeated ensure_uv
+# calls from growing PATH without end. Not meant to be called directly.
+_ensure_uv_add_path() {
+  declare dir="${1:?}"
+  case ":${PATH:-}:" in
+  *":$dir:"*) ;;
+  *) export PATH="$dir:${PATH:-}" ;;
+  esac
+}
+
+# _ensure_uv_add_user_bin (internal)
+#
+# Put $1's `pip install --user` script directory on PATH. That directory is
+# version and platform specific (~/.local/bin on Linux, ~/Library/Python/X.Y/bin
+# on macOS, %APPDATA%\Python\PythonXY\Scripts on Windows), so ask the interpreter
+# rather than assuming. Only one of bin/Scripts exists on any given platform, so
+# adding both is harmless.
 #
 # A no-op if the interpreter cannot report it. Not meant to be called directly.
-_ensure_uv_add_user_base() {
-  declare user_base
-  user_base="$("${1:?}" -m site --user-base 2>/dev/null)" || return 0
-  [ -n "$user_base" ] || return 0
-
-  # Both are added together and only one of them exists on any given platform,
-  # so either serves as a sentinel for "already added" -- which keeps repeated
-  # calls from growing PATH without end.
-  case ":${PATH:-}:" in
-  *":$user_base/bin:"*) ;;
-  *) export PATH="$user_base/bin:$user_base/Scripts:${PATH:-}" ;;
-  esac
+_ensure_uv_add_user_bin() {
+  declare base
+  base="$("${1:?}" -m site --user-base 2>/dev/null)" || return 0
+  [ -n "$base" ] || return 0
+  _ensure_uv_add_path "$base/bin"
+  _ensure_uv_add_path "$base/Scripts"
 }
 
 # ensure_uv
@@ -84,24 +91,34 @@ _ensure_uv_add_user_base() {
 # Usage:
 #   ensure_uv
 #
-# Return 0 (true) if `uv` is available on PATH, installing it with
-# `pip install --user uv` if it was not already present.
+# Return 0 (true) if `uv` is available on PATH, installing it if it was not
+# already present.
 # Return a non-zero value (false) otherwise, after printing an actionable
 # error message to stderr.
 #
 # Sets the following environment variables:
 #
 # - PYENV_VERSION (only when pyenv is installed)
-# - PATH (only when uv had to be installed)
+# - PATH (~/.local/bin, the venv, and pip's `--user` script directory)
 # - UV_TOOL_DIR (only when $DRIVERS_TOOLS is set)
 # - UV_CACHE_DIR, UV_PYTHON_INSTALL_DIR (additionally require $CI to be set)
 #
-# This mainly checks PATH and falls back to a plain `pip install --user`.
-# The one exception is a fallback to the MongoDB toolchain's python3, needed
-# on hosts (e.g. RHEL7) that have no python3 on PATH at all.
+# First look everywhere uv may already be: PATH, ~/.local/bin where uv's own
+# installer puts it, and the two places an earlier call may have installed it.
+# Failing that, install it with `pip install --user`, and failing that into a
+# virtual environment under $TMPDIR.
 #
-# On success, also relocates uv's shared state into the checkout; see
-# _ensure_uv_scope_paths above for exactly what is scoped and when.
+# Both install paths are load-bearing because the host fleet is split. Evergreen's
+# debian11 images have python3-pip but no python3-venv, so a venv cannot be built
+# there. The remote KMS VMs have python3-venv but no python3-pip, and Debian and
+# Ubuntu disable `ensurepip` for the system python, so no pip can be bootstrapped
+# there.
+#
+# The one wrinkle is a fallback to the MongoDB toolchain's python3, needed on
+# hosts (e.g. RHEL7) that have no python3 on PATH at all.
+#
+# On success, also relocates uv's shared state; see _ensure_uv_scope_paths above
+# for exactly what is scoped and when.
 ensure_uv() {
   # Some hosts (e.g. RHEL8 zseries/power8) have pyenv installed, whose shims
   # intercept `python`/`python3`/`uv` and enforce whichever .python-version
@@ -118,12 +135,15 @@ ensure_uv() {
     [ -n "$pyenv_global" ] && export PYENV_VERSION="$pyenv_global"
   fi
 
-  if uv --version >/dev/null 2>&1; then
-    _ensure_uv_scope_paths
-    return 0
-  fi
+  # Kept stable rather than mktemp'd so a later ensure_uv call in a fresh shell
+  # reuses the venv instead of rebuilding it. Under CI, Evergreen points TMPDIR at
+  # a per-task directory, so the venv is recycled with the task and stays out of
+  # the failure artifacts, which are packed from $DRIVERS_TOOLS and
+  # $PROJECT_DIRECTORY.
+  declare venv_dir="${TMPDIR:-/tmp}"
+  venv_dir="${venv_dir%/}/drivers-tools-uv-venv"
 
-  local py=""
+  declare py=""
   if command -v python3 >/dev/null 2>&1; then
     py=python3
   else
@@ -140,38 +160,64 @@ ensure_uv() {
     fi
   fi
 
-  # An earlier ensure_uv call may have already installed uv into the `--user`
-  # script directory. That PATH addition does not outlive the shell it ran in,
-  # and on hosts where the directory is not on the default PATH (e.g. RHEL7,
-  # where it is /root/.local/bin) every later script would otherwise pay for
-  # another pip install. Look there before reinstalling.
-  if [ -n "$py" ]; then
-    _ensure_uv_add_user_base "$py"
-    if uv --version >/dev/null 2>&1; then
-      _ensure_uv_scope_paths
-      return 0
-    fi
+  # Everywhere uv may already be, none of it reliably on PATH in a fresh shell:
+  # ~/.local/bin is where uv's own installer puts it and is off the default PATH
+  # on some hosts (e.g. RHEL7 root shells), while the venv and the `--user` script
+  # directory are where an earlier ensure_uv call put it. Checking them together
+  # means a later call in a new shell reuses whichever install happened.
+  [ -n "${HOME:-}" ] && _ensure_uv_add_path "$HOME/.local/bin"
+  _ensure_uv_add_path "$venv_dir/bin"
+  _ensure_uv_add_path "$venv_dir/Scripts"
+  [ -n "$py" ] && _ensure_uv_add_user_bin "$py"
+
+  if uv --version >/dev/null 2>&1; then
+    _ensure_uv_scope_paths
+    return 0
   fi
 
+  # Both install paths are needed, because the host fleet is split: Evergreen's
+  # debian11 images ship python3-pip but no python3-venv, so `python3 -m venv`
+  # fails outright there, while the remote KMS VMs ship python3-venv but no
+  # python3-pip, and Debian and Ubuntu disable `ensurepip` for the system python
+  # so nothing can bootstrap one. Neither path alone covers both.
   if [ -n "$py" ]; then
-    echo "uv not found on PATH; installing with '$py -m pip install --user uv'..." >&2
-
-    # Some Python builds (e.g. the deadsnakes PPA used in the docker test
-    # images) don't ship pip; bootstrap it from the stdlib bundle, which
-    # requires no network access.
+    # pip first, being much cheaper than building a venv. Some Python builds
+    # (e.g. the deadsnakes PPA in the docker test images) ship no pip at all;
+    # bootstrap it from the stdlib bundle, which needs no network access.
     "$py" -m pip --version >/dev/null 2>&1 || "$py" -m ensurepip --user >/dev/null 2>&1 || true
 
-    # PIP_BREAK_SYSTEM_PACKAGES bypasses PEP 668's externally-managed-environment
-    # guard, which some distros (e.g. Debian/Ubuntu) enable by default. This is
-    # safe here: it's a --user install and does not touch system site-packages.
-    #
-    # Upgrade pip itself first: some hosts ship a pip too old to recognize
-    # uv's wheel tags (e.g. PEP 600 manylinux tags require pip 20.3+). This is
-    # a fast no-op when pip is already current.
-    PIP_BREAK_SYSTEM_PACKAGES=1 "$py" -m pip install --user -q --upgrade pip || true
-    PIP_BREAK_SYSTEM_PACKAGES=1 "$py" -m pip install --user -q uv || true
+    if "$py" -m pip --version >/dev/null 2>&1; then
+      echo "uv not found; installing it with '$py -m pip install --user uv'..." >&2
 
-    _ensure_uv_add_user_base "$py"
+      # PIP_BREAK_SYSTEM_PACKAGES bypasses PEP 668's externally-managed-environment
+      # guard, which Debian and Ubuntu enable by default. Safe here: a --user
+      # install does not touch system site-packages.
+      #
+      # Upgrade pip first, since one predating PEP 600 (e.g. 20.0.2 on Ubuntu
+      # 20.04) mis-resolves uv's wheel tags. A fast no-op when already current.
+      PIP_BREAK_SYSTEM_PACKAGES=1 "$py" -m pip install --user -q --upgrade pip || true
+      PIP_BREAK_SYSTEM_PACKAGES=1 "$py" -m pip install --user -q uv || true
+
+      _ensure_uv_add_user_bin "$py"
+    fi
+
+    if ! uv --version >/dev/null 2>&1; then
+      echo "uv not found; installing it into a virtual environment at $venv_dir..." >&2
+
+      # --clear so a previously broken venv is replaced. A working one would have
+      # been found above, so anything still here is unusable.
+      if "$py" -m venv --clear "$venv_dir" >/dev/null 2>&1; then
+        # Windows venvs put the interpreter under Scripts, everything else in bin.
+        declare venv_py="$venv_dir/bin/python"
+        [ -x "$venv_py" ] || venv_py="$venv_dir/Scripts/python.exe"
+
+        # Upgrade pip for the same wheel-tag reason as above. It matters more
+        # here: a venv seeds itself with the pip bundled in the system
+        # interpreter, which on Ubuntu 20.04 is that same 20.0.2.
+        "$venv_py" -m pip install -q --upgrade pip || true
+        "$venv_py" -m pip install -q uv || true
+      fi
+    fi
   fi
 
   if uv --version >/dev/null 2>&1; then

--- a/.evergreen/ensure-uv.sh
+++ b/.evergreen/ensure-uv.sh
@@ -180,11 +180,20 @@ ensure_uv() {
   # fails outright there, while the remote KMS VMs ship python3-venv but no
   # python3-pip, and Debian and Ubuntu disable `ensurepip` for the system python
   # so nothing can bootstrap one. Neither path alone covers both.
+  # Each attempt below is allowed to fail, since a later one may still succeed, so
+  # their output is collected here instead of being printed as it happens. On
+  # success it is noise: `pip install --user` is refused outright inside an active
+  # venv, which is expected when the venv path is about to succeed anyway. On
+  # failure it is the only diagnosis there is, so it is replayed before the error.
+  # Kept beside the venv under $TMPDIR, so there is nothing to clean up.
+  declare log="${venv_dir}-install.log"
+  : >"$log" 2>/dev/null || log=/dev/null
+
   if [ -n "$py" ]; then
     # pip first, being much cheaper than building a venv. Some Python builds
     # (e.g. the deadsnakes PPA in the docker test images) ship no pip at all;
     # bootstrap it from the stdlib bundle, which needs no network access.
-    "$py" -m pip --version >/dev/null 2>&1 || "$py" -m ensurepip --user >/dev/null 2>&1 || true
+    "$py" -m pip --version >>"$log" 2>&1 || "$py" -m ensurepip --user >>"$log" 2>&1 || true
 
     if "$py" -m pip --version >/dev/null 2>&1; then
       echo "uv not found; installing it with '$py -m pip install --user uv'..." >&2
@@ -195,8 +204,8 @@ ensure_uv() {
       #
       # Upgrade pip first, since one predating PEP 600 (e.g. 20.0.2 on Ubuntu
       # 20.04) mis-resolves uv's wheel tags. A fast no-op when already current.
-      PIP_BREAK_SYSTEM_PACKAGES=1 "$py" -m pip install --user -q --upgrade pip || true
-      PIP_BREAK_SYSTEM_PACKAGES=1 "$py" -m pip install --user -q uv || true
+      PIP_BREAK_SYSTEM_PACKAGES=1 "$py" -m pip install --user -q --upgrade pip >>"$log" 2>&1 || true
+      PIP_BREAK_SYSTEM_PACKAGES=1 "$py" -m pip install --user -q uv >>"$log" 2>&1 || true
 
       _ensure_uv_add_user_bin "$py"
     fi
@@ -206,7 +215,7 @@ ensure_uv() {
 
       # --clear so a previously broken venv is replaced. A working one would have
       # been found above, so anything still here is unusable.
-      if "$py" -m venv --clear "$venv_dir" >/dev/null 2>&1; then
+      if "$py" -m venv --clear "$venv_dir" >>"$log" 2>&1; then
         # Windows venvs put the interpreter under Scripts, everything else in bin.
         declare venv_py="$venv_dir/bin/python"
         [ -x "$venv_py" ] || venv_py="$venv_dir/Scripts/python.exe"
@@ -214,8 +223,8 @@ ensure_uv() {
         # Upgrade pip for the same wheel-tag reason as above. It matters more
         # here: a venv seeds itself with the pip bundled in the system
         # interpreter, which on Ubuntu 20.04 is that same 20.0.2.
-        "$venv_py" -m pip install -q --upgrade pip || true
-        "$venv_py" -m pip install -q uv || true
+        "$venv_py" -m pip install -q --upgrade pip >>"$log" 2>&1 || true
+        "$venv_py" -m pip install -q uv >>"$log" 2>&1 || true
       fi
     fi
   fi
@@ -223,6 +232,14 @@ ensure_uv() {
   if uv --version >/dev/null 2>&1; then
     _ensure_uv_scope_paths
     return 0
+  fi
+
+  # Tail rather than the whole log: pip's connection retries can run to dozens of
+  # lines, and the message that actually explains the failure is the last one.
+  if [ "$log" != /dev/null ] && [ -s "$log" ]; then
+    echo "Last output from the failed install attempts (full log: $log):" >&2
+    tail -n 20 "$log" | sed 's/^/  /' >&2
+    echo >&2
   fi
 
   cat <<'EOF' >&2

--- a/.evergreen/tests/test-remote-kms-provisioning.sh
+++ b/.evergreen/tests/test-remote-kms-provisioning.sh
@@ -3,6 +3,11 @@
 # Smoke-tests that the gcpkms/azurekms remote-scripts leave a host in a state
 # where ensure_uv succeeds, without needing a real GCE/Azure VM. Runs each
 # script's dependency-install step in a container and then calls ensure_uv.
+#
+# Also covers the reverse direction, where the provisioning predates the current
+# ensure_uv. Drivers pin $DRIVERS_TOOLS, so a VM provisioned by an older pin has
+# to keep working with current code. test_provisioning alone runs both halves from
+# the working tree, so it cannot catch that skew.
 set -eu
 
 SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
@@ -37,7 +42,81 @@ test_provisioning() {
   echo "Testing $name provisioning ... done."
 }
 
+# Asserts ensure_uv works on a host provisioned by a $DRIVERS_TOOLS revision from
+# before python3-pip was added to the remote-scripts. Those revisions installed
+# python3-venv only, and Debian and Ubuntu disable `ensurepip` for the system
+# python, so there is no way to reach pip from the system interpreter: ensure_uv
+# has to get there through a venv. Drivers bump their pin on their own schedule,
+# so this has to keep working indefinitely, not just until they all have.
+test_no_system_pip() {
+  local name="$1" base_image="$2"
+  echo "Testing ensure_uv without system pip ($base_image) ..."
+  $DOCKER build -q -t "$IMAGE-$name" --build-arg BASE_IMAGE="$base_image" \
+    -f "$SCRIPT_DIR/docker/remote-kms-provisioning.Dockerfile" "$SCRIPT_DIR/docker"
+  $DOCKER run --rm -v "$ROOT_DIR:/drivers-tools:ro" "$IMAGE-$name" bash -c '
+    set -e
+    # The dependency list the remote-scripts installed before python3-pip, i.e.
+    # what a VM provisioned from an older pin still looks like.
+    sudo apt-get -qq update
+    sudo DEBIAN_FRONTEND=noninteractive apt-get -y -qq \
+      -o DPkg::Lock::Timeout=-1 install python3 python3-venv git < /dev/null > /dev/null
+    if python3 -m pip --version > /dev/null 2>&1; then
+      echo "expected no system pip; this test is no longer testing anything" >&2
+      exit 1
+    fi
+    cp -r /drivers-tools ~/drivers-tools
+    cd ~/drivers-tools
+    . .evergreen/ensure-uv.sh
+    ensure_uv
+    uv --version
+    # The venv is the only way through here, so confirm that is what happened
+    # rather than some pip path quietly reappearing.
+    case "$(command -v uv)" in
+    *drivers-tools-uv-venv*) ;;
+    *) echo "expected uv from the fallback venv, got $(command -v uv)" >&2; exit 1 ;;
+    esac
+  '
+  echo "Testing ensure_uv without system pip ($base_image) ... done."
+}
+
+# The mirror image of test_no_system_pip, and the reason ensure_uv keeps both
+# install paths. Evergreen's debian11 images have python3-pip but no
+# python3-venv, so `python3 -m venv` fails outright and pip is the only way
+# through. A venv-only ensure_uv passed every test above and still broke those
+# hosts, so assert this shape too.
+test_no_venv_module() {
+  local name="$1" base_image="$2"
+  echo "Testing ensure_uv without the venv module ($base_image) ..."
+  $DOCKER build -q -t "$IMAGE-$name" --build-arg BASE_IMAGE="$base_image" \
+    -f "$SCRIPT_DIR/docker/remote-kms-provisioning.Dockerfile" "$SCRIPT_DIR/docker"
+  $DOCKER run --rm -v "$ROOT_DIR:/drivers-tools:ro" "$IMAGE-$name" bash -c '
+    set -e
+    sudo apt-get -qq update
+    sudo DEBIAN_FRONTEND=noninteractive apt-get -y -qq \
+      -o DPkg::Lock::Timeout=-1 install python3 python3-pip git < /dev/null > /dev/null
+    if python3 -m venv --clear /tmp/probe > /dev/null 2>&1; then
+      echo "expected no working venv module; this test is no longer testing anything" >&2
+      exit 1
+    fi
+    cp -r /drivers-tools ~/drivers-tools
+    cd ~/drivers-tools
+    . .evergreen/ensure-uv.sh
+    ensure_uv
+    uv --version
+  '
+  echo "Testing ensure_uv without the venv module ($base_image) ... done."
+}
+
 # Keep these in sync with the defaults in create-and-setup-instance.sh
 # (GCPKMS_IMAGEFAMILY) and create-and-setup-vm.sh (AZUREKMS_IMAGE).
 test_provisioning gcpkms .evergreen/csfle/gcpkms/remote-scripts/setup-gce-instance.sh debian:11
 test_provisioning azurekms .evergreen/csfle/azurekms/remote-scripts/setup-azure-vm.sh debian:11
+
+# debian:11 matches both defaults above. ubuntu:20.04 is a supported
+# AZUREKMS_IMAGE (see azurekms/README.md) and additionally covers a system
+# interpreter whose bundled pip predates PEP 600.
+test_no_system_pip nopip-debian11 debian:11
+test_no_system_pip nopip-ubuntu2004 ubuntu:20.04
+
+# debian:11 matches the Evergreen image whose missing python3-venv this covers.
+test_no_venv_module novenv-debian11 debian:11

--- a/.evergreen/tests/test-remote-kms-provisioning.sh
+++ b/.evergreen/tests/test-remote-kms-provisioning.sh
@@ -107,6 +107,42 @@ test_no_venv_module() {
   echo "Testing ensure_uv without the venv module ($base_image) ... done."
 }
 
+# ensure_uv called from an active virtual environment, which is how the Node OIDC
+# tests invoke it. pip is present there, but pip refuses `--user` inside a venv, so
+# the venv fallback is the only way through, and it has to build its venv using a
+# venv's own interpreter. Neither of the cases above covers that.
+test_inside_active_venv() {
+  local name="$1" base_image="$2"
+  echo "Testing ensure_uv inside an active venv ($base_image) ..."
+  $DOCKER build -q -t "$IMAGE-$name" --build-arg BASE_IMAGE="$base_image" \
+    -f "$SCRIPT_DIR/docker/remote-kms-provisioning.Dockerfile" "$SCRIPT_DIR/docker"
+  $DOCKER run --rm -v "$ROOT_DIR:/drivers-tools:ro" "$IMAGE-$name" bash -c '
+    set -e
+    sudo apt-get -qq update
+    sudo DEBIAN_FRONTEND=noninteractive apt-get -y -qq \
+      -o DPkg::Lock::Timeout=-1 install python3 python3-pip python3-venv git < /dev/null > /dev/null
+    python3 -m venv ~/outer
+    . ~/outer/bin/activate
+    # Guard both halves of what makes this case distinct, so it cannot quietly
+    # stop testing anything: pip has to be present, and --user has to be refused.
+    python3 -m pip --version > /dev/null
+    if python3 -m pip install --user -q uv > /dev/null 2>&1; then
+      echo "expected --user to be refused inside a venv" >&2
+      exit 1
+    fi
+    cp -r /drivers-tools ~/drivers-tools
+    cd ~/drivers-tools
+    . .evergreen/ensure-uv.sh
+    ensure_uv
+    uv --version
+    case "$(command -v uv)" in
+    *drivers-tools-uv-venv*) ;;
+    *) echo "expected uv from the fallback venv, got $(command -v uv)" >&2; exit 1 ;;
+    esac
+  '
+  echo "Testing ensure_uv inside an active venv ($base_image) ... done."
+}
+
 # Keep these in sync with the defaults in create-and-setup-instance.sh
 # (GCPKMS_IMAGEFAMILY) and create-and-setup-vm.sh (AZUREKMS_IMAGE).
 test_provisioning gcpkms .evergreen/csfle/gcpkms/remote-scripts/setup-gce-instance.sh debian:11
@@ -120,3 +156,5 @@ test_no_system_pip nopip-ubuntu2004 ubuntu:20.04
 
 # debian:11 matches the Evergreen image whose missing python3-venv this covers.
 test_no_venv_module novenv-debian11 debian:11
+
+test_inside_active_venv invenv-debian11 debian:11


### PR DESCRIPTION
DRIVERS-3564

## Summary

`ensure_uv` used `pip install --user`, which needs a system pip. The remote KMS
VMs have none: they install `python3-venv`, not `python3-pip`, and Debian and
Ubuntu disable `ensurepip` for the system python. The gcpkms and azurekms tasks
failed with `No module named pip`.

[4c63815](https://github.com/mongodb-labs/drivers-evergreen-tools/commit/4c63815912cb0a4ff7bc877c173d0deab39690c5) added `python3-pip` to the
provisioning scripts, but those come from the driver's pinned
`drivers-evergreen-tools`, so it only helps once a driver bumps its pin. This
fixes the side that runs on the VM, so no driver has to act.

## Changes in this PR

[97b2779](https://github.com/mongodb-labs/drivers-evergreen-tools/commit/97b2779) falls back to installing uv into a virtual environment,
which brings its own pip and needs only the stdlib module those VMs have.

Both install paths are kept, because the fleet is split in both directions:
Evergreen's debian11 images have `python3-pip` but no `python3-venv`, so a venv
cannot be built there, while the KMS VMs are the reverse. Neither path alone
covers both.

## Test Plan

`test-remote-kms-provisioning.sh` gained cases for both shapes: a host with
`python3-venv` and no `python3-pip` (debian:11 and ubuntu:20.04, the latter also
covering a bundled pip predating PEP 600), and a host with `python3-pip` and no
`python3-venv` (debian:11). Each asserts uv ends up installed, and disabling
either install path makes the corresponding case fail.

Verified on real GCE and Azure VMs with the two node driver tasks that originally
failed, with the remote clone temporarily pointed at this branch, since the VM
otherwise clones the default branch and would not pick the change up:
https://spruce.corp.mongodb.com/version/6a7338dda768b70007e5601d

A follow-up PR will have remote VMs unpack an archive of the host's checkout
rather than cloning the default branch, which removes the need for that override.

## Checklist

### Checklist for Author

- [x] Does the title of the PR reference a JIRA Ticket?
- [x] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [x] Is all relevant documentation (README or docstring) updated?

### Checklist for Reviewer

- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?
