### PR TITLE
DRIVERS-3564: Ship the host's drivers-evergreen-tools to remote VMs and pods

### DIFF
--- a/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
+++ b/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
@@ -70,14 +70,16 @@ AZUREKMS_DST="./" \
 # Push Drivers Evergreen Tools onto the VM
 TARFILE=/tmp/drivers-evergreen-tools.tgz
 pushd $DRIVERS_TOOLS
-git archive --format=tar.gz -o $TARFILE --prefix=drivers-evergreen-tools/ HEAD
+bash $DRIVERS_TOOLS/.evergreen/make-drivers-tools-archive.sh $TARFILE
 TARFILE_BASE=$(basename ${TARFILE})
 AZUREKMS_SRC=${TARFILE} \
     AZUREKMS_DST="./" \
     $DRIVERS_TOOLS/.evergreen/csfle/azurekms/copy-file.sh
 echo "Copying files ... end"
 echo "Untarring file ... begin"
-AZUREKMS_CMD="tar xf ${TARFILE_BASE}" \
+# The archive is flat, so name the destination here rather than baking it in as
+# a tar --prefix.
+AZUREKMS_CMD="mkdir -p drivers-evergreen-tools && tar xf ${TARFILE_BASE} -C drivers-evergreen-tools" \
   $DRIVERS_TOOLS/.evergreen/csfle/azurekms/run-command.sh
 echo "Untarring file ... end"
 popd

--- a/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
+++ b/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
@@ -70,7 +70,7 @@ AZUREKMS_DST="./" \
 # Push Drivers Evergreen Tools onto the VM
 TARFILE=/tmp/drivers-evergreen-tools.tgz
 pushd $DRIVERS_TOOLS
-bash $DRIVERS_TOOLS/.evergreen/make-drivers-tools-archive.sh $TARFILE
+bash "$DRIVERS_TOOLS/.evergreen/make-drivers-tools-archive.sh" "$TARFILE"
 TARFILE_BASE=$(basename ${TARFILE})
 AZUREKMS_SRC=${TARFILE} \
     AZUREKMS_DST="./" \

--- a/.evergreen/auth_oidc/k8s/start-server.sh
+++ b/.evergreen/auth_oidc/k8s/start-server.sh
@@ -14,9 +14,7 @@ source $K8S_VARIANT_DIR/secrets-export.sh
 echo "Setting up server on ${K8S_POD_NAME}..."
 kubectl exec ${K8S_POD_NAME} -- bash -c "rm -rf /tmp/server && mkdir /tmp/server/"
 K8S_TAR_FILE=/tmp/drivers-tools.tgz
-pushd $DRIVERS_TOOLS
-git archive -o $K8S_TAR_FILE HEAD
-popd
+bash $DRIVERS_TOOLS/.evergreen/make-drivers-tools-archive.sh $K8S_TAR_FILE
 kubectl cp ${K8S_TAR_FILE}  ${K8S_POD_NAME}:/tmp/server/drivers-tools.tgz
 kubectl cp $K8S_VARIANT_DIR/secrets-export.sh ${K8S_POD_NAME}:/tmp/server/secrets-export.sh
 kubectl cp ./remote-scripts/start-server.sh ${K8S_POD_NAME}:/tmp/server/start-server.sh

--- a/.evergreen/auth_oidc/k8s/start-server.sh
+++ b/.evergreen/auth_oidc/k8s/start-server.sh
@@ -14,7 +14,7 @@ source $K8S_VARIANT_DIR/secrets-export.sh
 echo "Setting up server on ${K8S_POD_NAME}..."
 kubectl exec ${K8S_POD_NAME} -- bash -c "rm -rf /tmp/server && mkdir /tmp/server/"
 K8S_TAR_FILE=/tmp/drivers-tools.tgz
-bash $DRIVERS_TOOLS/.evergreen/make-drivers-tools-archive.sh $K8S_TAR_FILE
+bash "$DRIVERS_TOOLS/.evergreen/make-drivers-tools-archive.sh" "$K8S_TAR_FILE"
 kubectl cp ${K8S_TAR_FILE}  ${K8S_POD_NAME}:/tmp/server/drivers-tools.tgz
 kubectl cp $K8S_VARIANT_DIR/secrets-export.sh ${K8S_POD_NAME}:/tmp/server/secrets-export.sh
 kubectl cp ./remote-scripts/start-server.sh ${K8S_POD_NAME}:/tmp/server/start-server.sh

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -413,7 +413,7 @@ functions:
           set -o errexit
           cd ${DRIVERS_TOOLS}
           export AZUREOIDC_DRIVERS_TAR_FILE=/tmp/drivers-tools.tgz
-          git archive -o $AZUREOIDC_DRIVERS_TAR_FILE HEAD
+          bash ./.evergreen/make-drivers-tools-archive.sh $AZUREOIDC_DRIVERS_TAR_FILE
           export AZUREOIDC_TEST_CMD="source ./env.sh && echo 'hello'"
           bash ./.evergreen/auth_oidc/azure/run-driver-test.sh
           # Generate a test results file
@@ -448,7 +448,7 @@ functions:
           set -o errexit
           cd ${DRIVERS_TOOLS}
           export GCPOIDC_DRIVERS_TAR_FILE=/tmp/drivers-tools.tgz
-          git archive -o $GCPOIDC_DRIVERS_TAR_FILE HEAD
+          bash ./.evergreen/make-drivers-tools-archive.sh $GCPOIDC_DRIVERS_TAR_FILE
           export GCPOIDC_TEST_CMD="source ./secrets-export.sh && echo 'hello'"
           bash ./.evergreen/auth_oidc/gcp/run-driver-test.sh
           # Generate a test results file
@@ -468,7 +468,7 @@ functions:
           bash ./.evergreen/auth_oidc/k8s/setup-pod.sh
           bash ./.evergreen/auth_oidc/k8s/run-self-test.sh
           export K8S_DRIVERS_TAR_FILE=/tmp/drivers-tools.tgz
-          git archive -o $K8S_DRIVERS_TAR_FILE HEAD
+          bash ./.evergreen/make-drivers-tools-archive.sh $K8S_DRIVERS_TAR_FILE
           export K8S_TEST_CMD="echo 'hello'"
           bash ./.evergreen/auth_oidc/k8s/run-driver-test.sh
           bash ./.evergreen/auth_oidc/k8s/teardown-pod.sh
@@ -560,6 +560,13 @@ functions:
       params:
         binary: bash
         args: [src/.evergreen/tests/test-remote-kms-provisioning.sh]
+
+  "run drivers tools archive test":
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: bash
+        args: [src/.evergreen/tests/test-drivers-tools-archive.sh]
 
   "run mongodb runner test partial":
     - command: subprocess.exec
@@ -1041,6 +1048,11 @@ tasks:
       commands:
         - func: "run remote kms provisioning test"
 
+    - name: "test-drivers-tools-archive"
+      tags: ["pr"]
+      commands:
+        - func: "run drivers tools archive test"
+
     - name: "test-legacy-versions"
       commands:
         - func: "run legacy versions test"
@@ -1511,6 +1523,7 @@ buildvariants:
         add_tasks:
           - "test-install-binaries"
           - "test-csfle"
+          - "test-drivers-tools-archive"
           - "test-cli-full"
           - "test-mongodb-runner-full"
           - "test-happy-eyeballs"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -413,7 +413,7 @@ functions:
           set -o errexit
           cd ${DRIVERS_TOOLS}
           export AZUREOIDC_DRIVERS_TAR_FILE=/tmp/drivers-tools.tgz
-          bash ./.evergreen/make-drivers-tools-archive.sh $AZUREOIDC_DRIVERS_TAR_FILE
+          bash ./.evergreen/make-drivers-tools-archive.sh "$AZUREOIDC_DRIVERS_TAR_FILE"
           export AZUREOIDC_TEST_CMD="source ./env.sh && echo 'hello'"
           bash ./.evergreen/auth_oidc/azure/run-driver-test.sh
           # Generate a test results file
@@ -448,7 +448,7 @@ functions:
           set -o errexit
           cd ${DRIVERS_TOOLS}
           export GCPOIDC_DRIVERS_TAR_FILE=/tmp/drivers-tools.tgz
-          bash ./.evergreen/make-drivers-tools-archive.sh $GCPOIDC_DRIVERS_TAR_FILE
+          bash ./.evergreen/make-drivers-tools-archive.sh "$GCPOIDC_DRIVERS_TAR_FILE"
           export GCPOIDC_TEST_CMD="source ./secrets-export.sh && echo 'hello'"
           bash ./.evergreen/auth_oidc/gcp/run-driver-test.sh
           # Generate a test results file
@@ -468,7 +468,7 @@ functions:
           bash ./.evergreen/auth_oidc/k8s/setup-pod.sh
           bash ./.evergreen/auth_oidc/k8s/run-self-test.sh
           export K8S_DRIVERS_TAR_FILE=/tmp/drivers-tools.tgz
-          bash ./.evergreen/make-drivers-tools-archive.sh $K8S_DRIVERS_TAR_FILE
+          bash ./.evergreen/make-drivers-tools-archive.sh "$K8S_DRIVERS_TAR_FILE"
           export K8S_TEST_CMD="echo 'hello'"
           bash ./.evergreen/auth_oidc/k8s/run-driver-test.sh
           bash ./.evergreen/auth_oidc/k8s/teardown-pod.sh

--- a/.evergreen/csfle/azurekms/create-and-setup-vm.sh
+++ b/.evergreen/csfle/azurekms/create-and-setup-vm.sh
@@ -74,6 +74,19 @@ AZUREKMS_DST="./" \
     "$DRIVERS_TOOLS"/.evergreen/csfle/azurekms/copy-file.sh
 AZUREKMS_CMD="./setup-azure-vm.sh" \
     "$DRIVERS_TOOLS"/.evergreen/csfle/azurekms/run-command.sh
+# Ship this checkout so the VM runs the same revision that provisioned it. On
+# failure start-mongodb.sh falls back to cloning the default branch, so this must
+# not abort the task.
+AZUREKMS_ARCHIVE_DIR=$(mktemp -d)
+if bash "$DRIVERS_TOOLS"/.evergreen/make-drivers-tools-archive.sh "$AZUREKMS_ARCHIVE_DIR/drivers-evergreen-tools.tgz"; then
+    AZUREKMS_SRC="$AZUREKMS_ARCHIVE_DIR/drivers-evergreen-tools.tgz" \
+    AZUREKMS_DST="./" \
+        "$DRIVERS_TOOLS"/.evergreen/csfle/azurekms/copy-file.sh
+else
+    echo "WARNING: could not archive $DRIVERS_TOOLS; the VM will clone the default branch, which may not match this checkout."
+fi
+rm -rf "$AZUREKMS_ARCHIVE_DIR"
+
 # Start mongodb.
 AZUREKMS_SRC="$DRIVERS_TOOLS/.evergreen/csfle/azurekms/remote-scripts/start-mongodb.sh" \
 AZUREKMS_DST="./" \

--- a/.evergreen/csfle/azurekms/remote-scripts/start-mongodb.sh
+++ b/.evergreen/csfle/azurekms/remote-scripts/start-mongodb.sh
@@ -4,8 +4,18 @@ set -o pipefail
 # Do not error on unset variables. run-orchestration.sh accesses unset variables.
 
 echo "Starting MongoDB server ... begin"
-git clone https://github.com/mongodb-labs/drivers-evergreen-tools
 DRIVERS_TOOLS=$(pwd)/drivers-evergreen-tools
+if [ -f drivers-evergreen-tools.tgz ]; then
+  # create-and-setup-vm.sh shipped the host's checkout, so this VM runs the same
+  # revision that provisioned it.
+  mkdir -p "$DRIVERS_TOOLS"
+  tar xzf drivers-evergreen-tools.tgz -C "$DRIVERS_TOOLS"
+else
+  # No archive: the host could not build one. Cloning the default branch may not
+  # match the script that provisioned this VM.
+  echo "WARNING: no drivers-evergreen-tools archive; cloning the default branch instead."
+  git clone https://github.com/mongodb-labs/drivers-evergreen-tools
+fi
 export DRIVERS_TOOLS
 export MONGO_ORCHESTRATION_HOME="$DRIVERS_TOOLS/.evergreen/orchestration"
 export MONGODB_BINARIES="$DRIVERS_TOOLS/mongodb/bin"

--- a/.evergreen/csfle/gcpkms/remote-scripts/start-mongodb.sh
+++ b/.evergreen/csfle/gcpkms/remote-scripts/start-mongodb.sh
@@ -4,8 +4,19 @@ set -o pipefail
 # Do not error on unset variables. run-orchestration.sh accesses unset variables.
 
 echo "Starting MongoDB server ... begin"
-git clone https://github.com/mongodb-labs/drivers-evergreen-tools
 DRIVERS_TOOLS="$(pwd)/drivers-evergreen-tools"
+if [ -f drivers-evergreen-tools.tgz ]; then
+  # setup-instance.sh shipped the host's checkout, so this instance runs the
+  # same revision that provisioned it.
+  mkdir -p "$DRIVERS_TOOLS"
+  tar xzf drivers-evergreen-tools.tgz -C "$DRIVERS_TOOLS"
+else
+  # No archive: the host could not build one, or a driver supplied its own
+  # $GCPKMS_SETUP_INSTANCE that does not ship it. Cloning the default branch may
+  # not match the script that provisioned this instance.
+  echo "WARNING: no drivers-evergreen-tools archive; cloning the default branch instead."
+  git clone https://github.com/mongodb-labs/drivers-evergreen-tools
+fi
 export DRIVERS_TOOLS
 export MONGO_ORCHESTRATION_HOME="$DRIVERS_TOOLS/.evergreen/orchestration"
 export MONGODB_BINARIES="$DRIVERS_TOOLS/mongodb/bin"

--- a/.evergreen/csfle/gcpkms/setup-instance.sh
+++ b/.evergreen/csfle/gcpkms/setup-instance.sh
@@ -30,6 +30,21 @@ $GCPKMS_GCLOUD compute ssh "$GCPKMS_INSTANCENAME" \
 echo "Exit code of test-script is: $?"
 echo "Running setup-gce-instance.sh on GCE instance ($GCPKMS_INSTANCENAME) ... end"
 
+echo "Copying drivers-evergreen-tools to GCE instance ($GCPKMS_INSTANCENAME) ... begin"
+# Ship this checkout so the instance runs the same revision that provisioned it.
+# On failure start-mongodb.sh falls back to cloning the default branch, so this
+# must not abort the task.
+GCPKMS_ARCHIVE_DIR=$(mktemp -d)
+if bash $DRIVERS_TOOLS/.evergreen/make-drivers-tools-archive.sh "$GCPKMS_ARCHIVE_DIR/drivers-evergreen-tools.tgz"; then
+    $GCPKMS_GCLOUD compute scp "$GCPKMS_ARCHIVE_DIR/drivers-evergreen-tools.tgz" "$GCPKMS_INSTANCENAME":~ \
+        --zone $GCPKMS_ZONE \
+        --project $GCPKMS_PROJECT
+else
+    echo "WARNING: could not archive $DRIVERS_TOOLS; the instance will clone the default branch, which may not match this checkout."
+fi
+rm -rf "$GCPKMS_ARCHIVE_DIR"
+echo "Copying drivers-evergreen-tools to GCE instance ($GCPKMS_INSTANCENAME) ... end"
+
 echo "Copying start-mongodb.sh to GCE instance ($GCPKMS_INSTANCENAME) ... begin"
 # Copy files to test. Use "-p" to preserve execute mode.
 $GCPKMS_GCLOUD compute scp $DRIVERS_TOOLS/.evergreen/csfle/gcpkms/remote-scripts/start-mongodb.sh "$GCPKMS_INSTANCENAME":~ \

--- a/.evergreen/csfle/gcpkms/setup-instance.sh
+++ b/.evergreen/csfle/gcpkms/setup-instance.sh
@@ -35,7 +35,7 @@ echo "Copying drivers-evergreen-tools to GCE instance ($GCPKMS_INSTANCENAME) ...
 # On failure start-mongodb.sh falls back to cloning the default branch, so this
 # must not abort the task.
 GCPKMS_ARCHIVE_DIR=$(mktemp -d)
-if bash $DRIVERS_TOOLS/.evergreen/make-drivers-tools-archive.sh "$GCPKMS_ARCHIVE_DIR/drivers-evergreen-tools.tgz"; then
+if bash "$DRIVERS_TOOLS/.evergreen/make-drivers-tools-archive.sh" "$GCPKMS_ARCHIVE_DIR/drivers-evergreen-tools.tgz"; then
     $GCPKMS_GCLOUD compute scp "$GCPKMS_ARCHIVE_DIR/drivers-evergreen-tools.tgz" "$GCPKMS_INSTANCENAME":~ \
         --zone $GCPKMS_ZONE \
         --project $GCPKMS_PROJECT

--- a/.evergreen/ensure-uv.sh
+++ b/.evergreen/ensure-uv.sh
@@ -192,8 +192,10 @@ ensure_uv() {
     fi
   fi
 
-  # None of these is reliably on PATH in a fresh shell: ~/.local/bin is where uv's
-  # own installer puts it, and the others are where an earlier call put it.
+  # None of these is reliably on PATH in a fresh shell. ~/.local/bin is where uv's
+  # own installer puts it and is off the default PATH on some hosts (RHEL7 root
+  # shells), and the rest are where an earlier ensure_uv call put it. Scripts is the
+  # Windows spelling of bin.
   [ -n "${HOME:-}" ] && _ensure_uv_add_path "$HOME/.local/bin"
   _ensure_uv_add_path "$venv_dir/bin"
   _ensure_uv_add_path "$venv_dir/Scripts"
@@ -207,6 +209,8 @@ ensure_uv() {
   # Past this point uv is genuinely absent and has to be installed. Output is
   # collected rather than printed, since each attempt is expected to fail on some
   # hosts and only a total failure is worth reporting.
+  # Beside the venv, so there is nothing to clean up. Falls back to discarding the
+  # output if $TMPDIR is not writable, which is better than failing over a log.
   declare log="${venv_dir}-install.log"
   : >"$log" 2>/dev/null || log=/dev/null
 

--- a/.evergreen/ensure-uv.sh
+++ b/.evergreen/ensure-uv.sh
@@ -86,6 +86,59 @@ _ensure_uv_add_user_bin() {
   _ensure_uv_add_path "$base/Scripts"
 }
 
+# _ensure_uv_install (internal)
+#
+# Install uv using interpreter $1, building a virtual environment at $2 if needed,
+# with all output appended to $3. Not meant to be called directly.
+#
+# Tries `pip install --user` and then a virtual environment, because no single
+# method covers every host we run on:
+#
+# - Remote KMS VMs provisioned before python3-pip was added to their setup scripts
+#   have no system pip. These are real Debian 11 cloud images, and Debian disables
+#   `ensurepip` for the system python, so only the venv works there.
+# - Evergreen's debian11 images have pip but no python3-venv, so `python3 -m venv`
+#   fails outright and only pip works there.
+# - Callers already inside an active venv have pip, but pip refuses `--user`
+#   inside one, so again only the venv works.
+#
+# Every step tolerates failure, since a later one may still succeed.
+_ensure_uv_install() {
+  declare py="${1:?}" venv_dir="${2:?}" log="${3:?}"
+
+  # Some Python builds (notably the deadsnakes PPA in the docker test images) ship
+  # no pip; bootstrap it from the stdlib bundle, which needs no network.
+  "$py" -m pip --version >>"$log" 2>&1 || "$py" -m ensurepip --user >>"$log" 2>&1 || true
+
+  if "$py" -m pip --version >/dev/null 2>&1; then
+    echo "uv not found; installing it with '$py -m pip install --user uv'..." >&2
+
+    # PIP_BREAK_SYSTEM_PACKAGES bypasses PEP 668's externally-managed guard, which
+    # Debian and Ubuntu enable. Safe here: `--user` leaves system site-packages
+    # alone. Upgrading pip first matters because one predating PEP 600 (20.0.2 on
+    # Ubuntu 20.04) mis-resolves uv's wheel tags.
+    PIP_BREAK_SYSTEM_PACKAGES=1 "$py" -m pip install --user -q --upgrade pip >>"$log" 2>&1 || true
+    PIP_BREAK_SYSTEM_PACKAGES=1 "$py" -m pip install --user -q uv >>"$log" 2>&1 || true
+
+    _ensure_uv_add_user_bin "$py"
+  fi
+
+  uv --version >/dev/null 2>&1 && return 0
+
+  echo "uv not found; installing it into a virtual environment at $venv_dir..." >&2
+
+  # --clear replaces a previously broken venv; a working one was found already.
+  "$py" -m venv --clear "$venv_dir" >>"$log" 2>&1 || return 0
+
+  # Windows venvs put the interpreter under Scripts, everything else in bin. A
+  # venv seeds itself with the system interpreter's pip, so it needs the same
+  # upgrade for the same reason.
+  declare venv_py="$venv_dir/bin/python"
+  [ -x "$venv_py" ] || venv_py="$venv_dir/Scripts/python.exe"
+  "$venv_py" -m pip install -q --upgrade pip >>"$log" 2>&1 || true
+  "$venv_py" -m pip install -q uv >>"$log" 2>&1 || true
+}
+
 # ensure_uv
 #
 # Usage:
@@ -103,43 +156,25 @@ _ensure_uv_add_user_bin() {
 # - UV_TOOL_DIR (only when $DRIVERS_TOOLS is set)
 # - UV_CACHE_DIR, UV_PYTHON_INSTALL_DIR (additionally require $CI to be set)
 #
-# First look everywhere uv may already be: PATH, ~/.local/bin where uv's own
-# installer puts it, and the two places an earlier call may have installed it.
-# Failing that, install it with `pip install --user`, and failing that into a
-# virtual environment under $TMPDIR.
+# Looks everywhere uv may already be, and only then hands off to
+# _ensure_uv_install, which documents why installing it takes two attempts.
 #
-# Both install paths are load-bearing because the host fleet is split. Evergreen's
-# debian11 images have python3-pip but no python3-venv, so a venv cannot be built
-# there. The remote KMS VMs have python3-venv but no python3-pip, and Debian and
-# Ubuntu disable `ensurepip` for the system python, so no pip can be bootstrapped
-# there.
-#
-# The one wrinkle is a fallback to the MongoDB toolchain's python3, needed on
-# hosts (e.g. RHEL7) that have no python3 on PATH at all.
-#
-# On success, also relocates uv's shared state; see _ensure_uv_scope_paths above
-# for exactly what is scoped and when.
+# On success, also relocates uv's shared state; see _ensure_uv_scope_paths.
 ensure_uv() {
-  # Some hosts (e.g. RHEL8 zseries/power8) have pyenv installed, whose shims
-  # intercept `python`/`python3`/`uv` and enforce whichever .python-version
-  # file they find walking up from the working directory, failing outright if
-  # pyenv doesn't already have that exact version installed (some of these
-  # hosts already have a working uv installed under pyenv's own configured
-  # version). Defer to pyenv's own global version instead of hardcoding e.g.
-  # "system", which may not be where uv/python are actually installed on a
-  # given host. This repo ships no .python-version, but a parent directory of
-  # the checkout may still have one.
+  # Some hosts (e.g. RHEL8 zseries/power8) have pyenv, whose shims intercept
+  # python/uv and enforce whichever .python-version they find walking up from the
+  # working directory, failing if pyenv lacks that exact version. Defer to pyenv's
+  # own global version rather than hardcoding e.g. "system", which may not be
+  # where uv is actually installed.
   if command -v pyenv >/dev/null 2>&1; then
     declare pyenv_global
     pyenv_global="$(pyenv global 2>/dev/null | head -n1)" || true
     [ -n "$pyenv_global" ] && export PYENV_VERSION="$pyenv_global"
   fi
 
-  # Kept stable rather than mktemp'd so a later ensure_uv call in a fresh shell
-  # reuses the venv instead of rebuilding it. Under CI, Evergreen points TMPDIR at
-  # a per-task directory, so the venv is recycled with the task and stays out of
-  # the failure artifacts, which are packed from $DRIVERS_TOOLS and
-  # $PROJECT_DIRECTORY.
+  # Stable rather than mktemp'd, so a later call in a fresh shell reuses the venv.
+  # Under CI, Evergreen points TMPDIR at a per-task directory, so it is recycled
+  # with the task and stays out of the uploaded failure artifacts.
   declare venv_dir="${TMPDIR:-/tmp}"
   venv_dir="${venv_dir%/}/drivers-tools-uv-venv"
 
@@ -148,9 +183,8 @@ ensure_uv() {
     py=python3
   else
     # Some legacy hosts (e.g. RHEL7) have no python3 on PATH at all, only an
-    # ancient Python 2 `python`, which uv does not support. Look for the
-    # MongoDB toolchain's python3, which is present on these hosts, before
-    # falling back to plain `python`.
+    # ancient Python 2 `python` that uv does not support. Prefer the MongoDB
+    # toolchain's python3, which those hosts do have.
     declare toolchain_py
     toolchain_py="$(compgen -G '/opt/mongodbtoolchain/v*/bin/python3' | sort -V | tail -n1)" || true
     if [ -n "$toolchain_py" ] && [ -x "$toolchain_py" ]; then
@@ -160,11 +194,8 @@ ensure_uv() {
     fi
   fi
 
-  # Everywhere uv may already be, none of it reliably on PATH in a fresh shell:
-  # ~/.local/bin is where uv's own installer puts it and is off the default PATH
-  # on some hosts (e.g. RHEL7 root shells), while the venv and the `--user` script
-  # directory are where an earlier ensure_uv call put it. Checking them together
-  # means a later call in a new shell reuses whichever install happened.
+  # None of these is reliably on PATH in a fresh shell: ~/.local/bin is where uv's
+  # own installer puts it, and the others are where an earlier call put it.
   [ -n "${HOME:-}" ] && _ensure_uv_add_path "$HOME/.local/bin"
   _ensure_uv_add_path "$venv_dir/bin"
   _ensure_uv_add_path "$venv_dir/Scripts"
@@ -175,67 +206,21 @@ ensure_uv() {
     return 0
   fi
 
-  # Both install paths are needed, because the host fleet is split: Evergreen's
-  # debian11 images ship python3-pip but no python3-venv, so `python3 -m venv`
-  # fails outright there, while the remote KMS VMs ship python3-venv but no
-  # python3-pip, and Debian and Ubuntu disable `ensurepip` for the system python
-  # so nothing can bootstrap one. Neither path alone covers both.
-  # Each attempt below is allowed to fail, since a later one may still succeed, so
-  # their output is collected here instead of being printed as it happens. On
-  # success it is noise: `pip install --user` is refused outright inside an active
-  # venv, which is expected when the venv path is about to succeed anyway. On
-  # failure it is the only diagnosis there is, so it is replayed before the error.
-  # Kept beside the venv under $TMPDIR, so there is nothing to clean up.
+  # Past this point uv is genuinely absent and has to be installed. Output is
+  # collected rather than printed, since each attempt is expected to fail on some
+  # hosts and only a total failure is worth reporting.
   declare log="${venv_dir}-install.log"
   : >"$log" 2>/dev/null || log=/dev/null
 
-  if [ -n "$py" ]; then
-    # pip first, being much cheaper than building a venv. Some Python builds
-    # (e.g. the deadsnakes PPA in the docker test images) ship no pip at all;
-    # bootstrap it from the stdlib bundle, which needs no network access.
-    "$py" -m pip --version >>"$log" 2>&1 || "$py" -m ensurepip --user >>"$log" 2>&1 || true
-
-    if "$py" -m pip --version >/dev/null 2>&1; then
-      echo "uv not found; installing it with '$py -m pip install --user uv'..." >&2
-
-      # PIP_BREAK_SYSTEM_PACKAGES bypasses PEP 668's externally-managed-environment
-      # guard, which Debian and Ubuntu enable by default. Safe here: a --user
-      # install does not touch system site-packages.
-      #
-      # Upgrade pip first, since one predating PEP 600 (e.g. 20.0.2 on Ubuntu
-      # 20.04) mis-resolves uv's wheel tags. A fast no-op when already current.
-      PIP_BREAK_SYSTEM_PACKAGES=1 "$py" -m pip install --user -q --upgrade pip >>"$log" 2>&1 || true
-      PIP_BREAK_SYSTEM_PACKAGES=1 "$py" -m pip install --user -q uv >>"$log" 2>&1 || true
-
-      _ensure_uv_add_user_bin "$py"
-    fi
-
-    if ! uv --version >/dev/null 2>&1; then
-      echo "uv not found; installing it into a virtual environment at $venv_dir..." >&2
-
-      # --clear so a previously broken venv is replaced. A working one would have
-      # been found above, so anything still here is unusable.
-      if "$py" -m venv --clear "$venv_dir" >>"$log" 2>&1; then
-        # Windows venvs put the interpreter under Scripts, everything else in bin.
-        declare venv_py="$venv_dir/bin/python"
-        [ -x "$venv_py" ] || venv_py="$venv_dir/Scripts/python.exe"
-
-        # Upgrade pip for the same wheel-tag reason as above. It matters more
-        # here: a venv seeds itself with the pip bundled in the system
-        # interpreter, which on Ubuntu 20.04 is that same 20.0.2.
-        "$venv_py" -m pip install -q --upgrade pip >>"$log" 2>&1 || true
-        "$venv_py" -m pip install -q uv >>"$log" 2>&1 || true
-      fi
-    fi
-  fi
+  [ -n "$py" ] && _ensure_uv_install "$py" "$venv_dir" "$log"
 
   if uv --version >/dev/null 2>&1; then
     _ensure_uv_scope_paths
     return 0
   fi
 
-  # Tail rather than the whole log: pip's connection retries can run to dozens of
-  # lines, and the message that actually explains the failure is the last one.
+  # Tail, because pip's connection retries can run to dozens of lines and the
+  # message that explains the failure is the last one.
   if [ "$log" != /dev/null ] && [ -s "$log" ]; then
     echo "Last output from the failed install attempts (full log: $log):" >&2
     tail -n 20 "$log" | sed 's/^/  /' >&2

--- a/.evergreen/ensure-uv.sh
+++ b/.evergreen/ensure-uv.sh
@@ -101,14 +101,12 @@ _ensure_uv_add_user_bin() {
 #   fails outright and only pip works there.
 # - Callers already inside an active venv have pip, but pip refuses `--user`
 #   inside one, so again only the venv works.
+# - The docker test images install a deadsnakes python with venv but no pip, so the
+#   venv covers them as well.
 #
 # Every step tolerates failure, since a later one may still succeed.
 _ensure_uv_install() {
   declare py="${1:?}" venv_dir="${2:?}" log="${3:?}"
-
-  # Some Python builds (notably the deadsnakes PPA in the docker test images) ship
-  # no pip; bootstrap it from the stdlib bundle, which needs no network.
-  "$py" -m pip --version >>"$log" 2>&1 || "$py" -m ensurepip --user >>"$log" 2>&1 || true
 
   if "$py" -m pip --version >/dev/null 2>&1; then
     echo "uv not found; installing it with '$py -m pip install --user uv'..." >&2

--- a/.evergreen/make-drivers-tools-archive.sh
+++ b/.evergreen/make-drivers-tools-archive.sh
@@ -16,8 +16,11 @@
 # Tracked paths read from the working tree, rather than `git archive HEAD`, so a
 # patch build's uncommitted edits are included and untracked files are not. That
 # keeps out secrets-export.sh, which azurekms writes into .evergreen/csfle/, along
-# with server binaries and .local, holding the transfer near 1.5 MB.
-set -eu
+# with server binaries and .local, holding the transfer under 500 KB.
+#
+# pipefail matters here: the file list reaches tar through a pipe, so a git that
+# dies partway would otherwise leave tar writing a short archive and exiting zero.
+set -eu -o pipefail
 
 # Unsupported on Windows: git and tar want opposite path forms there, since native
 # git needs `C:/...` while Cygwin's GNU tar reads that as an rsh `host:path` and
@@ -45,7 +48,43 @@ if ! git -C "$DRIVERS_TOOLS" rev-parse --git-dir >/dev/null 2>&1; then
   exit 1
 fi
 
+# Prints the ancestor that makes $1's absence unverifiable, if any. An unsearchable
+# directory leaves everything beneath it unstattable, and git reports those paths as
+# --deleted just as it does real deletions. The deepest ancestor that exists settles
+# it: searchable means the path is truly gone, unsearchable means we cannot tell.
+unsearchable_ancestor() {
+  local dir
+  dir=$(dirname "$1")
+  while [ "$dir" != "/" ] && [ "$dir" != "." ] && [ ! -e "$dir" ]; do
+    dir=$(dirname "$dir")
+  done
+  if [ -x "$dir" ]; then
+    return 1
+  fi
+  printf '%s' "$dir"
+}
+
 # --no-xattrs: building on macOS otherwise records com.apple.provenance on every
 # entry, which GNU tar then warns about once per file. Both tars accept the flag.
 git -C "$DRIVERS_TOOLS" ls-files -z |
+  while IFS= read -r -d '' path; do
+    # Skip what is not in the working tree: a patch build can delete a tracked file
+    # without staging it, and tar aborts the whole archive on the first entry it
+    # cannot stat. Same set as subtracting `git ls-files --deleted` ("in the index,
+    # missing from the working tree"), as a stat per path -- subtracting two
+    # NUL-delimited lists costs a subprocess each and leans on a `-z` whose meaning
+    # varies across greps. -L is required: -e follows the link, so a tracked
+    # symlink with a missing target would be dropped though tar handles it fine.
+    if [ -e "$DRIVERS_TOOLS/$path" ] || [ -L "$DRIVERS_TOOLS/$path" ]; then
+      printf '%s\0' "$path"
+    elif blocker=$(unsearchable_ancestor "$DRIVERS_TOOLS/$path"); then
+      rel=${blocker#"$DRIVERS_TOOLS"/}
+      echo "ERROR: cannot determine whether $path exists." >&2
+      echo "Its ancestor $rel is not searchable, which leaves a deleted file" >&2
+      echo "and an unreadable one looking identical from here." >&2
+      echo "Refusing to build an archive that may silently omit tracked files." >&2
+      echo "Fix that directory's permissions (chmod +rx) and rebuild." >&2
+      exit 1
+    fi
+  done |
   tar czf "$OUTPUT" --no-xattrs -C "$DRIVERS_TOOLS" --null -T -

--- a/.evergreen/make-drivers-tools-archive.sh
+++ b/.evergreen/make-drivers-tools-archive.sh
@@ -6,37 +6,23 @@
 #   make-drivers-tools-archive.sh <output.tgz>
 #
 # Build the gzipped tarball of $DRIVERS_TOOLS that remote VMs and pods unpack
-# instead of cloning this repo, so the remote side always runs the same revision
-# as the host. Drivers pin $DRIVERS_TOOLS, and a remote `git clone` of the
-# default branch silently pairs a pinned provisioning script with unpinned code.
+# instead of cloning this repo, so the remote side runs the host's revision.
+# Drivers pin $DRIVERS_TOOLS, and a remote clone of the default branch would pair
+# a pinned provisioning script with unpinned code.
 #
-# The archive is flat, with no path prefix. Callers pick the destination with
-# `tar -C`, which is the only convention that suits every caller.
+# Flat, no path prefix: callers pick the destination with `tar -C`. .git is not
+# shipped; nothing this repo runs remotely inspects it.
 #
-# Two properties come from listing paths with `git ls-files` and reading them
-# from the working tree rather than using `git archive HEAD`:
-#
-# - A patch build's uncommitted edits are included. Evergreen may leave a
-#   patch's diff uncommitted, and prepare-env-and-resources.sh copies the
-#   working tree into $DRIVERS_TOOLS precisely so patch builds test the patch.
-# - Untracked files are skipped. That keeps secrets-export.sh out of the
-#   archive, which matters because create-and-setup-vm.sh writes one into
-#   .evergreen/csfle/azurekms/ on the host. Surfaces that legitimately need
-#   secrets remotely copy them as separate files. It also keeps downloaded
-#   server binaries and .local tool state out, holding the transfer near 1.5 MB.
-#
-# .git is deliberately not shipped. Nothing this repo runs remotely inspects its
-# own git metadata.
+# Tracked paths read from the working tree, rather than `git archive HEAD`, so a
+# patch build's uncommitted edits are included and untracked files are not. That
+# keeps out secrets-export.sh, which azurekms writes into .evergreen/csfle/, along
+# with server binaries and .local, holding the transfer near 1.5 MB.
 set -eu
 
-# Unsupported on Windows, by design. Every consumer unpacks this archive on a
-# Linux VM or pod, and here git and tar want opposite path forms that cannot both
-# be satisfied: native git needs `C:/...`, while Cygwin's GNU tar reads that as an
-# rsh `host:path` spec and tries to connect to a machine named `C`. Refuse
-# outright rather than emit a broken archive.
-#
-# Checked before anything else, so refusing costs nothing. Detected the way
-# handle-paths.sh does it, which is the form these hosts are known to match.
+# Unsupported on Windows: git and tar want opposite path forms there, since native
+# git needs `C:/...` while Cygwin's GNU tar reads that as an rsh `host:path` and
+# tries to connect to a host named `C`. Every consumer unpacks on Linux anyway.
+# Checked first, so refusing costs nothing. Detection matches handle-paths.sh.
 case "$(uname -s)" in
 CYGWIN*)
   echo "ERROR: make-drivers-tools-archive.sh is not supported on Windows." >&2
@@ -59,8 +45,7 @@ if ! git -C "$DRIVERS_TOOLS" rev-parse --git-dir >/dev/null 2>&1; then
   exit 1
 fi
 
-# --no-xattrs because building this on macOS otherwise records com.apple.provenance
-# on every entry, and GNU tar on the Linux side then warns once per file. Accepted
-# by both bsdtar and GNU tar.
+# --no-xattrs: building on macOS otherwise records com.apple.provenance on every
+# entry, which GNU tar then warns about once per file. Both tars accept the flag.
 git -C "$DRIVERS_TOOLS" ls-files -z |
   tar czf "$OUTPUT" --no-xattrs -C "$DRIVERS_TOOLS" --null -T -

--- a/.evergreen/make-drivers-tools-archive.sh
+++ b/.evergreen/make-drivers-tools-archive.sh
@@ -59,5 +59,8 @@ if ! git -C "$DRIVERS_TOOLS" rev-parse --git-dir >/dev/null 2>&1; then
   exit 1
 fi
 
+# --no-xattrs because building this on macOS otherwise records com.apple.provenance
+# on every entry, and GNU tar on the Linux side then warns once per file. Accepted
+# by both bsdtar and GNU tar.
 git -C "$DRIVERS_TOOLS" ls-files -z |
-  tar czf "$OUTPUT" -C "$DRIVERS_TOOLS" --null -T -
+  tar czf "$OUTPUT" --no-xattrs -C "$DRIVERS_TOOLS" --null -T -

--- a/.evergreen/make-drivers-tools-archive.sh
+++ b/.evergreen/make-drivers-tools-archive.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# make-drivers-tools-archive.sh
+#
+# Usage:
+#   make-drivers-tools-archive.sh <output.tgz>
+#
+# Build the gzipped tarball of $DRIVERS_TOOLS that remote VMs and pods unpack
+# instead of cloning this repo, so the remote side always runs the same revision
+# as the host. Drivers pin $DRIVERS_TOOLS, and a remote `git clone` of the
+# default branch silently pairs a pinned provisioning script with unpinned code.
+#
+# The archive is flat, with no path prefix. Callers pick the destination with
+# `tar -C`, which is the only convention that suits every caller.
+#
+# Two properties come from listing paths with `git ls-files` and reading them
+# from the working tree rather than using `git archive HEAD`:
+#
+# - A patch build's uncommitted edits are included. Evergreen may leave a
+#   patch's diff uncommitted, and prepare-env-and-resources.sh copies the
+#   working tree into $DRIVERS_TOOLS precisely so patch builds test the patch.
+# - Untracked files are skipped. That keeps secrets-export.sh out of the
+#   archive, which matters because create-and-setup-vm.sh writes one into
+#   .evergreen/csfle/azurekms/ on the host. Surfaces that legitimately need
+#   secrets remotely copy them as separate files. It also keeps downloaded
+#   server binaries and .local tool state out, holding the transfer near 1.5 MB.
+#
+# .git is deliberately not shipped. Nothing this repo runs remotely inspects its
+# own git metadata.
+set -eu
+
+# Unsupported on Windows, by design. Every consumer unpacks this archive on a
+# Linux VM or pod, and here git and tar want opposite path forms that cannot both
+# be satisfied: native git needs `C:/...`, while Cygwin's GNU tar reads that as an
+# rsh `host:path` spec and tries to connect to a machine named `C`. Refuse
+# outright rather than emit a broken archive.
+#
+# Checked before anything else, so refusing costs nothing. Detected the way
+# handle-paths.sh does it, which is the form these hosts are known to match.
+case "$(uname -s)" in
+CYGWIN*)
+  echo "ERROR: make-drivers-tools-archive.sh is not supported on Windows." >&2
+  echo "Every remote target that consumes this archive runs Linux, so build it there." >&2
+  exit 1
+  ;;
+esac
+
+if [ $# -ne 1 ]; then
+  echo "usage: make-drivers-tools-archive.sh <output.tgz>" >&2
+  exit 1
+fi
+OUTPUT="$1"
+
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+. "$SCRIPT_DIR/handle-paths.sh"
+
+if ! git -C "$DRIVERS_TOOLS" rev-parse --git-dir >/dev/null 2>&1; then
+  echo "ERROR: $DRIVERS_TOOLS is not a git checkout, cannot build an archive." >&2
+  exit 1
+fi
+
+git -C "$DRIVERS_TOOLS" ls-files -z |
+  tar czf "$OUTPUT" -C "$DRIVERS_TOOLS" --null -T -

--- a/.evergreen/tests/test-drivers-tools-archive.sh
+++ b/.evergreen/tests/test-drivers-tools-archive.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+#
+# Tests make-drivers-tools-archive.sh, which builds the tarball every remote
+# VM and pod receives instead of cloning this repo.
+#
+# Runs against a miniature $DRIVERS_TOOLS built in a temp directory rather than
+# the real checkout, so the assertions do not drift as the repo changes.
+set -eu
+
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+ARCHIVER="$ROOT_DIR/.evergreen/make-drivers-tools-archive.sh"
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+FAILED=0
+
+pass() {
+  echo "  ok: $1"
+}
+
+fail() {
+  echo "  FAIL: $1" >&2
+  FAILED=1
+}
+
+assert_file() {
+  if [ -f "$2" ]; then pass "$1"; else fail "$1"; fi
+}
+
+assert_no_file() {
+  if [ -f "$2" ]; then fail "$1"; else pass "$1"; fi
+}
+
+assert_contents() {
+  local desc="$1" path="$2" want="$3" got
+  got=$(cat "$path" 2>/dev/null || true)
+  if [ "$got" = "$want" ]; then pass "$desc"; else fail "$desc (want '$want', got '$got')"; fi
+}
+
+# The archiver refuses to run on Windows, so assert that rather than skipping.
+# Everything below it needs a working archiver, and asserting keeps the refusal
+# and its message honest instead of letting them rot untested.
+case "$(uname -s)" in
+CYGWIN*)
+  echo "Testing the archiver refuses to run on Windows ..."
+  if bash "$ARCHIVER" "$WORK/out.tgz" >/dev/null 2>"$WORK/err"; then
+    fail "archiver should have refused to run on Windows"
+  elif grep -q "not supported on Windows" "$WORK/err"; then
+    pass "archiver refuses to run on Windows with an actionable error"
+  else
+    fail "archiver failed on Windows, but not with the expected message"
+    cat "$WORK/err" >&2
+  fi
+  echo "Testing the archiver refuses to run on Windows ... done."
+  if [ "$FAILED" -ne 0 ]; then
+    echo "FAILED" >&2
+    exit 1
+  fi
+  echo "All archive tests passed."
+  exit 0
+  ;;
+esac
+
+# A git checkout holding a plain tracked file, a tracked file carrying an
+# uncommitted edit, and an untracked secrets file in the very location
+# azurekms/create-and-setup-vm.sh writes one on the host.
+FAKE="$WORK/drivers-tools"
+mkdir -p "$FAKE/.evergreen/csfle/azurekms"
+git -C "$FAKE" init -q
+git -C "$FAKE" config user.email test@example.com
+git -C "$FAKE" config user.name "Test"
+echo "tracked" >"$FAKE/.evergreen/tracked.sh"
+echo "committed" >"$FAKE/.evergreen/edited.sh"
+printf '#!/usr/bin/env bash\ntrue\n' >"$FAKE/.evergreen/runnable.sh"
+chmod +x "$FAKE/.evergreen/runnable.sh"
+git -C "$FAKE" add -A
+git -C "$FAKE" commit -qm "initial"
+echo "uncommitted" >"$FAKE/.evergreen/edited.sh"
+echo "export AZUREKMS_SECRET=hunter2" >"$FAKE/.evergreen/csfle/azurekms/secrets-export.sh"
+
+echo "Testing archive contents ..."
+DRIVERS_TOOLS="$FAKE" bash "$ARCHIVER" "$WORK/out.tgz"
+OUT="$WORK/extracted"
+mkdir -p "$OUT"
+tar xzf "$WORK/out.tgz" -C "$OUT"
+
+assert_file "tracked file is included" "$OUT/.evergreen/tracked.sh"
+
+# Every caller extracts with an explicit -C, so a prefix directory would put the
+# tree one level too deep on all seven of them.
+assert_no_file "archive carries no path prefix" "$OUT/drivers-evergreen-tools/.evergreen/tracked.sh"
+
+# The reason the archive is built from tracked paths rather than a recursive
+# copy. Regressing this ships KMS credentials to a test VM.
+assert_no_file "untracked secrets-export.sh is excluded" \
+  "$OUT/.evergreen/csfle/azurekms/secrets-export.sh"
+
+# Read from the working tree, not HEAD: Evergreen may leave a patch build's diff
+# uncommitted, and `git archive HEAD` would ship the pre-patch tree.
+assert_contents "uncommitted edit to a tracked file is included" \
+  "$OUT/.evergreen/edited.sh" "uncommitted"
+
+# The remote side invokes scripts from the unpacked tree directly, so losing the
+# executable bit in transit would break it.
+if [ -x "$OUT/.evergreen/runnable.sh" ]; then
+  pass "executable bit is preserved"
+else
+  fail "executable bit is preserved"
+fi
+
+echo "Testing archive contents ... done."
+
+echo "Testing failure without git metadata ..."
+NOGIT="$WORK/nogit"
+mkdir -p "$NOGIT/.evergreen"
+if DRIVERS_TOOLS="$NOGIT" bash "$ARCHIVER" "$WORK/nogit.tgz" 2>/dev/null; then
+  fail "exits non-zero when \$DRIVERS_TOOLS is not a git checkout"
+else
+  pass "exits non-zero when \$DRIVERS_TOOLS is not a git checkout"
+fi
+echo "Testing failure without git metadata ... done."
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "FAILED" >&2
+  exit 1
+fi
+echo "All archive tests passed."

--- a/.evergreen/tests/test-drivers-tools-archive.sh
+++ b/.evergreen/tests/test-drivers-tools-archive.sh
@@ -12,7 +12,8 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 ARCHIVER="$ROOT_DIR/.evergreen/make-drivers-tools-archive.sh"
 
 WORK=$(mktemp -d)
-trap 'rm -rf "$WORK"' EXIT
+# The unsearchable-directory case below would otherwise defeat the cleanup.
+trap 'chmod -R u+rwX "$WORK" 2>/dev/null; rm -rf "$WORK"' EXIT
 
 FAILED=0
 
@@ -63,9 +64,9 @@ CYGWIN*)
   ;;
 esac
 
-# A git checkout holding a plain tracked file, a tracked file carrying an
-# uncommitted edit, and an untracked secrets file in the very location
-# azurekms/create-and-setup-vm.sh writes one on the host.
+# A git checkout holding a plain tracked file, one carrying an uncommitted edit,
+# one deleted without staging it, a whole removed directory, a dangling tracked
+# symlink, and an untracked secrets file where azurekms writes one on the host.
 FAKE="$WORK/drivers-tools"
 mkdir -p "$FAKE/.evergreen/csfle/azurekms"
 git -C "$FAKE" init -q
@@ -73,15 +74,28 @@ git -C "$FAKE" config user.email test@example.com
 git -C "$FAKE" config user.name "Test"
 echo "tracked" >"$FAKE/.evergreen/tracked.sh"
 echo "committed" >"$FAKE/.evergreen/edited.sh"
+echo "doomed" >"$FAKE/.evergreen/deleted.sh"
+mkdir -p "$FAKE/.evergreen/removed/nested"
+echo "gone" >"$FAKE/.evergreen/removed/nested/buried.sh"
 printf '#!/usr/bin/env bash\ntrue\n' >"$FAKE/.evergreen/runnable.sh"
 chmod +x "$FAKE/.evergreen/runnable.sh"
+ln -s missing-target "$FAKE/.evergreen/dangling.pem"
 git -C "$FAKE" add -A
 git -C "$FAKE" commit -qm "initial"
 echo "uncommitted" >"$FAKE/.evergreen/edited.sh"
+rm "$FAKE/.evergreen/deleted.sh"
+rm -rf "$FAKE/.evergreen/removed"
 echo "export AZUREKMS_SECRET=hunter2" >"$FAKE/.evergreen/csfle/azurekms/secrets-export.sh"
 
 echo "Testing archive contents ..."
-DRIVERS_TOOLS="$FAKE" bash "$ARCHIVER" "$WORK/out.tgz"
+# Guarded rather than bare: a non-zero exit here would otherwise take the suite
+# down through `set -e` without naming what broke. Its stderr is echoed instead.
+if ! DRIVERS_TOOLS="$FAKE" bash "$ARCHIVER" "$WORK/out.tgz" 2>"$WORK/build.err"; then
+  fail "archiver exits zero over a checkout with deletions but nothing unreadable"
+  sed 's/^/    /' "$WORK/build.err" >&2
+  echo "FAILED" >&2
+  exit 1
+fi
 OUT="$WORK/extracted"
 mkdir -p "$OUT"
 tar xzf "$WORK/out.tgz" -C "$OUT"
@@ -110,7 +124,90 @@ else
   fail "executable bit is preserved"
 fi
 
+# An unstaged removal leaves the path in the index, and tar aborts on it.
+assert_no_file "tracked file deleted in the working tree is excluded" \
+  "$OUT/.evergreen/deleted.sh"
+
+# A removed directory takes its parent with it, so the unsearchable-ancestor guard
+# must walk past the missing levels. Firing here would fail every patch that
+# deletes a directory.
+assert_no_file "tracked file under a removed directory is excluded" \
+  "$OUT/.evergreen/removed/nested/buried.sh"
+
+# Deleted paths are dropped by testing existence, which a dangling symlink fails,
+# so surviving takes an explicit -L. x509gen and orchestration/lib track symlinks.
+if [ -L "$OUT/.evergreen/dangling.pem" ]; then
+  pass "tracked symlink is included even with a missing target"
+else
+  fail "tracked symlink is included even with a missing target"
+fi
+
 echo "Testing archive contents ... done."
+
+echo "Testing failure when git fails mid-pipeline ..."
+# The file list is piped into tar, so a git that dies partway leaves tar writing a
+# short archive. Unless that surfaces, callers ship a truncated tree.
+REAL_GIT=$(command -v git)
+STUB_BIN="$WORK/stub-bin"
+mkdir -p "$STUB_BIN"
+cat >"$STUB_BIN/git" <<EOF
+#!/usr/bin/env bash
+# Fails only ls-files, so the archiver's is-this-a-checkout guard still passes.
+for arg in "\$@"; do
+  if [ "\$arg" = "ls-files" ]; then
+    echo "stub git: simulated ls-files failure" >&2
+    exit 1
+  fi
+done
+exec "$REAL_GIT" "\$@"
+EOF
+chmod +x "$STUB_BIN/git"
+
+if PATH="$STUB_BIN:$PATH" DRIVERS_TOOLS="$FAKE" bash "$ARCHIVER" "$WORK/broken.tgz" \
+  2>/dev/null; then
+  fail "exits non-zero when git ls-files fails"
+else
+  pass "exits non-zero when git ls-files fails"
+fi
+echo "Testing failure when git fails mid-pipeline ... done."
+
+echo "Testing refusal when a path's absence cannot be established ..."
+# An unsearchable directory makes its contents unstattable, and git reports those
+# paths as --deleted just as it does real deletions. Skipping them silently would
+# drop tracked files that are actually present.
+if [ "$(id -u)" -eq 0 ]; then
+  # Root ignores directory permissions, so the condition cannot be staged here.
+  echo "  skip: running as root, cannot make a directory unsearchable"
+else
+  LOCKED="$WORK/locked"
+  mkdir -p "$LOCKED/.evergreen/private"
+  git -C "$LOCKED" init -q
+  git -C "$LOCKED" config user.email test@example.com
+  git -C "$LOCKED" config user.name "Test"
+  echo "visible" >"$LOCKED/.evergreen/visible.sh"
+  echo "hidden" >"$LOCKED/.evergreen/private/hidden.sh"
+  git -C "$LOCKED" add -A
+  git -C "$LOCKED" commit -qm "initial"
+  chmod 000 "$LOCKED/.evergreen/private"
+
+  if DRIVERS_TOOLS="$LOCKED" bash "$ARCHIVER" "$WORK/locked.tgz" \
+    2>"$WORK/locked.err"; then
+    fail "exits non-zero when a tracked path can neither be read nor ruled out"
+    if [ -f "$WORK/locked.tgz" ] &&
+      ! tar tzf "$WORK/locked.tgz" 2>/dev/null | grep -q "private/hidden.sh"; then
+      echo "    (it built an archive silently missing private/hidden.sh)" >&2
+    fi
+  elif grep -q "cannot determine whether" "$WORK/locked.err"; then
+    pass "refuses to guess when a directory is not searchable"
+  else
+    fail "exited non-zero, but not with the expected message"
+    cat "$WORK/locked.err" >&2
+  fi
+
+  # Restore before the archive-wide cleanup so nothing depends on trap ordering.
+  chmod 755 "$LOCKED/.evergreen/private"
+fi
+echo "Testing refusal when a path's absence cannot be established ... done."
 
 echo "Testing failure without git metadata ..."
 NOGIT="$WORK/nogit"

--- a/.evergreen/tests/test-remote-kms-provisioning.sh
+++ b/.evergreen/tests/test-remote-kms-provisioning.sh
@@ -25,14 +25,23 @@ if [ -n "${DOCKER_COMMAND:-}" ]; then
   DOCKER=$DOCKER_COMMAND
 fi
 
+# Populate the containers from the archive a real VM unpacks, rather than from a
+# recursive copy, so these cases exercise the actual artifact. Each case unpacks
+# it the same way the remote start-mongodb.sh scripts do.
+ARCHIVE_DIR=$(mktemp -d)
+trap 'rm -rf "$ARCHIVE_DIR"' EXIT
+ARCHIVE="$ARCHIVE_DIR/drivers-evergreen-tools.tgz"
+DRIVERS_TOOLS="$ROOT_DIR" bash "$ROOT_DIR/.evergreen/make-drivers-tools-archive.sh" "$ARCHIVE"
+
 test_provisioning() {
   local name="$1" script="$2" base_image="$3"
   echo "Testing $name provisioning ($base_image) ..."
   $DOCKER build -q -t "$IMAGE-$name" --build-arg BASE_IMAGE="$base_image" \
     -f "$SCRIPT_DIR/docker/remote-kms-provisioning.Dockerfile" "$SCRIPT_DIR/docker"
-  $DOCKER run --rm -v "$ROOT_DIR:/drivers-tools:ro" "$IMAGE-$name" bash -c "
+  $DOCKER run --rm -v "$ARCHIVE:/drivers-evergreen-tools.tgz:ro" "$IMAGE-$name" bash -c "
     set -e
-    cp -r /drivers-tools ~/drivers-tools
+    mkdir -p ~/drivers-tools
+    tar xzf /drivers-evergreen-tools.tgz -C ~/drivers-tools
     cd ~/drivers-tools
     bash $script
     . .evergreen/ensure-uv.sh
@@ -53,7 +62,7 @@ test_no_system_pip() {
   echo "Testing ensure_uv without system pip ($base_image) ..."
   $DOCKER build -q -t "$IMAGE-$name" --build-arg BASE_IMAGE="$base_image" \
     -f "$SCRIPT_DIR/docker/remote-kms-provisioning.Dockerfile" "$SCRIPT_DIR/docker"
-  $DOCKER run --rm -v "$ROOT_DIR:/drivers-tools:ro" "$IMAGE-$name" bash -c '
+  $DOCKER run --rm -v "$ARCHIVE:/drivers-evergreen-tools.tgz:ro" "$IMAGE-$name" bash -c '
     set -e
     # The dependency list the remote-scripts installed before python3-pip, i.e.
     # what a VM provisioned from an older pin still looks like.
@@ -64,7 +73,8 @@ test_no_system_pip() {
       echo "expected no system pip; this test is no longer testing anything" >&2
       exit 1
     fi
-    cp -r /drivers-tools ~/drivers-tools
+    mkdir -p ~/drivers-tools
+    tar xzf /drivers-evergreen-tools.tgz -C ~/drivers-tools
     cd ~/drivers-tools
     . .evergreen/ensure-uv.sh
     ensure_uv
@@ -89,7 +99,7 @@ test_no_venv_module() {
   echo "Testing ensure_uv without the venv module ($base_image) ..."
   $DOCKER build -q -t "$IMAGE-$name" --build-arg BASE_IMAGE="$base_image" \
     -f "$SCRIPT_DIR/docker/remote-kms-provisioning.Dockerfile" "$SCRIPT_DIR/docker"
-  $DOCKER run --rm -v "$ROOT_DIR:/drivers-tools:ro" "$IMAGE-$name" bash -c '
+  $DOCKER run --rm -v "$ARCHIVE:/drivers-evergreen-tools.tgz:ro" "$IMAGE-$name" bash -c '
     set -e
     sudo apt-get -qq update
     sudo DEBIAN_FRONTEND=noninteractive apt-get -y -qq \
@@ -98,7 +108,8 @@ test_no_venv_module() {
       echo "expected no working venv module; this test is no longer testing anything" >&2
       exit 1
     fi
-    cp -r /drivers-tools ~/drivers-tools
+    mkdir -p ~/drivers-tools
+    tar xzf /drivers-evergreen-tools.tgz -C ~/drivers-tools
     cd ~/drivers-tools
     . .evergreen/ensure-uv.sh
     ensure_uv
@@ -116,7 +127,7 @@ test_inside_active_venv() {
   echo "Testing ensure_uv inside an active venv ($base_image) ..."
   $DOCKER build -q -t "$IMAGE-$name" --build-arg BASE_IMAGE="$base_image" \
     -f "$SCRIPT_DIR/docker/remote-kms-provisioning.Dockerfile" "$SCRIPT_DIR/docker"
-  $DOCKER run --rm -v "$ROOT_DIR:/drivers-tools:ro" "$IMAGE-$name" bash -c '
+  $DOCKER run --rm -v "$ARCHIVE:/drivers-evergreen-tools.tgz:ro" "$IMAGE-$name" bash -c '
     set -e
     sudo apt-get -qq update
     sudo DEBIAN_FRONTEND=noninteractive apt-get -y -qq \
@@ -130,7 +141,8 @@ test_inside_active_venv() {
       echo "expected --user to be refused inside a venv" >&2
       exit 1
     fi
-    cp -r /drivers-tools ~/drivers-tools
+    mkdir -p ~/drivers-tools
+    tar xzf /drivers-evergreen-tools.tgz -C ~/drivers-tools
     cd ~/drivers-tools
     . .evergreen/ensure-uv.sh
     ensure_uv
@@ -142,6 +154,55 @@ test_inside_active_venv() {
   '
   echo "Testing ensure_uv inside an active venv ($base_image) ... done."
 }
+
+# Asserts start-mongodb.sh unpacks the archive the host ships instead of cloning.
+# Runs locally rather than in a container: the branch under test is pure shell, and
+# the archive here holds a stub run-orchestration.sh so no server is started.
+test_start_mongodb_uses_archive() {
+  local name="$1" script="$2"
+  echo "Testing $name start-mongodb.sh uses the archive ..."
+  local work stub
+  work=$(mktemp -d)
+  stub="$work/stub-drivers-tools"
+
+  mkdir -p "$stub/.evergreen/orchestration"
+  git -C "$stub" init -q
+  git -C "$stub" config user.email test@example.com
+  git -C "$stub" config user.name "Test"
+  printf '#!/usr/bin/env bash\necho ran-from-archive > "$(dirname "${BASH_SOURCE[0]}")/../marker"\n' \
+    >"$stub/.evergreen/run-orchestration.sh"
+  chmod +x "$stub/.evergreen/run-orchestration.sh"
+  # start-mongodb.sh writes orchestration.config here, and git does not track
+  # empty directories, so the directory needs a file to survive the archive.
+  touch "$stub/.evergreen/orchestration/.keep"
+  git -C "$stub" add -A
+  git -C "$stub" commit -qm "stub"
+
+  mkdir -p "$work/vm"
+  DRIVERS_TOOLS="$stub" bash "$ROOT_DIR/.evergreen/make-drivers-tools-archive.sh" \
+    "$work/vm/drivers-evergreen-tools.tgz"
+
+  # The remote scripts run from the home directory with the tarball beside them.
+  ( cd "$work/vm" && bash "$ROOT_DIR/$script" ) >"$work/out.log" 2>&1 || {
+    echo "  FAIL: $name start-mongodb.sh exited non-zero" >&2
+    cat "$work/out.log" >&2; rm -rf "$work"; return 1
+  }
+  if [ ! -f "$work/vm/drivers-evergreen-tools/marker" ]; then
+    echo "  FAIL: $name did not run run-orchestration.sh from the archive" >&2
+    cat "$work/out.log" >&2; rm -rf "$work"; return 1
+  fi
+  if grep -q "cloning the default branch" "$work/out.log"; then
+    echo "  FAIL: $name fell back to cloning despite the archive being present" >&2
+    rm -rf "$work"; return 1
+  fi
+  echo "  ok: unpacked the archive and did not fall back to cloning"
+  rm -rf "$work"
+  echo "Testing $name start-mongodb.sh uses the archive ... done."
+}
+
+# These need no container, so run them first and fail fast.
+test_start_mongodb_uses_archive gcpkms .evergreen/csfle/gcpkms/remote-scripts/start-mongodb.sh
+test_start_mongodb_uses_archive azurekms .evergreen/csfle/azurekms/remote-scripts/start-mongodb.sh
 
 # Keep these in sync with the defaults in create-and-setup-instance.sh
 # (GCPKMS_IMAGEFAMILY) and create-and-setup-vm.sh (AZUREKMS_IMAGE).


### PR DESCRIPTION
DRIVERS-3564

## Summary

Seven places send this repo to a remote VM or pod, three different ways. The two csfle KMS scripts cloned the default branch, so a provisioning script and the code depending on it came from different revisions: that is how the `python3-pip` fix in [4c63815](https://github.com/mongodb-labs/drivers-evergreen-tools/commit/4c63815912cb0a4ff7bc877c173d0deab39690c5) could not reach a VM. The other five used `git archive HEAD`, which drops a patch build's uncommitted changes.

## Changes in this PR

[45aceb3](https://github.com/mongodb-labs/drivers-evergreen-tools/commit/45aceb3) adds `make-drivers-tools-archive.sh` and uses it for all seven, so the remote side runs the host's revision. Listing tracked paths from the working tree keeps patch-build changes and leaves `secrets-export.sh` and downloaded server binaries out. The csfle scripts keep cloning as a fallback.

[fb15fc4](https://github.com/mongodb-labs/drivers-evergreen-tools/commit/fb15fc4) and [ac89dc2](https://github.com/mongodb-labs/drivers-evergreen-tools/commit/ac89dc2) follow up on review of #825: the install fallbacks move into `_ensure_uv_install`, and the `ensurepip` bootstrap is gone, since the virtual environment fallback already covers the deadsnakes docker images it existed for.

## Test Plan

New `test-drivers-tools-archive.sh` covers archive contents, absence of a path prefix, exclusion of an untracked `secrets-export.sh`, uncommitted edits, executable bits, and the Windows refusal. `test-remote-kms-provisioning.sh` now feeds its containers from the archive and runs the real `start-mongodb.sh` against a stub one.

Node driver patch, green on the two tasks that originally failed: https://spruce.corp.mongodb.com/version/6a73ab778333f9000720137d

Both shipped and unpacked the archive, with no clone and no fallback warning, which is the point of the change: the VM gets this branch through the archive rather than needing an override.

## Checklist

### Checklist for Author

- [x] Does the title of the PR reference a JIRA Ticket?
- [x] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [x] Is all relevant documentation (README or docstring) updated?

### Checklist for Reviewer

- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?
