### PR TITLE
DRIVERS-3602: Add a release workflow with semver tagging and signed GitHub Releases

### DIFF
--- a/.github/scripts/bump_version.py
+++ b/.github/scripts/bump_version.py
@@ -1,0 +1,91 @@
+"""Compute the next release version from the latest version tag in git."""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+TAG_PATTERN = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+LEVELS = ("patch", "minor", "major")
+
+
+def parse_version(tag):
+    """Return (major, minor, patch) for a vX.Y.Z tag, or None for anything else."""
+    match = TAG_PATTERN.match(tag)
+    if match is None:
+        return None
+    return tuple(int(part) for part in match.groups())
+
+
+def latest_version(tags):
+    """Return the highest version among tags, or None when none is a version."""
+    versions = [
+        parsed for parsed in (parse_version(tag) for tag in tags) if parsed is not None
+    ]
+    if not versions:
+        return None
+    return max(versions)
+
+
+def bump(version, level):
+    """Return version bumped at level, one of patch, minor, or major."""
+    major, minor, patch = version
+    if level == "patch":
+        return (major, minor, patch + 1)
+    if level == "minor":
+        return (major, minor + 1, 0)
+    if level == "major":
+        return (major + 1, 0, 0)
+    raise ValueError(f"unknown bump level: {level}")
+
+
+def format_tag(version):
+    """Return the tag name for a version."""
+    major, minor, patch = version
+    return f"v{major}.{minor}.{patch}"
+
+
+def list_tags():
+    """Return the repository's tags that start with v."""
+    completed = subprocess.run(
+        ["git", "tag", "--list", "v*"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.split()
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "level", choices=LEVELS, help="which part of the version to bump"
+    )
+    args = parser.parse_args(argv)
+
+    current = latest_version(list_tags())
+    if current is None:
+        print(
+            "error: no vX.Y.Z tag found, create and push the first tag (v1.0.0) before releasing",
+            file=sys.stderr,
+        )
+        return 1
+
+    outputs = [
+        f"current-version={format_tag(current)}",
+        f"next-version={format_tag(bump(current, args.level))}",
+    ]
+    for line in outputs:
+        print(line)
+
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with open(github_output, "a") as fid:
+            fid.write("\n".join(outputs) + "\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/bump_version.py
+++ b/.github/scripts/bump_version.py
@@ -64,7 +64,13 @@ def main(argv=None):
     )
     args = parser.parse_args(argv)
 
-    current = latest_version(list_tags())
+    try:
+        tags = list_tags()
+    except subprocess.CalledProcessError as error:
+        sys.stderr.write(error.stderr)
+        return 1
+
+    current = latest_version(tags)
     if current is None:
         print(
             "error: no vX.Y.Z tag found, create and push the first tag (v1.0.0) before releasing",

--- a/.github/scripts/test_bump_version.py
+++ b/.github/scripts/test_bump_version.py
@@ -1,0 +1,139 @@
+"""Tests for bump_version."""
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SCRIPT = HERE / "bump_version.py"
+sys.path.insert(0, str(HERE))
+
+import bump_version
+
+
+def make_repo(tags):
+    """Create a temporary git repository with one empty commit and the given tags."""
+    tmp = tempfile.TemporaryDirectory()
+    path = Path(tmp.name)
+    git = ["git", "-c", "user.email=test@example.com", "-c", "user.name=Test"]
+    subprocess.run([*git, "init", "-q", "-b", "main", "."], cwd=path, check=True)
+    subprocess.run(
+        [*git, "commit", "-q", "--allow-empty", "-m", "init"], cwd=path, check=True
+    )
+    for tag in tags:
+        subprocess.run([*git, "tag", tag], cwd=path, check=True)
+    return tmp
+
+
+def run_script(cwd, level, env=None):
+    """Run the script in cwd and return the CompletedProcess.
+
+    GITHUB_OUTPUT is dropped unless a test sets it, so a test run inside GitHub
+    Actions does not append to the real step output file.
+    """
+    if env is None:
+        env = {
+            key: value for key, value in os.environ.items() if key != "GITHUB_OUTPUT"
+        }
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), level],
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+class TestParseVersion(unittest.TestCase):
+    def test_accepts_plain_version_tag(self):
+        self.assertEqual(bump_version.parse_version("v1.2.3"), (1, 2, 3))
+        self.assertEqual(bump_version.parse_version("v10.0.11"), (10, 0, 11))
+
+    def test_rejects_anything_else(self):
+        for tag in [
+            "v1.2",
+            "1.2.3",
+            "v1.2.3.4",
+            "v1.2.3-rc1",
+            "v6.0-perf",
+            "vlatest",
+            "",
+        ]:
+            with self.subTest(tag=tag):
+                self.assertIsNone(bump_version.parse_version(tag))
+
+
+class TestLatestVersion(unittest.TestCase):
+    def test_compares_numerically_not_as_strings(self):
+        tags = ["v1.9.0", "v1.10.0", "v0.1.0"]
+        self.assertEqual(bump_version.latest_version(tags), (1, 10, 0))
+
+    def test_ignores_tags_that_are_not_versions(self):
+        tags = ["v6.0-perf", "v1.0.0", "not-a-tag"]
+        self.assertEqual(bump_version.latest_version(tags), (1, 0, 0))
+
+    def test_returns_none_when_no_tag_is_a_version(self):
+        self.assertIsNone(bump_version.latest_version(["v6.0-perf", "latest"]))
+        self.assertIsNone(bump_version.latest_version([]))
+
+
+class TestBump(unittest.TestCase):
+    def test_patch_increments_patch(self):
+        self.assertEqual(bump_version.bump((1, 2, 3), "patch"), (1, 2, 4))
+
+    def test_minor_increments_minor_and_zeroes_patch(self):
+        self.assertEqual(bump_version.bump((1, 2, 3), "minor"), (1, 3, 0))
+
+    def test_major_increments_major_and_zeroes_the_rest(self):
+        self.assertEqual(bump_version.bump((1, 2, 3), "major"), (2, 0, 0))
+
+    def test_rejects_an_unknown_level(self):
+        with self.assertRaises(ValueError):
+            bump_version.bump((1, 2, 3), "epoch")
+
+
+class TestFormatTag(unittest.TestCase):
+    def test_renders_a_version_tuple(self):
+        self.assertEqual(bump_version.format_tag((1, 10, 2)), "v1.10.2")
+
+
+class TestMain(unittest.TestCase):
+    def test_reports_current_and_next_version(self):
+        tmp = make_repo(["v1.0.0", "v1.10.0", "v6.0-perf"])
+        self.addCleanup(tmp.cleanup)
+        result = run_script(tmp.name, "minor")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("current-version=v1.10.0", result.stdout)
+        self.assertIn("next-version=v1.11.0", result.stdout)
+
+    def test_writes_github_output_when_set(self):
+        tmp = make_repo(["v2.3.4"])
+        self.addCleanup(tmp.cleanup)
+        output = Path(tmp.name) / "github_output"
+        env = dict(os.environ, GITHUB_OUTPUT=str(output))
+        result = run_script(tmp.name, "patch", env=env)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        written = output.read_text()
+        self.assertIn("current-version=v2.3.4\n", written)
+        self.assertIn("next-version=v2.3.5\n", written)
+
+    def test_fails_when_no_version_tag_exists(self):
+        tmp = make_repo(["v6.0-perf"])
+        self.addCleanup(tmp.cleanup)
+        result = run_script(tmp.name, "patch")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("v1.0.0", result.stderr)
+
+    def test_rejects_an_invalid_level(self):
+        tmp = make_repo(["v1.0.0"])
+        self.addCleanup(tmp.cleanup)
+        result = run_script(tmp.name, "epoch")
+        self.assertEqual(result.returncode, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_bump_version.py
+++ b/.github/scripts/test_bump_version.py
@@ -14,17 +14,35 @@ sys.path.insert(0, str(HERE))
 import bump_version
 
 
+def git_env():
+    """Return an environment with the developer's global/system git config disabled.
+
+    Without this, a global `commit.gpgsign = true` or `core.hooksPath` can make
+    `git commit` fail in `make_repo`, for reasons unrelated to the code under test.
+    """
+    env = dict(os.environ)
+    env["GIT_CONFIG_GLOBAL"] = "/dev/null"
+    env["GIT_CONFIG_SYSTEM"] = "/dev/null"
+    return env
+
+
 def make_repo(tags):
     """Create a temporary git repository with one empty commit and the given tags."""
     tmp = tempfile.TemporaryDirectory()
     path = Path(tmp.name)
+    env = git_env()
     git = ["git", "-c", "user.email=test@example.com", "-c", "user.name=Test"]
-    subprocess.run([*git, "init", "-q", "-b", "main", "."], cwd=path, check=True)
     subprocess.run(
-        [*git, "commit", "-q", "--allow-empty", "-m", "init"], cwd=path, check=True
+        [*git, "init", "-q", "-b", "main", "."], cwd=path, env=env, check=True
+    )
+    subprocess.run(
+        [*git, "commit", "-q", "--allow-empty", "-m", "init"],
+        cwd=path,
+        env=env,
+        check=True,
     )
     for tag in tags:
-        subprocess.run([*git, "tag", tag], cwd=path, check=True)
+        subprocess.run([*git, "tag", tag], cwd=path, env=env, check=True)
     return tmp
 
 
@@ -35,9 +53,7 @@ def run_script(cwd, level, env=None):
     Actions does not append to the real step output file.
     """
     if env is None:
-        env = {
-            key: value for key, value in os.environ.items() if key != "GITHUB_OUTPUT"
-        }
+        env = {key: value for key, value in git_env().items() if key != "GITHUB_OUTPUT"}
     return subprocess.run(
         [sys.executable, str(SCRIPT), level],
         cwd=cwd,
@@ -114,7 +130,7 @@ class TestMain(unittest.TestCase):
         tmp = make_repo(["v2.3.4"])
         self.addCleanup(tmp.cleanup)
         output = Path(tmp.name) / "github_output"
-        env = dict(os.environ, GITHUB_OUTPUT=str(output))
+        env = dict(git_env(), GITHUB_OUTPUT=str(output))
         result = run_script(tmp.name, "patch", env=env)
         self.assertEqual(result.returncode, 0, result.stderr)
         written = output.read_text()
@@ -133,6 +149,14 @@ class TestMain(unittest.TestCase):
         self.addCleanup(tmp.cleanup)
         result = run_script(tmp.name, "epoch")
         self.assertEqual(result.returncode, 2)
+
+    def test_fails_with_git_message_outside_a_git_repository(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        result = run_script(tmp.name, "patch")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("not a git repository", result.stderr)
+        self.assertNotIn("Traceback", result.stderr)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v7"
+        with:
+          persist-credentials: false
 
       - name: "Check Markdown"
         uses: "john0isaac/action-check-markdown@c255625e4ae89924a5f39a440a22e51fcc9f5893"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,9 +31,20 @@ jobs:
     runs-on: ubuntu-latest
     environment: automation
     timeout-minutes: 10
-    permissions: {}
+    permissions:
+      contents: read
 
     steps:
+      - name: "Check the ref"
+        if: ${{ !inputs.dry_run }}
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          if [ "$GITHUB_REF" != "refs/heads/$DEFAULT_BRANCH" ]; then
+            echo "A release must run on refs/heads/$DEFAULT_BRANCH, got $GITHUB_REF"
+            exit 1
+          fi
+
       - name: "Create a GitHub App token"
         id: app-token
         uses: actions/create-github-app-token@v2
@@ -48,16 +59,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: "Check the ref"
-        if: ${{ !inputs.dry_run }}
-        env:
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-        run: |
-          if [ "$GITHUB_REF" != "refs/heads/$DEFAULT_BRANCH" ]; then
-            echo "A release must run on refs/heads/$DEFAULT_BRANCH, got $GITHUB_REF"
-            exit 1
-          fi
-
       - name: "Compute the next version"
         id: bump
         env:
@@ -68,6 +69,7 @@ jobs:
         if: ${{ inputs.dry_run }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
           CURRENT_VERSION: ${{ steps.bump.outputs.current-version }}
           NEXT_VERSION: ${{ steps.bump.outputs.next-version }}
         run: |
@@ -85,10 +87,13 @@ jobs:
         if: ${{ !inputs.dry_run }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          CURRENT_VERSION: ${{ steps.bump.outputs.current-version }}
           NEXT_VERSION: ${{ steps.bump.outputs.next-version }}
         run: |
           gh release create "$NEXT_VERSION" \
             --target "$GITHUB_SHA" \
             --title "$NEXT_VERSION" \
-            --generate-notes
+            --generate-notes \
+            --notes-start-tag "$CURRENT_VERSION"
           echo "Created release $NEXT_VERSION" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,93 @@
+name: "Release"
+
+on:
+  workflow_dispatch:
+    inputs:
+      level:
+        description: "Which part of the version to bump"
+        required: true
+        type: choice
+        options:
+          - "patch"
+          - "minor"
+          - "major"
+      dry_run:
+        description: "Report the next version and preview the notes without creating anything"
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash -eu {0}
+
+jobs:
+  release:
+    name: "Release"
+    runs-on: ubuntu-latest
+    environment: automation
+    timeout-minutes: 10
+    permissions: {}
+
+    steps:
+      - name: "Create a GitHub App token"
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: "Checkout"
+        uses: "actions/checkout@v7"
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: "Check the ref"
+        if: ${{ !inputs.dry_run }}
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          if [ "$GITHUB_REF" != "refs/heads/$DEFAULT_BRANCH" ]; then
+            echo "A release must run on refs/heads/$DEFAULT_BRANCH, got $GITHUB_REF"
+            exit 1
+          fi
+
+      - name: "Compute the next version"
+        id: bump
+        env:
+          LEVEL: ${{ inputs.level }}
+        run: python3 .github/scripts/bump_version.py "$LEVEL"
+
+      - name: "Preview the release notes"
+        if: ${{ inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          CURRENT_VERSION: ${{ steps.bump.outputs.current-version }}
+          NEXT_VERSION: ${{ steps.bump.outputs.next-version }}
+        run: |
+          {
+            echo "## Dry run: $CURRENT_VERSION to $NEXT_VERSION"
+            echo
+            gh api "repos/$GITHUB_REPOSITORY/releases/generate-notes" \
+              -f tag_name="$NEXT_VERSION" \
+              -f previous_tag_name="$CURRENT_VERSION" \
+              -f target_commitish="$GITHUB_SHA" \
+              --jq ".body"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: "Create the tag and release"
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          NEXT_VERSION: ${{ steps.bump.outputs.next-version }}
+        run: |
+          gh release create "$NEXT_VERSION" \
+            --target "$GITHUB_SHA" \
+            --title "$NEXT_VERSION" \
+            --generate-notes
+          echo "Created release $NEXT_VERSION" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,7 @@ jobs:
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
 
       - name: "Checkout"
         uses: "actions/checkout@v7"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,11 @@ jobs:
     name: "Release"
     runs-on: ubuntu-latest
     environment: automation
-    timeout-minutes: 10
+    timeout-minutes: 20
     permissions:
+      # id-token is for the AWS OIDC login inside the setup action. Every
+      # privileged GitHub call uses the App token minted by secure-checkout.
+      id-token: write
       contents: read
 
     steps:
@@ -45,19 +48,19 @@ jobs:
             exit 1
           fi
 
-      - name: "Create a GitHub App token"
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ vars.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          permission-contents: write
-
       - name: "Checkout"
-        uses: "actions/checkout@v7"
+        uses: mongodb-labs/drivers-github-tools/secure-checkout@v3
         with:
+          app_id: ${{ vars.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
           fetch-depth: 0
-          persist-credentials: false
+
+      - name: "Set up the signing environment"
+        uses: mongodb-labs/drivers-github-tools/setup@v3
+        with:
+          aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
+          aws_region_name: ${{ vars.AWS_REGION_NAME }}
+          aws_secret_id: ${{ secrets.AWS_SECRET_ID }}
 
       - name: "Compute the next version"
         id: bump
@@ -68,7 +71,6 @@ jobs:
       - name: "Preview the release notes"
         if: ${{ inputs.dry_run }}
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
           CURRENT_VERSION: ${{ steps.bump.outputs.current-version }}
           NEXT_VERSION: ${{ steps.bump.outputs.next-version }}
@@ -83,16 +85,21 @@ jobs:
               --jq ".body"
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: "Create the tag and release"
+      - name: "Create the signed tag"
+        uses: mongodb-labs/drivers-github-tools/tag-version@v3
+        with:
+          version: ${{ steps.bump.outputs.next-version }}
+          push_tag: ${{ !inputs.dry_run }}
+
+      - name: "Create the release"
         if: ${{ !inputs.dry_run }}
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_REPO: ${{ github.repository }}
           CURRENT_VERSION: ${{ steps.bump.outputs.current-version }}
           NEXT_VERSION: ${{ steps.bump.outputs.next-version }}
         run: |
           gh release create "$NEXT_VERSION" \
-            --target "$GITHUB_SHA" \
+            --verify-tag \
             --title "$NEXT_VERSION" \
             --generate-notes \
             --notes-start-tag "$CURRENT_VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
   release:
     name: "Release"
     runs-on: ubuntu-latest
-    environment: automation
+    environment: release
     timeout-minutes: 20
     permissions:
       # id-token is for the AWS OIDC login inside the setup action. Every

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,6 +57,7 @@ jobs:
         uses: "actions/checkout@v7"
         with:
           fetch-depth: 2
+          persist-credentials: false
 
       - id: setup-mongodb
         name: "Run GitHub Action"
@@ -83,6 +84,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
+      with:
+        persist-credentials: false
     - uses: actions/setup-python@v7
     - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
 
@@ -90,6 +93,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v7
       - id: cache-restore
         uses: actions/cache@v6
@@ -103,3 +108,15 @@ jobs:
       - name: Lint
         working-directory: .evergreen/github_app
         run: npm run lint
+
+  bump-version:
+    name: "Bump Version Script"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v7
+      - name: "Run unit tests"
+        run: python3 -m unittest discover -s .github/scripts -p "test_*.py" -v

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,16 @@ contain a README.md with usage instructions, including example Evergreen config 
 It should also have a test file in `.evergreen/tests` and be run as a dedicated task in this repository.
 If it does not use assets like Atlas or a VM, then it should have a "pr" tag so that it runs on PRs.
 
+## Releasing
+
+Releases are cut by hand from the "Release" workflow in GitHub Actions. Pick a bump level of
+`patch`, `minor`, or `major`. The workflow reads the highest `vX.Y.Z` tag, computes the next
+version, then creates that tag and a GitHub release whose notes are generated from the commits
+since the previous tag.
+
+Select `dry_run` to print the next version and a preview of the notes without creating a tag or a
+release. A real release only runs on the default branch, and the tag it creates is signed.
+
 ## Helpful Links
 
 See the [Drivers Cloud Services](https://wiki.corp.mongodb.com/spaces/DRIVERS/pages/473895023/Drivers+Cloud+Services) wiki

--- a/README.md
+++ b/README.md
@@ -185,19 +185,7 @@ version, then creates that tag and a GitHub release whose notes are generated fr
 since the previous tag.
 
 Select `dry_run` to print the next version and a preview of the notes without creating a tag or a
-release. A real release only runs on the default branch.
-
-The workflow needs a `release` environment holding an `APP_ID` variable and an
-`APP_PRIVATE_KEY` secret for a GitHub App, and that App must be installed with `contents: write`
-permission. A `vX.Y.Z` tag must already exist in the repository, since the script fails when it
-finds none.
-
-The release tag is signed, and signing runs through `mongodb-labs/drivers-github-tools`. The
-`release` environment additionally needs `AWS_ROLE_ARN` and `AWS_SECRET_ID` secrets and an
-`AWS_REGION_NAME` variable, which MongoDB release infrastructure provisions.
-
-The version arithmetic lives in `.github/scripts/bump_version.py` and is covered by
-`.github/scripts/test_bump_version.py`.
+release. A real release only runs on the default branch, and the tag it creates is signed.
 
 ## Setup and Teardown
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,11 @@ since the previous tag.
 Select `dry_run` to print the next version and a preview of the notes without creating a tag or a
 release. A real release only runs on the default branch.
 
+The workflow needs an `automation` environment holding an `APP_ID` variable and an
+`APP_PRIVATE_KEY` secret for a GitHub App, and that App must be installed with `contents: write`
+permission. A `vX.Y.Z` tag must already exist in the repository, since the script fails when it
+finds none.
+
 The version arithmetic lives in `.github/scripts/bump_version.py` and is covered by
 `.github/scripts/test_bump_version.py`.
 

--- a/README.md
+++ b/README.md
@@ -187,13 +187,13 @@ since the previous tag.
 Select `dry_run` to print the next version and a preview of the notes without creating a tag or a
 release. A real release only runs on the default branch.
 
-The workflow needs an `automation` environment holding an `APP_ID` variable and an
+The workflow needs a `release` environment holding an `APP_ID` variable and an
 `APP_PRIVATE_KEY` secret for a GitHub App, and that App must be installed with `contents: write`
 permission. A `vX.Y.Z` tag must already exist in the repository, since the script fails when it
 finds none.
 
 The release tag is signed, and signing runs through `mongodb-labs/drivers-github-tools`. The
-`automation` environment additionally needs `AWS_ROLE_ARN` and `AWS_SECRET_ID` secrets and an
+`release` environment additionally needs `AWS_ROLE_ARN` and `AWS_SECRET_ID` secrets and an
 `AWS_REGION_NAME` variable, which MongoDB release infrastructure provisions.
 
 The version arithmetic lives in `.github/scripts/bump_version.py` and is covered by

--- a/README.md
+++ b/README.md
@@ -125,19 +125,6 @@ See [run-orchestration.sh](./.evergreen/run-orchestration.sh) for the available 
 
 Run `bash ./evergreen/start-orchestration.sh --help` for usage of command line flags.
 
-## Releasing
-
-Releases are cut by hand from the "Release" workflow in GitHub Actions. Pick a bump level of
-`patch`, `minor`, or `major`. The workflow reads the highest `vX.Y.Z` tag, computes the next
-version, then creates that tag and a GitHub release whose notes are generated from the commits
-since the previous tag.
-
-Select `dry_run` to print the next version and a preview of the notes without creating a tag or a
-release. A real release only runs on the default branch.
-
-The version arithmetic lives in `.github/scripts/bump_version.py` and is covered by
-`.github/scripts/test_bump_version.py`.
-
 ### Usage of MongoDB Runner
 
 As part of [DRIVERS-3335](https://jira.mongodb.org/browse/DRIVERS-3335) we are migrating away from
@@ -189,6 +176,19 @@ To fix it, simply run:
 ```sh
 softwareupdate --install-rosetta
 ```
+
+## Releasing
+
+Releases are cut by hand from the "Release" workflow in GitHub Actions. Pick a bump level of
+`patch`, `minor`, or `major`. The workflow reads the highest `vX.Y.Z` tag, computes the next
+version, then creates that tag and a GitHub release whose notes are generated from the commits
+since the previous tag.
+
+Select `dry_run` to print the next version and a preview of the notes without creating a tag or a
+release. A real release only runs on the default branch.
+
+The version arithmetic lives in `.github/scripts/bump_version.py` and is covered by
+`.github/scripts/test_bump_version.py`.
 
 ## Setup and Teardown
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ The following inputs exist:
 
 These correspond to the respective environment variables that are passed to `run-orchestration.sh`.
 
+The example above tracks `master`. To pin a published version instead, use a release tag such as
+`mongodb-labs/drivers-evergreen-tools@v1.0.0`. See [Releasing](#releasing).
+
 After the cluster is started, its URI is exposed via the `cluster-uri` output. In addition, the action also exposes the
 path to `crypt_shared` via the `crypt-shared-lib-path` output, unless the installation was not requested or failed.
 This configuration snippet environment variables with the cluster URI and `crypt_shared` lib path
@@ -121,6 +124,19 @@ MONGODB_BINARIES folder or setting MONGODB_BINARIES to the appropriate folder.
 See [run-orchestration.sh](./.evergreen/run-orchestration.sh) for the available environment variables.
 
 Run `bash ./evergreen/start-orchestration.sh --help` for usage of command line flags.
+
+## Releasing
+
+Releases are cut by hand from the "Release" workflow in GitHub Actions. Pick a bump level of
+`patch`, `minor`, or `major`. The workflow reads the highest `vX.Y.Z` tag, computes the next
+version, then creates that tag and a GitHub release whose notes are generated from the commits
+since the previous tag.
+
+Select `dry_run` to print the next version and a preview of the notes without creating a tag or a
+release. A real release only runs on the default branch.
+
+The version arithmetic lives in `.github/scripts/bump_version.py` and is covered by
+`.github/scripts/test_bump_version.py`.
 
 ### Usage of MongoDB Runner
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ The following inputs exist:
 These correspond to the respective environment variables that are passed to `run-orchestration.sh`.
 
 The example above tracks `master`. To pin a published version instead, use a release tag such as
-`mongodb-labs/drivers-evergreen-tools@v1.0.0`. See [Releasing](#releasing).
+`mongodb-labs/drivers-evergreen-tools@v1.0.0`. See [Releasing](CONTRIBUTING.md#releasing) for how
+those versions are cut.
 
 After the cluster is started, its URI is exposed via the `cluster-uri` output. In addition, the action also exposes the
 path to `crypt_shared` via the `crypt-shared-lib-path` output, unless the installation was not requested or failed.
@@ -176,16 +177,6 @@ To fix it, simply run:
 ```sh
 softwareupdate --install-rosetta
 ```
-
-## Releasing
-
-Releases are cut by hand from the "Release" workflow in GitHub Actions. Pick a bump level of
-`patch`, `minor`, or `major`. The workflow reads the highest `vX.Y.Z` tag, computes the next
-version, then creates that tag and a GitHub release whose notes are generated from the commits
-since the previous tag.
-
-Select `dry_run` to print the next version and a preview of the notes without creating a tag or a
-release. A real release only runs on the default branch, and the tag it creates is signed.
 
 ## Setup and Teardown
 

--- a/README.md
+++ b/README.md
@@ -192,6 +192,10 @@ The workflow needs an `automation` environment holding an `APP_ID` variable and 
 permission. A `vX.Y.Z` tag must already exist in the repository, since the script fails when it
 finds none.
 
+The release tag is signed, and signing runs through `mongodb-labs/drivers-github-tools`. The
+`automation` environment additionally needs `AWS_ROLE_ARN` and `AWS_SECRET_ID` secrets and an
+`AWS_REGION_NAME` variable, which MongoDB release infrastructure provisions.
+
 The version arithmetic lives in `.github/scripts/bump_version.py` and is covered by
 `.github/scripts/test_bump_version.py`.
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -41,3 +41,4 @@ unfixable = ["F401"]
 ".evergreen/ocsp/mock_ocsp_responder.py" = ["PLW"]
 ".evergreen/csfle/kms_*.py" = ["PLW"]
 ".evergreen/csfle/gcpkms/mock_server.py" = ["PLW"]
+".github/scripts/test_*.py" = ["PT"]      # unittest, not pytest


### PR DESCRIPTION
[DRIVERS-3602](https://jira.mongodb.org/browse/DRIVERS-3602)

## Summary

This repository is consumed as a GitHub composite action but had no version tags, so the documented usage pins `@master` and consumers cannot pin an immutable version.

This adds a manually triggered `Release` workflow that bumps the version by `patch`, `minor`, or `major`, creates a signed tag, and publishes a GitHub Release with generated notes. Dry run mode reports the next version and previews the notes without creating anything. Tags are exact versions only, with no floating `v1`, so a published tag never moves.

## Changes in this PR

- `.github/workflows/release.yml`: the workflow. Runs in the `release` environment, authenticates with a GitHub App, and refuses a real release unless dispatched from the default branch. Signs the tag with `mongodb-labs/drivers-github-tools@v3` (`secure-checkout`, `setup`, `tag-version`), then attaches the release with `--verify-tag`.
- `.github/scripts/bump_version.py`: computes the next version from the highest `vX.Y.Z` tag. Standard library only, and fails rather than guessing when no tag exists.
- `.github/scripts/test_bump_version.py` and a `bump-version` job in `tests.yml`: 15 unit tests.
- `CONTRIBUTING.md`: a `Releasing` section, with a `README.md` pointer to it for pinning a released tag.
- `tests.yml`, `markdown.yml`: `persist-credentials: false` on the existing checkouts.
- `ruff.toml`: narrow `PT` ignore for the new `unittest` tests.

## Test Plan

Unit tests run in CI. The workflow was exercised against this repository from a temporary branch, with the default branch switched for the duration and restored afterward.

- Dry run, [run 31605449625](https://github.com/mongodb-labs/drivers-evergreen-tools/actions/runs/31605449625): reported `v0.1.0` to `v0.1.1`, previewed the notes, signed a tag inside the Garasign container with `git verify-tag` passing, and created nothing.
- Real [release](https://github.com/mongodb-labs/drivers-evergreen-tools/releases/tag/v0.1.1), [run 31605788361](https://github.com/mongodb-labs/drivers-evergreen-tools/actions/runs/31605788361): signed annotated tag `v0.1.1` by `mongodb-dbx-release-bot[bot]`, notes scoped from `v0.1.0`. Both releases were left in place as the baseline for this rollout.
- Branch guard: a real release dispatched from `refs/tags/v0.1.1` aborted at the first step, before any App token was minted. That run has since been deleted from the history.

After this merges, a `major` run produces `v1.0.0`.

## Checklist

### Checklist for Author

- [x] Does the title of the PR reference a JIRA Ticket?
- [x] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [x] Is all relevant documentation (README or docstring) updated?

### Checklist for Reviewer

- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?
