### PR TITLE
DRIVERS-3622: Add agent-facing documentation (AGENTS.md/CLAUDE.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,105 @@
+# AGENTS.md
+
+Instructions for coding agents working in this repository. Human contributors should
+read [README.md](./README.md) (what this repo is, how drivers consume it) and
+[CONTRIBUTING.md](./CONTRIBUTING.md) (server-version and Python support policy, new-feature
+process) first; this file assumes both and adds only what an agent needs to act.
+
+## What this repo is
+
+Drivers bootstrap their Evergreen CI configuration from this repo — scripts for
+downloading MongoDB, launching topologies, and other tasks most drivers need. See
+[README.md](./README.md) for how drivers consume it and
+[https://evergreen.mongodb.com/waterfall/drivers-tools](https://evergreen.mongodb.com/waterfall/drivers-tools)
+for the CI that runs it.
+
+## Repo layout
+
+- Root: `Makefile`, `CONTRIBUTING.md`, `README.md`, `ruff.toml`, `.pre-commit-config.yaml`,
+  and `.evergreen/pyproject.toml` (packages `mongodl`, `mongosh-dl`, `socks5srv`).
+- `.evergreen/<feature>/` — one subfolder per feature (e.g. `csfle`, `atlas`,
+  `auth_oidc`, `k8s`), each with its own README and scripts. New features follow this
+  layout (see [CONTRIBUTING.md#new-features](./CONTRIBUTING.md#new-features)).
+- `.evergreen/orchestration/` — the MongoDB server/topology launcher, its own
+  `pyproject.toml`, and its own dependency lockfile (`uv.lock`), separate from the
+  root package.
+- `.evergreen/tests/` — `test-<feature>.sh` scripts; these are the test suite (see
+  Testing below), run as Evergreen tasks, not a pytest suite.
+
+## Prerequisites
+
+- `DRIVERS_TOOLS` — expected to point at the repo root; several scripts read it.
+- `.evergreen/find-python3.sh` — sourced by scripts needing a Python interpreter; a
+  handful of older scripts still use its `find_python3`/`venvcreate` path instead of `uv`.
+- `.evergreen/ensure-uv.sh` (`ensure_uv`) — installs/locates `uv` and scopes its state
+  under the task's temp dir in CI, and under this checkout locally, so a local run
+  can't disturb globally installed tools.
+- `uv` runs most Python scripts (`uv run`) and manages CLI installs; isolated virtual
+  environments are used throughout, never the system interpreter.
+
+## Running things
+
+- `make run-server` / `make run-local-atlas` — start a MongoDB deployment.
+- `make stop-server` — stop it.
+- `make test-connect` — check connectivity to a running deployment
+  (`.evergreen/check-connection.sh`).
+- `make clean` — remove generated files (`.evergreen/clean.sh`).
+- `make test` is a **legacy stub** — it prints a canned pass and writes a placeholder
+  `test-results.json`. `.evergreen/tests/test-cli.sh` calls it directly as live CI
+  behavior, so it can't be changed; it is not real validation and running it proves
+  nothing about a change.
+
+## Python CLIs
+
+Two independently packaged CLIs, both installed via
+`bash .evergreen/install-cli.sh <dir>` (uv-managed, isolated):
+
+- From `.evergreen/pyproject.toml`: `mongodl`, `mongosh-dl`, `socks5srv`.
+- From `.evergreen/orchestration/pyproject.toml`: `drivers-orchestration`.
+
+Everything else under `.evergreen/` is an unpackaged script — run directly, e.g.
+`python3 .evergreen/<path>.py --help`.
+
+## Testing
+
+There is no pytest suite. Validation is:
+
+- `.evergreen/tests/test-*.sh` — one script per feature area, run as Evergreen tasks.
+- `.github/workflows/tests.yml` — GitHub Actions test workflow.
+- `.github/workflows/markdown.yml` — checks for broken relative links in Markdown files.
+
+## Pre-commit / linting
+
+`make lint` is the validation entry point — there is no `just`, no `justfile`, and no
+mypy step in this repo; don't assume the conventions from other repos apply here.
+
+- `make install` once, to set up `pre-commit` — this installs it into `.bin/` under
+  this checkout via `uv`, not globally, so a bare `pre-commit` command on `PATH` won't
+  work unless you've run `make install` in this shell session.
+- `make lint` runs `pre-commit run --all-files`. If it modifies files (many hooks
+  auto-fix in place) it exits non-zero on that run — re-run `make lint` to confirm clean;
+  there is no separate "fix" mode, checking and fixing happen in the same pass.
+- `make lint HOOK=<hook-id>` runs a single hook (e.g. `make lint HOOK=shellcheck`).
+
+Run `make lint` before opening a PR.
+
+## Adding a new feature
+
+Per [CONTRIBUTING.md#new-features](./CONTRIBUTING.md#new-features): a new folder under
+`.evergreen/<feature>/` with a `README.md` (usage instructions, example Evergreen config
+where relevant) and a test file at `.evergreen/tests/test-<feature>.sh`, wired up as a
+dedicated Evergreen task. Tag it `pr` if it's self-contained enough to run on every PR.
+
+## PR requirements
+
+- Title references a JIRA ticket (see `.github/pull_request_template.md`).
+- Body fills in Summary / Changes in this PR / Test Plan.
+- Run `make lint` first — CI checks the same things.
+
+## Gotchas
+
+- Gitignored build artifacts (venvs, `uv` caches, downloaded binaries) are not source —
+  don't treat their presence or absence as a signal about what changed.
+- Shell scripts need a shebang and the executable bit; Evergreen invokes them directly.
+- The CI matrix includes Windows — avoid assumptions that only hold on Unix (path
+  separators, `cygpath`, case sensitivity).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,9 @@ for the CI that runs it.
 
 ## Running things
 
-- `make run-server` or `make run-local-atlas` starts a MongoDB deployment.
+- `make run-server` or `make run-local-atlas` starts a MongoDB deployment. Both are
+  configured through environment variables (topology, auth, SSL, version, and more); see
+  the comment block at the top of `.evergreen/run-mongodb.sh` for the full list.
 - `make stop-server` stops it.
 - `make test-connect` checks connectivity to a running deployment
   (`.evergreen/check-connection.sh`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,11 +31,14 @@ for the CI that runs it.
 - `DRIVERS_TOOLS`: expected to point at the repo root. Several scripts read it.
 - `.evergreen/find-python3.sh`: sourced by scripts that need a Python interpreter. A
   handful of older scripts still use its `find_python3`/`venvcreate` path instead of `uv`.
-- `.evergreen/ensure-uv.sh` (`ensure_uv`): installs or locates `uv` and scopes its state
-  under the task's temp directory in CI, and under this checkout locally, so a local run
-  can't disturb globally installed tools.
-- `uv` runs most Python scripts (`uv run`) and manages CLI installs. Scripts use isolated
-  virtual environments, never the system interpreter.
+- `.evergreen/ensure-uv.sh` (`ensure_uv`): installs or locates `uv`. In CI it scopes uv's
+  cache, tool, and Python install dirs under the task's temp directory; outside CI it
+  only redirects the tool dir, so a local `uv tool install --force` can't overwrite
+  globally installed tools, and the cache stays shared to avoid re-downloading.
+- `uv` runs most Python scripts (`uv run`) and manages CLI installs, but not all: some
+  scripts (`.evergreen/clean.sh`) call `python3` directly, and some features (`auth_aws`)
+  still use the legacy `find-python3.sh`/`venvcreate` virtual environments. Check the
+  script before assuming uv isolation.
 
 ## Running things
 
@@ -50,14 +53,16 @@ for the CI that runs it.
 
 ## Python CLIs
 
-Two independently packaged CLIs, both installed with
+Two independently packaged CLI projects, both installed with
 `bash .evergreen/install-cli.sh <dir>` (uv-managed, isolated):
 
 - `.evergreen/pyproject.toml` packages `mongodl`, `mongosh-dl`, `socks5srv`.
 - `.evergreen/orchestration/pyproject.toml` packages `drivers-orchestration`.
 
-Everything else under `.evergreen/` is an unpackaged script. Run it directly, e.g.
-`python3 .evergreen/<path>.py --help`.
+Everything else under `.evergreen/` is an unpackaged script. Check the script and its
+feature directory for a setup wrapper (e.g. `auth_aws/activate-authawsvenv.sh`) before
+running it: some import dependencies (`pymongo`) that only exist in a feature-specific
+virtual environment, so a direct `python3 <path>.py --help` fails on import first.
 
 ## Testing
 
@@ -73,8 +78,9 @@ There is no pytest suite. Validation is:
 step in this repo; conventions from other repos don't carry over.
 
 - Run `make install` once to set up `pre-commit`. It installs `pre-commit` into `.bin/`
-  under this checkout using `uv`, not globally, so a bare `pre-commit` command on `PATH`
-  only works after `make install` has run in that shell session.
+  under this checkout using `uv`, not globally. The `PATH` change lives only inside the
+  Make recipe, so a bare `pre-commit` command never resolves in your shell; use
+  `make lint` instead.
 - `make lint` runs `pre-commit run --all-files`. Many hooks auto-fix in place, so a run
   that modifies files exits non-zero even though it fixed the problem; re-run `make lint`
   to confirm clean. There is no separate fix mode.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,10 @@ feature directory for a setup wrapper (e.g. `auth_aws/activate-authawsvenv.sh`) 
 running it: some import dependencies (`pymongo`) that only exist in a feature-specific
 virtual environment, so a direct `python3 <path>.py --help` fails on import first.
 
+Not everything under `.evergreen/` is Python: `.evergreen/github_app/` is an npm project
+(its own `package.json`, linted separately), and `.evergreen/mongoproxy/` and
+`.evergreen/perfcomp/` are Go modules (their own `go.mod`, tested with `go test ./...`).
+
 ## Testing
 
 There is no pytest suite. Validation is:
@@ -71,6 +75,10 @@ There is no pytest suite. Validation is:
 - `.evergreen/tests/test-*.sh`: one script per feature area, run as Evergreen tasks.
 - `.github/workflows/tests.yml`: GitHub Actions test workflow.
 - `.github/workflows/markdown.yml`: checks for broken relative links in Markdown files.
+
+Outside that, `.evergreen/mongoproxy/` and `.evergreen/perfcomp/` have their own Go tests
+(`go test ./...`, per each folder's README), and `.github/scripts/test_*.py` has its own
+unittest suite, run by the `bump-version` job in `tests.yml`.
 
 ## Pre-commit and linting
 
@@ -99,7 +107,9 @@ dedicated Evergreen task. Tag it `pr` if it's self-contained enough to run on ev
 
 - Title references a JIRA ticket; see `.github/pull_request_template.md`.
 - Body fills in Summary, Changes in this PR, and Test Plan.
-- Run `make lint` first. CI checks the same things.
+- Run `make lint` first. CI checks the same things in its own `pre-commit` job, but also
+  runs a deployment test matrix, `eslint` on `.evergreen/github_app/`, and the
+  `.github/scripts/test_*.py` unittest suite; `make lint` doesn't cover those.
 
 ## Gotchas
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,10 +100,8 @@ Run `make lint` before opening a PR.
 
 ## Adding a new feature
 
-Per [CONTRIBUTING.md#new-features](./CONTRIBUTING.md#new-features): add a folder under
-`.evergreen/<feature>/` with a `README.md` (usage instructions, example Evergreen config
-where relevant) and a test file at `.evergreen/tests/test-<feature>.sh`, wired up as a
-dedicated Evergreen task. Tag it `pr` if it's self-contained enough to run on every PR.
+Per [CONTRIBUTING.md#new-features](./CONTRIBUTING.md#new-features), with the test file
+named `.evergreen/tests/test-<feature>.sh`.
 
 ## PR requirements
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,105 +1,104 @@
 # AGENTS.md
 
-Instructions for coding agents working in this repository. Human contributors should
-read [README.md](./README.md) (what this repo is, how drivers consume it) and
-[CONTRIBUTING.md](./CONTRIBUTING.md) (server-version and Python support policy, new-feature
-process) first; this file assumes both and adds only what an agent needs to act.
+Instructions for coding agents working in this repository. Read [README.md](./README.md)
+(what this repo is, how drivers consume it) and [CONTRIBUTING.md](./CONTRIBUTING.md)
+(server-version and Python support policy, new-feature process) first; this file assumes
+both and adds only what an agent needs to act.
 
 ## What this repo is
 
-Drivers bootstrap their Evergreen CI configuration from this repo — scripts for
+Drivers bootstrap their Evergreen CI configuration from this repo. It contains scripts for
 downloading MongoDB, launching topologies, and other tasks most drivers need. See
-[README.md](./README.md) for how drivers consume it and
+[README.md](./README.md) for how drivers consume it, and
 [https://evergreen.mongodb.com/waterfall/drivers-tools](https://evergreen.mongodb.com/waterfall/drivers-tools)
 for the CI that runs it.
 
 ## Repo layout
 
-- Root: `Makefile`, `CONTRIBUTING.md`, `README.md`, `ruff.toml`, `.pre-commit-config.yaml`,
-  and `.evergreen/pyproject.toml` (packages `mongodl`, `mongosh-dl`, `socks5srv`).
-- `.evergreen/<feature>/` — one subfolder per feature (e.g. `csfle`, `atlas`,
-  `auth_oidc`, `k8s`), each with its own README and scripts. New features follow this
-  layout (see [CONTRIBUTING.md#new-features](./CONTRIBUTING.md#new-features)).
-- `.evergreen/orchestration/` — the MongoDB server/topology launcher, its own
-  `pyproject.toml`, and its own dependency lockfile (`uv.lock`), separate from the
-  root package.
-- `.evergreen/tests/` — `test-<feature>.sh` scripts; these are the test suite (see
-  Testing below), run as Evergreen tasks, not a pytest suite.
+- Root: `Makefile`, `CONTRIBUTING.md`, `README.md`, `ruff.toml`, `.pre-commit-config.yaml`.
+- `.evergreen/pyproject.toml` packages `mongodl`, `mongosh-dl`, and `socks5srv`.
+- `.evergreen/<feature>/`: one subfolder per feature (e.g. `csfle`, `atlas`, `auth_oidc`,
+  `k8s`), each with its own README and scripts. New features follow this layout; see
+  [CONTRIBUTING.md#new-features](./CONTRIBUTING.md#new-features).
+- `.evergreen/orchestration/`: the MongoDB server/topology launcher. Has its own
+  `pyproject.toml` and its own dependency lockfile (`uv.lock`), independent of
+  `.evergreen/pyproject.toml`.
+- `.evergreen/tests/`: `test-<feature>.sh` scripts. These are the test suite (see Testing
+  below), run as Evergreen tasks, not a pytest suite.
 
 ## Prerequisites
 
-- `DRIVERS_TOOLS` — expected to point at the repo root; several scripts read it.
-- `.evergreen/find-python3.sh` — sourced by scripts needing a Python interpreter; a
+- `DRIVERS_TOOLS`: expected to point at the repo root. Several scripts read it.
+- `.evergreen/find-python3.sh`: sourced by scripts that need a Python interpreter. A
   handful of older scripts still use its `find_python3`/`venvcreate` path instead of `uv`.
-- `.evergreen/ensure-uv.sh` (`ensure_uv`) — installs/locates `uv` and scopes its state
-  under the task's temp dir in CI, and under this checkout locally, so a local run
+- `.evergreen/ensure-uv.sh` (`ensure_uv`): installs or locates `uv` and scopes its state
+  under the task's temp directory in CI, and under this checkout locally, so a local run
   can't disturb globally installed tools.
-- `uv` runs most Python scripts (`uv run`) and manages CLI installs; isolated virtual
-  environments are used throughout, never the system interpreter.
+- `uv` runs most Python scripts (`uv run`) and manages CLI installs. Scripts use isolated
+  virtual environments, never the system interpreter.
 
 ## Running things
 
-- `make run-server` / `make run-local-atlas` — start a MongoDB deployment.
-- `make stop-server` — stop it.
-- `make test-connect` — check connectivity to a running deployment
+- `make run-server` or `make run-local-atlas` starts a MongoDB deployment.
+- `make stop-server` stops it.
+- `make test-connect` checks connectivity to a running deployment
   (`.evergreen/check-connection.sh`).
-- `make clean` — remove generated files (`.evergreen/clean.sh`).
-- `make test` is a **legacy stub** — it prints a canned pass and writes a placeholder
+- `make clean` removes generated files (`.evergreen/clean.sh`).
+- `make test` is a legacy stub: it prints a canned pass and writes a placeholder
   `test-results.json`. `.evergreen/tests/test-cli.sh` calls it directly as live CI
-  behavior, so it can't be changed; it is not real validation and running it proves
-  nothing about a change.
+  behavior, so it can't be changed. It proves nothing about a change.
 
 ## Python CLIs
 
-Two independently packaged CLIs, both installed via
+Two independently packaged CLIs, both installed with
 `bash .evergreen/install-cli.sh <dir>` (uv-managed, isolated):
 
-- From `.evergreen/pyproject.toml`: `mongodl`, `mongosh-dl`, `socks5srv`.
-- From `.evergreen/orchestration/pyproject.toml`: `drivers-orchestration`.
+- `.evergreen/pyproject.toml` packages `mongodl`, `mongosh-dl`, `socks5srv`.
+- `.evergreen/orchestration/pyproject.toml` packages `drivers-orchestration`.
 
-Everything else under `.evergreen/` is an unpackaged script — run directly, e.g.
+Everything else under `.evergreen/` is an unpackaged script. Run it directly, e.g.
 `python3 .evergreen/<path>.py --help`.
 
 ## Testing
 
 There is no pytest suite. Validation is:
 
-- `.evergreen/tests/test-*.sh` — one script per feature area, run as Evergreen tasks.
-- `.github/workflows/tests.yml` — GitHub Actions test workflow.
-- `.github/workflows/markdown.yml` — checks for broken relative links in Markdown files.
+- `.evergreen/tests/test-*.sh`: one script per feature area, run as Evergreen tasks.
+- `.github/workflows/tests.yml`: GitHub Actions test workflow.
+- `.github/workflows/markdown.yml`: checks for broken relative links in Markdown files.
 
-## Pre-commit / linting
+## Pre-commit and linting
 
-`make lint` is the validation entry point — there is no `just`, no `justfile`, and no
-mypy step in this repo; don't assume the conventions from other repos apply here.
+`make lint` is the validation entry point. There is no `just`, no `justfile`, and no mypy
+step in this repo; conventions from other repos don't carry over.
 
-- `make install` once, to set up `pre-commit` — this installs it into `.bin/` under
-  this checkout via `uv`, not globally, so a bare `pre-commit` command on `PATH` won't
-  work unless you've run `make install` in this shell session.
-- `make lint` runs `pre-commit run --all-files`. If it modifies files (many hooks
-  auto-fix in place) it exits non-zero on that run — re-run `make lint` to confirm clean;
-  there is no separate "fix" mode, checking and fixing happen in the same pass.
-- `make lint HOOK=<hook-id>` runs a single hook (e.g. `make lint HOOK=shellcheck`).
+- Run `make install` once to set up `pre-commit`. It installs `pre-commit` into `.bin/`
+  under this checkout using `uv`, not globally, so a bare `pre-commit` command on `PATH`
+  only works after `make install` has run in that shell session.
+- `make lint` runs `pre-commit run --all-files`. Many hooks auto-fix in place, so a run
+  that modifies files exits non-zero even though it fixed the problem; re-run `make lint`
+  to confirm clean. There is no separate fix mode.
+- `make lint HOOK=<hook-id>` runs a single hook, e.g. `make lint HOOK=shellcheck`.
 
 Run `make lint` before opening a PR.
 
 ## Adding a new feature
 
-Per [CONTRIBUTING.md#new-features](./CONTRIBUTING.md#new-features): a new folder under
+Per [CONTRIBUTING.md#new-features](./CONTRIBUTING.md#new-features): add a folder under
 `.evergreen/<feature>/` with a `README.md` (usage instructions, example Evergreen config
 where relevant) and a test file at `.evergreen/tests/test-<feature>.sh`, wired up as a
 dedicated Evergreen task. Tag it `pr` if it's self-contained enough to run on every PR.
 
 ## PR requirements
 
-- Title references a JIRA ticket (see `.github/pull_request_template.md`).
-- Body fills in Summary / Changes in this PR / Test Plan.
-- Run `make lint` first — CI checks the same things.
+- Title references a JIRA ticket; see `.github/pull_request_template.md`.
+- Body fills in Summary, Changes in this PR, and Test Plan.
+- Run `make lint` first. CI checks the same things.
 
 ## Gotchas
 
-- Gitignored build artifacts (venvs, `uv` caches, downloaded binaries) are not source —
-  don't treat their presence or absence as a signal about what changed.
+- Gitignored build artifacts (venvs, `uv` caches, downloaded binaries) aren't source.
+  Their presence or absence isn't a signal about what changed.
 - Shell scripts need a shebang and the executable bit; Evergreen invokes them directly.
-- The CI matrix includes Windows — avoid assumptions that only hold on Unix (path
-  separators, `cygpath`, case sensitivity).
+- The CI matrix includes Windows. Don't assume Unix-only behavior for path separators,
+  `cygpath`, or case sensitivity.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,1 @@
-# CLAUDE.md
-
-This repo's agent instructions (build/run/test, conventions, gotchas) live in
-[AGENTS.md](./AGENTS.md). It is the source of truth for coding agents working in this
-repository; read it before making changes.
-
 @AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# CLAUDE.md
+
+This repo's agent instructions (build/run/test, conventions, gotchas) live in
+[AGENTS.md](./AGENTS.md), which is the source of truth for all coding agents
+working in this repository — read it before making changes.
+
+@AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md
 
 This repo's agent instructions (build/run/test, conventions, gotchas) live in
-[AGENTS.md](./AGENTS.md), which is the source of truth for all coding agents
-working in this repository — read it before making changes.
+[AGENTS.md](./AGENTS.md). It is the source of truth for coding agents working in this
+repository; read it before making changes.
 
 @AGENTS.md


### PR DESCRIPTION
DRIVERS-3622

## Summary

This repo has no agent-facing documentation, so coding agents can't discover its structure, prerequisites, or the `make install`/`make lint` workflow (added in DRIVERS-3590) before making a change.

## Changes in this PR

- Added `AGENTS.md` documenting repo structure, prerequisites, running scripts, the Python CLIs, testing, the pre-commit workflow, new-feature conventions, PR requirements, and gotchas.
- Added `CLAUDE.md` pointing coding agents to `AGENTS.md` as the source of truth.

## Test Plan

- `make install && make lint` runs clean, including against the new files.
- `make lint HOOK=codespell` still runs a single hook.
- Verified the relative links in `AGENTS.md`/`CLAUDE.md` resolve (`README.md`, `CONTRIBUTING.md`, `CONTRIBUTING.md#new-features` all exist).

## Checklist

<!-- Do not delete the items provided on this checklist -->

### Checklist for Author

- [x] Does the title of the PR reference a JIRA Ticket?
- [x] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [x] Is all relevant documentation (README or docstring) updated?

### Checklist for Reviewer

- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?