### PR TITLE
DRIVERS-3626: Route MongoDB 4.2 to mongo-orchestration

### DIFF
--- a/.evergreen/orchestration/drivers_orchestration.py
+++ b/.evergreen/orchestration/drivers_orchestration.py
@@ -567,9 +567,12 @@ def run(opts):
     if opts.local_atlas:
         opts.mongodb_runner = False
 
-    if opts.mongodb_runner and version in ("3.6", "4.0"):
+    # mongodb-runner drives the server with the Node driver, which dropped 4.2 in
+    # mongodb 7.6.0. mongodb-runner asks for ^7.2.0, so it can no longer reach a
+    # 4.2 server at all: the handshake fails on wire version 8.
+    if opts.mongodb_runner and version in ("3.6", "4.0", "4.2"):
         LOGGER.warning(
-            "mongodb-runner does not support MongoDB < 4.2, using mongo-orchestration"
+            "mongodb-runner does not support MongoDB < 4.4, using mongo-orchestration"
         )
         opts.mongodb_runner = False
 


### PR DESCRIPTION
DRIVERS-3626
Passing [build](https://spruce.corp.mongodb.com/task/drivers_tools_tests_all__os_fully_featured~rhel8_auth~auth_ssl~nossl_test_mongodb_runner_full_patch_199e3ef1a8688415d688d3ff928ddb1f19c14f07_6a8f7a947e00f200070c39c0_26_08_26_23_45_26/logs?execution=0) with 4.2.

## Summary

Every MongoDB 4.2 server started through `mongodb-runner` has failed its handshake since 2026-08-24, when `mongodb` 7.6.0 raised the Node driver's `minWireVersion` to 9 (NODE-7547). Routing 4.2 to `mongo-orchestration`, which the gate already does for 3.6 and 4.0, unblocks CI.

Nothing here changed to cause it: `mongodb-runner` 6.8.2 asks for `mongodb: ^7.2.0` with no lockfile, so `test-mongodb-runner-full` passed on mainline on 2026-08-22 and the same revision failed two days later. This is a stop-gap; the main DRIVERS-3626 pull request locks the install and pins the driver per server version, then removes the entry added here.

## Changes in this PR

- Route MongoDB 4.2 to `mongo-orchestration` instead of `mongodb-runner`.
- Record why 4.2 is now unreachable through `mongodb-runner`, so a later reader does not mistake the entry for a stale workaround.
- Correct the fallback warning to name 4.4 as the lowest version `mongodb-runner` still supports.

## Test Plan

Started 4.2 locally and confirmed it comes up through the fallback path:

- `bash .evergreen/run-mongodb.sh start --version 4.2` brought up MongoDB 4.2.25. This needed `ARCH=x86_64`, because no arm64 4.2 build is published.
- The server reported `maxWireVersion=8`, and `db.runCommand({ping:1})` returned `ok:1`.
- `.evergreen/orchestration/out.log` held the mongo-orchestration daemon log rather than the cluster JSON the `mongodb-runner` path writes, which confirms which path ran.
- `make lint` passes.

4.2 still reaches `mongo-orchestration` only because `uv.lock` pins `pymongo` 4.14.0. PYTHON-5808 applies the same EOL to pymongo, so this path loses 4.2 once that ships and the lockfile moves past it.

## Checklist

<!-- Do not delete the items provided on this checklist -->

### Checklist for Author

- [x] Does the title of the PR reference a JIRA Ticket?
- [x] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [x] Is all relevant documentation (README or docstring) updated? No README or docstring documents the version gate; the reason for the new entry is recorded in a code comment beside it.

### Checklist for Reviewer

- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?
