### PR TITLE
[DRIVERS-3631]: Update GCP/Azure KMS test VMs off EOL Debian 11

### DIFF
--- a/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
+++ b/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
@@ -20,7 +20,7 @@ export AZUREKMS_PRIVATEKEYPATH="$SCRIPT_DIR/keyfile"
 export AZUREKMS_CERTFILE="$SCRIPT_DIR/cert.pem"
 export AZUREKMS_VMNAME_PREFIX=$AZUREOIDC_VMNAME_PREFIX
 export AZUREOIDC_ENVPATH="$SCRIPT_DIR/env.sh"
-export AZUREKMS_IMAGE=${AZUREOIDC_IMAGE:-"Debian:debian-12:12:latest"}
+export AZUREKMS_IMAGE=${AZUREOIDC_IMAGE:-"Debian:debian-12:12:0.20260821.2577"}
 
 # Handle secrets from AWS vault.
 if [ ! -f ./secrets-export.sh ]; then

--- a/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
+++ b/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
@@ -20,7 +20,7 @@ export AZUREKMS_PRIVATEKEYPATH="$SCRIPT_DIR/keyfile"
 export AZUREKMS_CERTFILE="$SCRIPT_DIR/cert.pem"
 export AZUREKMS_VMNAME_PREFIX=$AZUREOIDC_VMNAME_PREFIX
 export AZUREOIDC_ENVPATH="$SCRIPT_DIR/env.sh"
-export AZUREKMS_IMAGE=${AZUREOIDC_IMAGE:-"Debian:debian-11:11:0.20221020.1174"}
+export AZUREKMS_IMAGE=${AZUREOIDC_IMAGE:-"Debian:debian-12:12:latest"}
 
 # Handle secrets from AWS vault.
 if [ ! -f ./secrets-export.sh ]; then

--- a/.evergreen/csfle/azurekms/README.md
+++ b/.evergreen/csfle/azurekms/README.md
@@ -14,11 +14,11 @@ The distro used must have the Azure Command-Line Interface (`az`) version 2.25.0
 - ubuntu2204
 If another distro is required, consider filing a BUILD ticket similar to [BUILD-16836](https://jira.mongodb.org/browse/BUILD-16836).
 
-The image of the remote Virtual Machine defaults to the URN `Debian:debian-11:11:0.20221020.1174`. It may be overridden with the environment variable `AZUREKMS_IMAGE` set to the value of `--image` in `az vm create`. See [Azure documentation](https://learn.microsoft.com/en-us/cli/azure/vm?view=azure-cli-latest#az-vm-create) for valid values.
+The image of the remote Virtual Machine defaults to the URN `Debian:debian-12:12:latest`. It may be overridden with the environment variable `AZUREKMS_IMAGE` set to the value of `--image` in `az vm create`. See [Azure documentation](https://learn.microsoft.com/en-us/cli/azure/vm?view=azure-cli-latest#az-vm-create) for valid values.
 
-The list of images may be determined with `az vm image --list`. The following script can get the latest version of the `debian-11` image:
+The list of images may be determined with `az vm image --list`. The following script can get the latest version of the `debian-12` image:
 ```
-LATEST_DEBIAN_URN=$(az vm image list -p Debian -s 11 --all --query "[?offer=='debian-11'].urn" -o tsv | sort -u | tail -n 1)
+LATEST_DEBIAN_URN=$(az vm image list -p Debian -s 12 --all --query "[?offer=='debian-12'].urn" -o tsv | sort -u | tail -n 1)
 echo "LATEST_DEBIAN_URN=$LATEST_DEBIAN_URN"
 ```
 The URN may be passed as `AZUREKMS_IMAGE`.

--- a/.evergreen/csfle/azurekms/README.md
+++ b/.evergreen/csfle/azurekms/README.md
@@ -16,7 +16,7 @@ If another distro is required, consider filing a BUILD ticket similar to [BUILD-
 
 The image of the remote Virtual Machine defaults to the URN `Debian:debian-12:12:0.20260821.2577`. It may be overridden with the environment variable `AZUREKMS_IMAGE` set to the value of `--image` in `az vm create`. See [Azure documentation](https://learn.microsoft.com/en-us/cli/azure/vm?view=azure-cli-latest#az-vm-create) for valid values.
 
-The list of images may be determined with `az vm image --list`. The following script can get the latest version of the `debian-12` image:
+The list of images may be determined with `az vm image list`. The following script can get the latest version of the `debian-12` image:
 ```
 LATEST_DEBIAN_URN=$(az vm image list -p Debian -s 12 --all --query "[?offer=='debian-12'].urn" -o tsv | sort -u | tail -n 1)
 echo "LATEST_DEBIAN_URN=$LATEST_DEBIAN_URN"

--- a/.evergreen/csfle/azurekms/README.md
+++ b/.evergreen/csfle/azurekms/README.md
@@ -14,7 +14,7 @@ The distro used must have the Azure Command-Line Interface (`az`) version 2.25.0
 - ubuntu2204
 If another distro is required, consider filing a BUILD ticket similar to [BUILD-16836](https://jira.mongodb.org/browse/BUILD-16836).
 
-The image of the remote Virtual Machine defaults to the URN `Debian:debian-12:12:latest`. It may be overridden with the environment variable `AZUREKMS_IMAGE` set to the value of `--image` in `az vm create`. See [Azure documentation](https://learn.microsoft.com/en-us/cli/azure/vm?view=azure-cli-latest#az-vm-create) for valid values.
+The image of the remote Virtual Machine defaults to the URN `Debian:debian-12:12:0.20260821.2577`. It may be overridden with the environment variable `AZUREKMS_IMAGE` set to the value of `--image` in `az vm create`. See [Azure documentation](https://learn.microsoft.com/en-us/cli/azure/vm?view=azure-cli-latest#az-vm-create) for valid values.
 
 The list of images may be determined with `az vm image --list`. The following script can get the latest version of the `debian-12` image:
 ```

--- a/.evergreen/csfle/azurekms/create-and-setup-vm.sh
+++ b/.evergreen/csfle/azurekms/create-and-setup-vm.sh
@@ -47,7 +47,7 @@ done
 # Set defaults.
 # If this default changes, update the azurekms base_image in
 # .evergreen/tests/test-remote-kms-provisioning.sh to match.
-export AZUREKMS_IMAGE=${AZUREKMS_IMAGE:-"Debian:debian-12:12:latest"}
+export AZUREKMS_IMAGE=${AZUREKMS_IMAGE:-"Debian:debian-12:12:0.20260821.2577"}
 
 # Login.
 . "$DRIVERS_TOOLS"/.evergreen/csfle/azurekms/login.sh

--- a/.evergreen/csfle/azurekms/create-and-setup-vm.sh
+++ b/.evergreen/csfle/azurekms/create-and-setup-vm.sh
@@ -47,7 +47,7 @@ done
 # Set defaults.
 # If this default changes, update the azurekms base_image in
 # .evergreen/tests/test-remote-kms-provisioning.sh to match.
-export AZUREKMS_IMAGE=${AZUREKMS_IMAGE:-"Debian:debian-11:11:0.20221020.1174"}
+export AZUREKMS_IMAGE=${AZUREKMS_IMAGE:-"Debian:debian-12:12:latest"}
 
 # Login.
 . "$DRIVERS_TOOLS"/.evergreen/csfle/azurekms/login.sh

--- a/.evergreen/csfle/gcpkms/create-and-setup-instance.sh
+++ b/.evergreen/csfle/gcpkms/create-and-setup-instance.sh
@@ -45,7 +45,7 @@ export GCPKMS_ZONE=${GCPKMS_ZONE:-"us-east1-b"}
 export GCPKMS_IMAGEPROJECT=${GCPKMS_IMAGEPROJECT:-"debian-cloud"}
 # If this default changes, update the gcpkms base_image in
 # .evergreen/tests/test-remote-kms-provisioning.sh to match.
-export GCPKMS_IMAGEFAMILY=${GCPKMS_IMAGEFAMILY:-"debian-11"}
+export GCPKMS_IMAGEFAMILY=${GCPKMS_IMAGEFAMILY:-"debian-12"}
 export GCPKMS_MACHINETYPE=${GCPKMS_MACHINETYPE:-"e2-micro"}
 export GCPKMS_DISKSIZE=${GCPKMS_DISKSIZE:-"20gb"}
 

--- a/.evergreen/tests/docker/remote-kms-provisioning.Dockerfile
+++ b/.evergreen/tests/docker/remote-kms-provisioning.Dockerfile
@@ -1,7 +1,7 @@
 # Mirrors the environment the gcpkms/azurekms remote-scripts actually run in:
 # a fresh host reached as a non-root user with passwordless sudo. BASE_IMAGE
 # lets gcpkms and azurekms test against their own default VM image versions.
-ARG BASE_IMAGE=debian:11
+ARG BASE_IMAGE=debian:12
 FROM ${BASE_IMAGE}
 # man-db ships preinstalled on the real GCE/Azure base images; the
 # remote-scripts assume it's there when they silence its update trigger.

--- a/.evergreen/tests/test-remote-kms-provisioning.sh
+++ b/.evergreen/tests/test-remote-kms-provisioning.sh
@@ -215,7 +215,7 @@ test_provisioning azurekms .evergreen/csfle/azurekms/remote-scripts/setup-azure-
 test_no_system_pip nopip-debian12 debian:12
 test_no_system_pip nopip-ubuntu2004 ubuntu:20.04
 
-# debian:12 matches the Evergreen image whose missing python3-venv this covers.
+# debian:12 matches the current default VM image; this case covers hosts where python3-venv is missing.
 test_no_venv_module novenv-debian12 debian:12
 
 test_inside_active_venv invenv-debian12 debian:12

--- a/.evergreen/tests/test-remote-kms-provisioning.sh
+++ b/.evergreen/tests/test-remote-kms-provisioning.sh
@@ -206,16 +206,16 @@ test_start_mongodb_uses_archive azurekms .evergreen/csfle/azurekms/remote-script
 
 # Keep these in sync with the defaults in create-and-setup-instance.sh
 # (GCPKMS_IMAGEFAMILY) and create-and-setup-vm.sh (AZUREKMS_IMAGE).
-test_provisioning gcpkms .evergreen/csfle/gcpkms/remote-scripts/setup-gce-instance.sh debian:11
-test_provisioning azurekms .evergreen/csfle/azurekms/remote-scripts/setup-azure-vm.sh debian:11
+test_provisioning gcpkms .evergreen/csfle/gcpkms/remote-scripts/setup-gce-instance.sh debian:12
+test_provisioning azurekms .evergreen/csfle/azurekms/remote-scripts/setup-azure-vm.sh debian:12
 
-# debian:11 matches both defaults above. ubuntu:20.04 is a supported
+# debian:12 matches both defaults above. ubuntu:20.04 is a supported
 # AZUREKMS_IMAGE (see azurekms/README.md) and additionally covers a system
 # interpreter whose bundled pip predates PEP 600.
-test_no_system_pip nopip-debian11 debian:11
+test_no_system_pip nopip-debian12 debian:12
 test_no_system_pip nopip-ubuntu2004 ubuntu:20.04
 
-# debian:11 matches the Evergreen image whose missing python3-venv this covers.
-test_no_venv_module novenv-debian11 debian:11
+# debian:12 matches the Evergreen image whose missing python3-venv this covers.
+test_no_venv_module novenv-debian12 debian:12
 
-test_inside_active_venv invenv-debian11 debian:11
+test_inside_active_venv invenv-debian12 debian:12


### PR DESCRIPTION
[DRIVERS-3631](https://jira.mongodb.org/browse/DRIVERS-3631)

## Summary

Debian 11 [reached end of life on 2026-08-31](https://www.debian.org/News/2026/20260831), and GCP has started rejecting the `debian-11` image family. This broke GCP KMS CI for the Node driver (`gcloud.compute.instances.create: Could not fetch resource`) and will break it for any other driver using these scripts.

## Changes in this PR

- Changed the GCP KMS instance default (`GCPKMS_IMAGEFAMILY`) from `debian-11` to `debian-12`.
- Changed the Azure KMS VM default (`AZUREKMS_IMAGE`) from the pinned Debian 11 URN to a pinned Debian 12 URN (`Debian:debian-12:12:0.20260821.2577`), matching the existing precedent of pinning a specific dated version.
- Changed the Azure OIDC VM default (`AZUREOIDC_IMAGE`) to the same pinned Debian 12 URN.
- Updated `azurekms/README.md`'s documented default URN and `az vm image list` example to match.
- Updated the Docker base images in `test-remote-kms-provisioning.sh` to `debian:12`, per that file's own comment to keep them in sync with the two script defaults above.

## Test Plan

- Local pre-commit hooks (shellcheck, codespell, etc.) pass on the changed files.
- Confirmed via `az vm image show --urn Debian:debian-12:12:0.20260821.2577` and `az vm image list -p Debian -s 12` that the pinned Azure URN and offer/sku resolve.
- Validated against the real failure: bumped the Node driver's `drivers-evergreen-tools` submodule locally (not merged, not pushed) to this branch and ran a scoped Evergreen patch against the previously-failing task. It passed: [patch #11079](https://spruce.corp.mongodb.com/patch/6a9946fe18fc4900079cc6fe), `test-gcpkms-task` on `rhel8-test-gcp-kms`.
- Did not run `test-remote-kms-provisioning.sh` locally (it needs a Docker daemon unavailable in this environment); relies on this repo's own CI.

## Checklist

### Checklist for Author

- [x] Does the title of the PR reference a JIRA Ticket?
- [x] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [x] Is all relevant documentation (README or docstring) updated?

### Checklist for Reviewer

- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?