### PR TITLE
DRIVERS-3605: add opt-in OTel span-export server configuration for trace-context prose tests

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -596,6 +596,13 @@ functions:
         binary: bash
         args: [src/.evergreen/tests/test-cli.sh]
 
+  "run otel test":
+    - command: subprocess.exec
+      type: test
+      params:
+        binary: bash
+        args: [src/.evergreen/tests/test-otel.sh]
+
   "run ocsp test":
     - command: subprocess.exec
       type: test
@@ -1077,6 +1084,11 @@ tasks:
       commands:
         - func: "run cli test full"
 
+    - name: "test-otel"
+      tags: ["latest", "pr"]
+      commands:
+        - func: "run otel test"
+
     - name: "test-mongodb-runner-full"
       tags: ["pr"]
       commands:
@@ -1525,6 +1537,7 @@ buildvariants:
           - "test-csfle"
           - "test-drivers-tools-archive"
           - "test-cli-full"
+          - "test-otel"
           - "test-mongodb-runner-full"
           - "test-happy-eyeballs"
           - "test-ocsp"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -302,6 +302,7 @@ functions:
           - AUTH
           - LOAD_BALANCER
           - LOCAL_ATLAS
+          - OTEL
           - REQUIRE_API_VERSION,
           - SSL
           - STORAGE_ENGINE
@@ -342,6 +343,7 @@ functions:
           SSL: ${SSL}
           MONGODB_URI: ${MONGODB_URI}
           CRYPT_SHARED_LIB_PATH: ${CRYPT_SHARED_LIB_PATH}
+          OTEL_TRACE_DIR: ${OTEL_TRACE_DIR}
         args:
           - ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -303,7 +303,7 @@ functions:
           - LOAD_BALANCER
           - LOCAL_ATLAS
           - OTEL
-          - REQUIRE_API_VERSION,
+          - REQUIRE_API_VERSION
           - SSL
           - STORAGE_ENGINE
           - TOPOLOGY

--- a/.evergreen/docker/run-server.sh
+++ b/.evergreen/docker/run-server.sh
@@ -52,6 +52,7 @@ DISABLE_TEST_COMMANDS=${DISABLE_TEST_COMMANDS:-}
 MONGODB_VERSION=${MONGODB_VERSION:-latest}
 MONGODB_DOWNLOAD_URL=${MONGODB_DOWNLOAD_URL:-}
 ORCHESTRATION_FILE=${ORCHESTRATION_FILE:-}
+OTEL=${OTEL:-}
 
 # Build up the args.
 ARGS="$PLATFORM --rm -i --name mongodb"
@@ -65,6 +66,9 @@ ARGS+=" -e STORAGE_ENGINE=$STORAGE_ENGINE"
 ARGS+=" -e REQUIRE_API_VERSION=$REQUIRE_API_VERSION"
 ARGS+=" -e DISABLE_TEST_COMMANDS=$DISABLE_TEST_COMMANDS"
 ARGS+=" -e MONGODB_DOWNLOAD_URL=$MONGODB_DOWNLOAD_URL"
+# Forwarded so the in-container DOCKER_RUNNING fail-fast fires instead of
+# silently running without OTel.
+ARGS+=" -e OTEL=$OTEL"
 
 # Use the ECR pull-through registry for Ubuntu images when running in CI.
 if [[ "$IMAGE" =~ ^ubuntu.* ]] && [[ -n "${CI:-}" ]]; then

--- a/.evergreen/orchestration/README.md
+++ b/.evergreen/orchestration/README.md
@@ -44,8 +44,11 @@ alongside `MONGODB_URI`. Driver test suites should:
   `VERSION: latest`, never in a shared orchestration function — the version
   fail-fast will break every variant pinned below 9.0 otherwise.
 - Poll for span files with a generous timeout (e.g. 30 s) rather than a
-  single sleep: the exporter flushes every
+  single sleep: spans are batched every
   `openTelemetryTracingBatchExportIntervalMillis` (default 1000 ms).
+  Orchestration sets `openTelemetryTracingFileFlushCount: 1` so every
+  exported batch is written to disk immediately (the server default buffers
+  256 batches with a 30 s flush interval).
 - Read files recursively under `OTEL_TRACE_DIR`; match server spans to
   client spans by hex `traceId` / `parentSpanId`.
 

--- a/.evergreen/orchestration/README.md
+++ b/.evergreen/orchestration/README.md
@@ -1,0 +1,72 @@
+# Drivers Orchestration
+
+Scripts to manage MongoDB server deployments for driver testing, used by
+[run-orchestration.sh](../run-orchestration.sh). See the repository
+[README](../../README.md) for general usage.
+
+## OpenTelemetry trace export (MongoDB 9.0+)
+
+For the trace-context propagation prose tests
+([DRIVERS-3454](https://jira.mongodb.org/browse/DRIVERS-3454)), orchestration
+can start every `mongod`/`mongos` defined in the orchestration config
+(config servers that mongo-orchestration synthesizes itself are not covered)
+with the server's OpenTelemetry file exporter enabled:
+
+```bash
+OTEL=1 MONGODB_VERSION=latest TOPOLOGY=server \
+  bash .evergreen/run-orchestration.sh
+```
+
+This requires MongoDB 9.0+ (the setParameters do not exist on older servers)
+and a locally orchestrated cluster: the file exporter has no wire protocol,
+so the test runner must share a filesystem with the server processes.
+Orchestration fails fast if `OTEL` is combined with an older version,
+`DOCKER_RUNNING`, `--local-atlas`, or `--mongodb-runner`.
+
+Span export additionally requires a mongod binary compiled with OpenTelemetry support (the server's span-export tests are tagged `requires_otel_build`). On builds without it, the parameters are accepted but no span files are written — orchestration cannot detect this, so run the prose tests against an OTel-enabled 9.0+ build.
+
+Each cluster member writes OTLP JSON span batches (one batch per line,
+NDJSON) into its own per-port directory:
+
+```
+$DRIVERS_TOOLS/otel/          <- exported as OTEL_TRACE_DIR
+├── 27017/
+├── 27018/
+└── 27019/
+```
+
+`OTEL_TRACE_DIR` is written to `mo-expansion.sh` / `mo-expansion.yml`
+alongside `MONGODB_URI`. Driver test suites should:
+
+- Skip the prose test when `OTEL_TRACE_DIR` is unset or empty (this covers
+  every environment that did not opt in — no same-host detection needed).
+- Enable `OTEL` only in a dedicated task or variant pinned to
+  `VERSION: latest`, never in a shared orchestration function — the version
+  fail-fast will break every variant pinned below 9.0 otherwise.
+- Poll for span files with a generous timeout (e.g. 30 s) rather than a
+  single sleep: the exporter flushes every
+  `openTelemetryTracingBatchExportIntervalMillis` (default 1000 ms).
+- Read files recursively under `OTEL_TRACE_DIR`; match server spans to
+  client spans by hex `traceId` / `parentSpanId`.
+
+The directory is wiped at the start of each orchestration run. To upload the
+traces as task artifacts on failure, add to the driver project's Evergreen
+config:
+
+```yaml
+- command: archive.targz_pack
+  params:
+    target: "otel-traces.tar.gz"
+    source_dir: "${DRIVERS_TOOLS}/otel"
+    include: ["./**"]
+- command: s3.put
+  params:
+    aws_key: ${aws_key}
+    aws_secret: ${aws_secret}
+    local_file: otel-traces.tar.gz
+    remote_file: ${UPLOAD_BUCKET}/${build_variant}/${revision}/${version_id}/${build_id}/otel/${task_id}-${execution}-otel-traces.tar.gz
+    bucket: ${bucket_name}
+    permissions: public-read
+    content_type: ${content_type|application/x-gzip}
+    display_name: "otel-traces.tar.gz"
+```

--- a/.evergreen/orchestration/README.md
+++ b/.evergreen/orchestration/README.md
@@ -20,10 +20,16 @@ OTEL=1 MONGODB_VERSION=latest TOPOLOGY=server \
 This requires MongoDB 9.0+ (the setParameters do not exist on older servers)
 and a locally orchestrated cluster: the file exporter has no wire protocol,
 so the test runner must share a filesystem with the server processes.
-Orchestration fails fast if `OTEL` is combined with an older version,
-`DOCKER_RUNNING`, `--local-atlas`, or `--mongodb-runner`.
+Orchestration fails fast if `OTEL` is combined with a version below 9.0, a
+version alias that cannot guarantee 9.0+ (`rapid`, `latest-release`,
+`latest-stable`), `DOCKER_RUNNING`, `LOCAL_ATLAS` (`--local-atlas`), or
+`MONGODB_RUNNER` (`--mongodb-runner`).
 
-Span export additionally requires a mongod binary compiled with OpenTelemetry support (the server's span-export tests are tagged `requires_otel_build`). On builds without it, the parameters are accepted but no span files are written — orchestration cannot detect this, so run the prose tests against an OTel-enabled 9.0+ build.
+Span export additionally requires a mongod binary compiled with
+OpenTelemetry support (the server's span-export tests are tagged
+`requires_otel_build`). On builds without it, the parameters are accepted
+but no span files are written — orchestration cannot detect this, so run
+the prose tests against an OTel-enabled 9.0+ build.
 
 Each cluster member writes OTLP JSON span batches (one batch per line,
 NDJSON) into its own per-port directory:
@@ -43,9 +49,7 @@ alongside `MONGODB_URI`. Driver test suites should:
 - Enable `OTEL` only in a dedicated task or variant pinned to a 9.0+
   version (e.g. `VERSION: latest` or an explicit `9.x`), never in a shared
   orchestration function — the version fail-fast will break every variant
-  pinned below 9.0 otherwise. Aliases that resolve to the newest published
-  release (`rapid`, `latest-release`, `latest-stable`) are rejected while
-  they cannot guarantee a 9.0+ server.
+  pinned below 9.0 otherwise.
 - Poll for span files with a generous timeout (e.g. 30 s) rather than a
   single sleep: spans are batched every
   `openTelemetryTracingBatchExportIntervalMillis` (default 1000 ms).

--- a/.evergreen/orchestration/README.md
+++ b/.evergreen/orchestration/README.md
@@ -23,9 +23,11 @@ environment variable.)
 This requires MongoDB 9.0+ (the setParameters do not exist on older servers)
 and a locally orchestrated cluster: the file exporter has no wire protocol,
 so the test runner must share a filesystem with the server processes.
-Orchestration fails fast if `OTEL` is combined with a version below 9.0, a
-version alias that cannot guarantee 9.0+ (`rapid`, `latest-release`,
-`latest-stable`), `DOCKER_RUNNING`, or `LOCAL_ATLAS` (`--local-atlas`).
+Orchestration fails fast if `OTEL` is combined with a version below 9.0,
+`DOCKER_RUNNING`, or `LOCAL_ATLAS` (`--local-atlas`). Version aliases such
+as `rapid`, `latest-release`, and `latest-stable` are resolved through the
+release list (the same way the download resolves them) and the resolved
+version is gated, so an alias is accepted as soon as it resolves to 9.0+.
 With `--existing-binaries-dir` the version of the provided `mongod` binary
 is probed directly, since it bypasses version selection.
 

--- a/.evergreen/orchestration/README.md
+++ b/.evergreen/orchestration/README.md
@@ -26,6 +26,8 @@ so the test runner must share a filesystem with the server processes.
 Orchestration fails fast if `OTEL` is combined with a version below 9.0, a
 version alias that cannot guarantee 9.0+ (`rapid`, `latest-release`,
 `latest-stable`), `DOCKER_RUNNING`, or `LOCAL_ATLAS` (`--local-atlas`).
+With `--existing-binaries-dir` the version of the provided `mongod` binary
+is probed directly, since it bypasses version selection.
 
 Span export additionally requires a mongod binary compiled with
 OpenTelemetry support (the server's span-export tests are tagged

--- a/.evergreen/orchestration/README.md
+++ b/.evergreen/orchestration/README.md
@@ -23,13 +23,13 @@ environment variable.)
 This requires MongoDB 9.0+ (the setParameters do not exist on older servers)
 and a locally orchestrated cluster: the file exporter has no wire protocol,
 so the test runner must share a filesystem with the server processes.
-Orchestration fails fast if `OTEL` is combined with a version below 9.0,
-`DOCKER_RUNNING`, or `LOCAL_ATLAS` (`--local-atlas`). Version aliases such
-as `rapid`, `latest-release`, and `latest-stable` are resolved through the
-release list (the same way the download resolves them) and the resolved
-version is gated, so an alias is accepted as soon as it resolves to 9.0+.
-With `--existing-binaries-dir` the version of the provided `mongod` binary
-is probed directly, since it bypasses version selection.
+Orchestration fails fast if `OTEL` is combined with `DOCKER_RUNNING`,
+`LOCAL_ATLAS` (`--local-atlas`), or an explicitly sub-9.0 version string.
+The authoritative version gate probes the `mongod` binary that will
+actually run (right after it is downloaded or copied, before the
+deployment), so version aliases such as `rapid` are accepted as soon as
+they deliver a 9.0+ server, and `--existing-binaries-dir` is judged by the
+binary it provides rather than the requested version.
 
 Span export additionally requires a mongod binary compiled with
 OpenTelemetry support (the server's span-export tests are tagged

--- a/.evergreen/orchestration/README.md
+++ b/.evergreen/orchestration/README.md
@@ -42,7 +42,9 @@ $DRIVERS_TOOLS/otel/          <- exported as OTEL_TRACE_DIR
 ```
 
 `OTEL_TRACE_DIR` is written to `mo-expansion.sh` / `mo-expansion.yml`
-alongside `MONGODB_URI`. Driver test suites should:
+alongside `MONGODB_URI` (as an empty value when `OTEL` is not enabled, so a
+stale value from an earlier opt-in run is always overwritten). Driver test
+suites should:
 
 - Skip the prose test when `OTEL_TRACE_DIR` is unset or empty (this covers
   every environment that did not opt in — no same-host detection needed).

--- a/.evergreen/orchestration/README.md
+++ b/.evergreen/orchestration/README.md
@@ -40,9 +40,12 @@ alongside `MONGODB_URI`. Driver test suites should:
 
 - Skip the prose test when `OTEL_TRACE_DIR` is unset or empty (this covers
   every environment that did not opt in — no same-host detection needed).
-- Enable `OTEL` only in a dedicated task or variant pinned to
-  `VERSION: latest`, never in a shared orchestration function — the version
-  fail-fast will break every variant pinned below 9.0 otherwise.
+- Enable `OTEL` only in a dedicated task or variant pinned to a 9.0+
+  version (e.g. `VERSION: latest` or an explicit `9.x`), never in a shared
+  orchestration function — the version fail-fast will break every variant
+  pinned below 9.0 otherwise. Aliases that resolve to the newest published
+  release (`rapid`, `latest-release`, `latest-stable`) are rejected while
+  they cannot guarantee a 9.0+ server.
 - Poll for span files with a generous timeout (e.g. 30 s) rather than a
   single sleep: spans are batched every
   `openTelemetryTracingBatchExportIntervalMillis` (default 1000 ms).

--- a/.evergreen/orchestration/README.md
+++ b/.evergreen/orchestration/README.md
@@ -14,16 +14,18 @@ with the server's OpenTelemetry file exporter enabled:
 
 ```bash
 OTEL=1 MONGODB_VERSION=latest TOPOLOGY=server \
-  bash .evergreen/run-orchestration.sh
+  bash .evergreen/run-mongodb.sh start
 ```
+
+(`run-orchestration.sh`, the legacy entry point, supports the same `OTEL`
+environment variable.)
 
 This requires MongoDB 9.0+ (the setParameters do not exist on older servers)
 and a locally orchestrated cluster: the file exporter has no wire protocol,
 so the test runner must share a filesystem with the server processes.
 Orchestration fails fast if `OTEL` is combined with a version below 9.0, a
 version alias that cannot guarantee 9.0+ (`rapid`, `latest-release`,
-`latest-stable`), `DOCKER_RUNNING`, `LOCAL_ATLAS` (`--local-atlas`), or
-`MONGODB_RUNNER` (`--mongodb-runner`).
+`latest-stable`), `DOCKER_RUNNING`, or `LOCAL_ATLAS` (`--local-atlas`).
 
 Span export additionally requires a mongod binary compiled with
 OpenTelemetry support (the server's span-export tests are tagged

--- a/.evergreen/orchestration/drivers_orchestration.py
+++ b/.evergreen/orchestration/drivers_orchestration.py
@@ -47,6 +47,29 @@ CRYPT_NAME_MAP = {
 # Remove an entry once its GA release appears in full.json.
 UNPUBLISHED_VERSIONS = {"9.0"}
 
+# OpenTelemetry file-exporter configuration for trace-context prose tests
+# (DRIVERS-3454). Requires MongoDB 9.0+.
+# samplingFactor 1.0 samples every span (production default is ~0.000045,
+# which would make span assertions flake). Per the server IDL
+# (src/mongo/otel/traces/trace_sampling_parameters.idl), every sampling
+# strategy -- including defaultSampling -- also carries its own
+# tokenBucketRateLimit (default refillRate 1/s, maxTokens 10) that throttles
+# spans independently of samplingFactor, so it must be raised here too or
+# internally-initiated spans still get capped at a 10-burst. Externally-
+# propagated contexts (driver traceparents) bypass the probability sampler
+# entirely and go through the separate openTelemetryExternalTracing
+# setParameter -- NOT nested under openTelemetryTracingSampling -- which
+# needs the same raise. The values are JSON strings because
+# mongo-orchestration setParameter values must be scalars.
+OTEL_SAMPLING_JSON = (
+    '{"defaultSampling":{"samplingFactor":1.0,'
+    '"tokenBucketRateLimit":{"refillRate":1000.0,"maxTokens":1000}}}'
+)
+OTEL_EXTERNAL_TRACING_JSON = (
+    '{"tokenBucketRateLimit":{"refillRate":1000.0,"maxTokens":1000}}'
+)
+OTEL_DIR_NAME = "otel"
+
 # Top level files
 URI_TXT = DRIVERS_TOOLS / "uri.txt"
 MO_EXPANSION_SH = Path("mo-expansion.sh")
@@ -157,6 +180,12 @@ def get_options():
         other_group.add_argument(
             "--arch",
             help="the architecture.  if unspecified, the arch will be inferred.",
+        )
+        other_group.add_argument(
+            "--otel",
+            action="store_true",
+            help="Whether to configure the OpenTelemetry file exporter on every "
+            "mongod/mongos (requires MongoDB 9.0+; exports OTEL_TRACE_DIR)",
         )
 
     other_group.add_argument(
@@ -274,6 +303,67 @@ def handle_docker_config(data):
             router["ipv6"] = False
             router["bind_ip"] = "0.0.0.0,::1"
             router["logpath"] = f"/tmp/mongodb-{item['port']}.log"
+
+
+def handle_otel_config(data, otel_root):
+    """Configure every mongod/mongos to export OTel spans as NDJSON files.
+
+    Each member gets its own trace directory (keyed by port) under otel_root
+    so files from different members never interleave.
+    """
+    members = []
+
+    def traverse(root):
+        if isinstance(root, list):
+            [traverse(i) for i in root]
+            return
+        if "ipv6" in root:
+            members.append(root)
+            return
+        for value in root.values():
+            if isinstance(value, (dict, list)):
+                traverse(value)
+
+    traverse(data)
+
+    for member in members:
+        if "port" not in member:
+            raise ValueError(
+                "--otel requires an explicit port for every cluster member "
+                "so each gets its own trace directory"
+            )
+        member_dir = Path(otel_root) / str(member["port"])
+        os.makedirs(member_dir, exist_ok=True)
+        set_param = member.setdefault("setParameter", {})
+        set_param["opentelemetryTraceDirectory"] = normalize_path(member_dir)
+        set_param["featureFlagOtelTraceSampling"] = "true"
+        set_param["openTelemetryTracingSampling"] = OTEL_SAMPLING_JSON
+        set_param["openTelemetryExternalTracing"] = OTEL_EXTERNAL_TRACING_JSON
+
+
+def validate_otel_opts(opts):
+    """Fail fast on option combinations incompatible with --otel.
+
+    The OTel file exporter requires MongoDB 9.0+ and a cluster that shares
+    the host filesystem with the test process (the only way to read spans).
+    """
+    if not getattr(opts, "otel", False):
+        return
+    match = re.match(r"^(\d+)(?:\.(\d+))?", opts.version)
+    if match and (int(match.group(1)), int(match.group(2) or 0)) < (9, 0):
+        raise ValueError(
+            f"--otel requires MongoDB 9.0+ (OTel setParameters do not exist "
+            f"on {opts.version})"
+        )
+    if os.environ.get("DOCKER_RUNNING"):
+        raise ValueError(
+            "--otel is not supported with DOCKER_RUNNING: the container "
+            "filesystem is not readable by the host test process"
+        )
+    if opts.local_atlas:
+        raise ValueError("--otel is not supported with --local-atlas")
+    if opts.mongodb_runner:
+        raise ValueError("--otel is not supported with --mongodb-runner")
 
 
 def normalize_path(path: Path | str) -> str:
@@ -460,6 +550,9 @@ def clean_run(opts):
     crypt_path = DRIVERS_TOOLS / CRYPT_NAME_MAP[PLATFORM]
     crypt_path.unlink(missing_ok=True)
 
+    otel_dir = DRIVERS_TOOLS / OTEL_DIR_NAME
+    shutil.rmtree(normalize_path(otel_dir), ignore_errors=True)
+
 
 def run(opts):
     # Deferred import so we can run as a script without the cli installed.
@@ -467,6 +560,11 @@ def run(opts):
     from mongosh_dl import main as mongosh_dl
 
     LOGGER.info("Running orchestration...")
+    try:
+        validate_otel_opts(opts)
+    except ValueError as e:
+        LOGGER.error(str(e))
+        sys.exit(1)
     stop(opts)
     clean_run(opts)
 
@@ -562,6 +660,15 @@ def run(opts):
 
     data = get_orchestration_data(opts)
 
+    otel_root = DRIVERS_TOOLS / OTEL_DIR_NAME
+    if opts.otel:
+        LOGGER.info("Configuring OTel trace export to %s...", otel_root)
+        try:
+            handle_otel_config(data, otel_root)
+        except ValueError as e:
+            LOGGER.error(str(e))
+            sys.exit(1)
+
     # run-mongodb.sh passes --mongodb-runner even for --local-atlas, where
     # probing for runner support would install a Node we never use.
     if opts.local_atlas:
@@ -616,12 +723,18 @@ def run(opts):
         uri = resp.get("mongodb_auth_uri", resp["mongodb_uri"])
 
     # Handle the cluster uri.
+    expansions = {"MONGODB_URI": uri}
+    if opts.otel:
+        expansions["OTEL_TRACE_DIR"] = normalize_path(otel_root)
     MO_EXPANSION_YML.touch()
-    MO_EXPANSION_YML.write_text(
-        MO_EXPANSION_YML.read_text() + f'\nMONGODB_URI: "{uri}"'
-    )
     MO_EXPANSION_SH.touch()
-    MO_EXPANSION_SH.write_text(MO_EXPANSION_SH.read_text() + f'\nMONGODB_URI="{uri}"')
+    yml_text = MO_EXPANSION_YML.read_text()
+    sh_text = MO_EXPANSION_SH.read_text()
+    for key, value in expansions.items():
+        yml_text += f'\n{key}: "{value}"'
+        sh_text += f'\n{key}="{value}"'
+    MO_EXPANSION_YML.write_text(yml_text)
+    MO_EXPANSION_SH.write_text(sh_text)
     URI_TXT.write_text(uri)
     LOGGER.info(f"Cluster URI: {uri}")
 

--- a/.evergreen/orchestration/drivers_orchestration.py
+++ b/.evergreen/orchestration/drivers_orchestration.py
@@ -339,6 +339,10 @@ def handle_otel_config(data, otel_root):
         set_param["featureFlagOtelTraceSampling"] = "true"
         set_param["openTelemetryTracingSampling"] = OTEL_SAMPLING_JSON
         set_param["openTelemetryExternalTracing"] = OTEL_EXTERNAL_TRACING_JSON
+        # The file exporter buffers 256 export batches (flushed every 30s) by
+        # default, on top of the 1s batch processor; tests emit few spans, so
+        # flush every batch to disk like the server's own file-export tests.
+        set_param["openTelemetryTracingFileFlushCount"] = 1
 
 
 def validate_otel_opts(opts):
@@ -349,7 +353,9 @@ def validate_otel_opts(opts):
     """
     if not getattr(opts, "otel", False):
         return
-    match = re.match(r"^(\d+)(?:\.(\d+))?", opts.version)
+    # Optional "v" prefix: mongodl aliases like v8.0-perf resolve to servers
+    # below 9.0 and must be caught here rather than failing at startup.
+    match = re.match(r"^v?(\d+)(?:\.(\d+))?", opts.version)
     if match and (int(match.group(1)), int(match.group(2) or 0)) < (9, 0):
         raise ValueError(
             f"--otel requires MongoDB 9.0+ (OTel setParameters do not exist "

--- a/.evergreen/orchestration/drivers_orchestration.py
+++ b/.evergreen/orchestration/drivers_orchestration.py
@@ -356,10 +356,22 @@ def validate_otel_opts(opts):
     # Optional "v" prefix: mongodl aliases like v8.0-perf resolve to servers
     # below 9.0 and must be caught here rather than failing at startup.
     match = re.match(r"^v?(\d+)(?:\.(\d+))?", opts.version)
-    if match and (int(match.group(1)), int(match.group(2) or 0)) < (9, 0):
+    if match:
+        if (int(match.group(1)), int(match.group(2) or 0)) < (9, 0):
+            raise ValueError(
+                f"--otel requires MongoDB 9.0+ (OTel setParameters do not "
+                f"exist on {opts.version})"
+            )
+    # Non-numeric aliases are default-closed: only master nightlies are
+    # guaranteed to be 9.0+. Aliases like "rapid", "latest-release", and
+    # "latest-stable" resolve to the newest *published* release, which is
+    # still 8.x while 9.0 is unpublished (see UNPUBLISHED_VERSIONS). Add an
+    # alias here once every version it can resolve to is 9.0+.
+    elif opts.version not in ("latest", "latest-build"):
         raise ValueError(
-            f"--otel requires MongoDB 9.0+ (OTel setParameters do not exist "
-            f"on {opts.version})"
+            f"--otel requires MongoDB 9.0+, which cannot be guaranteed for "
+            f"version {opts.version!r}; use 'latest' or an explicit 9.x+ "
+            f"version"
         )
     if os.environ.get("DOCKER_RUNNING"):
         raise ValueError(

--- a/.evergreen/orchestration/drivers_orchestration.py
+++ b/.evergreen/orchestration/drivers_orchestration.py
@@ -27,6 +27,7 @@ import psutil
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from mongodb_runner import _mongodb_runner_supported, start_mongodb_runner
+from otel import OTEL_DIR_NAME, handle_otel_config, validate_otel_opts
 
 # Get global values.
 HERE = Path(__file__).absolute().parent
@@ -47,27 +48,6 @@ CRYPT_NAME_MAP = {
 # Remove an entry once its GA release appears in full.json.
 UNPUBLISHED_VERSIONS = {"9.0"}
 
-# OpenTelemetry file-exporter configuration for trace-context prose tests
-# (DRIVERS-3454). Requires MongoDB 9.0+.
-# samplingFactor 1.0 samples every span (production default is ~0.000045,
-# which would make span assertions flake). Per the server IDL
-# (src/mongo/otel/traces/trace_sampling_parameters.idl), every sampling
-# strategy -- including defaultSampling -- also carries its own
-# tokenBucketRateLimit (default refillRate 1/s, maxTokens 10) that throttles
-# spans independently of samplingFactor, so it must be raised here too or
-# internally-initiated spans still get capped at a 10-burst.
-OTEL_SAMPLING_JSON = (
-    '{"defaultSampling":{"samplingFactor":1.0,'
-    '"tokenBucketRateLimit":{"refillRate":1000.0,"maxTokens":1000}}}'
-)
-# Externally-propagated contexts (driver traceparents) bypass the probability
-# sampler entirely and go through the separate openTelemetryExternalTracing
-# setParameter -- NOT nested under openTelemetryTracingSampling -- which
-# needs the same raise.
-OTEL_EXTERNAL_TRACING_JSON = (
-    '{"tokenBucketRateLimit":{"refillRate":1000.0,"maxTokens":1000}}'
-)
-OTEL_DIR_NAME = "otel"
 
 # Top level files
 URI_TXT = DRIVERS_TOOLS / "uri.txt"
@@ -302,105 +282,6 @@ def handle_docker_config(data):
             router["ipv6"] = False
             router["bind_ip"] = "0.0.0.0,::1"
             router["logpath"] = f"/tmp/mongodb-{item['port']}.log"
-
-
-def handle_otel_config(data, otel_root):
-    """Configure every mongod/mongos to export OTel spans as NDJSON files.
-
-    Each member gets its own trace directory (keyed by port) under otel_root
-    so files from different members never interleave.
-    """
-    members = []
-
-    def traverse(root):
-        if isinstance(root, list):
-            [traverse(i) for i in root]
-            return
-        if "ipv6" in root:
-            members.append(root)
-            return
-        for value in root.values():
-            if isinstance(value, (dict, list)):
-                traverse(value)
-
-    traverse(data)
-
-    for member in members:
-        if "port" not in member:
-            raise ValueError(
-                "--otel requires an explicit port for every cluster member "
-                "so each gets its own trace directory"
-            )
-        member_dir = Path(otel_root) / str(member["port"])
-        os.makedirs(member_dir, exist_ok=True)
-        set_param = member.setdefault("setParameter", {})
-        # Pre-existing OTel settings (e.g. opentelemetryHttpEndpoint, or a
-        # tracing compression the file exporter rejects) can conflict with
-        # the parameters injected below and would only fail at server
-        # startup, after the download. The tracing feature flags are also
-        # rejected: featureFlagTracing=false would start fine yet silently
-        # export no spans (the server requires it alongside
-        # featureFlagOtelTraceSampling), and a pre-set
-        # featureFlagOtelTraceSampling would be silently overwritten below.
-        # Fail fast instead.
-        conflicts = [
-            k
-            for k in set_param
-            if k.lower().startswith("opentelemetry")
-            or k in ("featureFlagTracing", "featureFlagOtelTraceSampling")
-        ]
-        if conflicts:
-            raise ValueError(
-                f"--otel conflicts with OpenTelemetry setParameters already "
-                f"present in the orchestration config: {conflicts}"
-            )
-        set_param["opentelemetryTraceDirectory"] = normalize_path(member_dir)
-        set_param["featureFlagOtelTraceSampling"] = "true"
-        set_param["openTelemetryTracingSampling"] = OTEL_SAMPLING_JSON
-        set_param["openTelemetryExternalTracing"] = OTEL_EXTERNAL_TRACING_JSON
-        # The file exporter buffers 256 export batches (flushed every 30s) by
-        # default, on top of the 1s batch processor; tests emit few spans, so
-        # flush every batch to disk like the server's own file-export tests.
-        set_param["openTelemetryTracingFileFlushCount"] = 1
-
-
-def validate_otel_opts(opts):
-    """Fail fast on option combinations incompatible with --otel.
-
-    The OTel file exporter requires MongoDB 9.0+ and a cluster that shares
-    the host filesystem with the test process (the only way to read spans).
-    """
-    if not getattr(opts, "otel", False):
-        return
-    # Optional "v" prefix: mongodl aliases like v8.0-perf resolve to servers
-    # below 9.0 and must be caught here rather than failing at startup.
-    match = re.match(r"^v?(\d+)(?:\.(\d+))?", opts.version)
-    if match:
-        if (int(match.group(1)), int(match.group(2) or 0)) < (9, 0):
-            raise ValueError(
-                f"--otel requires MongoDB 9.0+ (OTel setParameters do not "
-                f"exist on {opts.version})"
-            )
-    # Non-numeric aliases are default-closed: only master nightlies are
-    # guaranteed to be 9.0+. Aliases like "rapid", "latest-release", and
-    # "latest-stable" resolve to the newest *published* release, which is
-    # still 8.x while 9.0 is unpublished (see UNPUBLISHED_VERSIONS). Add an
-    # alias here once every version it can resolve to is 9.0+.
-    elif opts.version not in ("latest", "latest-build"):
-        raise ValueError(
-            f"--otel requires MongoDB 9.0+, which cannot be guaranteed for "
-            f"version {opts.version!r}; use 'latest' or an explicit 9.x+ "
-            f"version"
-        )
-    if os.environ.get("DOCKER_RUNNING"):
-        raise ValueError(
-            "--otel is not supported with DOCKER_RUNNING: the container "
-            "filesystem is not readable by the host test process"
-        )
-    if opts.local_atlas:
-        raise ValueError("--otel is not supported with --local-atlas")
-    if opts.mongodb_runner:
-        raise ValueError("--otel is not supported with --mongodb-runner")
 
 
 def normalize_path(path: Path | str) -> str:

--- a/.evergreen/orchestration/drivers_orchestration.py
+++ b/.evergreen/orchestration/drivers_orchestration.py
@@ -334,6 +334,16 @@ def handle_otel_config(data, otel_root):
         member_dir = Path(otel_root) / str(member["port"])
         os.makedirs(member_dir, exist_ok=True)
         set_param = member.setdefault("setParameter", {})
+        # Pre-existing OTel settings (e.g. opentelemetryHttpEndpoint, or a
+        # tracing compression the file exporter rejects) can conflict with
+        # the parameters injected below and would only fail at server
+        # startup, after the download. Fail fast instead.
+        conflicts = [k for k in set_param if k.lower().startswith("opentelemetry")]
+        if conflicts:
+            raise ValueError(
+                f"--otel conflicts with OpenTelemetry setParameters already "
+                f"present in the orchestration config: {conflicts}"
+            )
         set_param["opentelemetryTraceDirectory"] = normalize_path(member_dir)
         set_param["featureFlagOtelTraceSampling"] = "true"
         set_param["openTelemetryTracingSampling"] = OTEL_SAMPLING_JSON
@@ -741,8 +751,11 @@ def run(opts):
 
     # Handle the cluster uri.
     expansions = {"MONGODB_URI": uri}
-    if opts.otel:
-        expansions["OTEL_TRACE_DIR"] = normalize_path(otel_root)
+    # Always emit OTEL_TRACE_DIR: an empty value on non-OTel runs overwrites
+    # any stale value left in the environment or Evergreen expansions by an
+    # earlier --otel run (whose directory clean_run has since deleted), so
+    # driver tests gating on "unset or empty" reliably skip.
+    expansions["OTEL_TRACE_DIR"] = normalize_path(otel_root) if opts.otel else ""
     MO_EXPANSION_YML.touch()
     MO_EXPANSION_SH.touch()
     yml_text = MO_EXPANSION_YML.read_text()

--- a/.evergreen/orchestration/drivers_orchestration.py
+++ b/.evergreen/orchestration/drivers_orchestration.py
@@ -171,7 +171,7 @@ def get_options():
         "--mongo-orchestration-home", help="The path to mongo-orchestration home"
     )
 
-    if command in ["start", "run"]:
+    if command in ["start", "run", "clean"]:
         other_group.add_argument(
             "--mongodb-binaries", help="The path to store the MongoDB binaries"
         )
@@ -200,7 +200,7 @@ def get_options():
 
     if opts.mongo_orchestration_home is None:
         opts.mongo_orchestration_home = DRIVERS_TOOLS / ".evergreen/orchestration"
-    if command in ["start", "run"]:
+    if command in ["start", "run", "clean"]:
         if opts.mongodb_binaries is None:
             opts.mongodb_binaries = DRIVERS_TOOLS / "mongodb/bin"
     if command == "run":
@@ -486,6 +486,20 @@ def run(opts):
     stop(opts)
     clean_run(opts)
 
+    # Load (and, for --otel, mutate) the orchestration config before the
+    # downloads: it only reads local files, and its failure modes -- a bad
+    # config file, or an OTel conflict -- should not cost a ~200MB download.
+    data = get_orchestration_data(opts)
+
+    otel_root = DRIVERS_TOOLS / OTEL_DIR_NAME
+    if opts.otel:
+        LOGGER.info("Configuring OTel trace export to %s...", otel_root)
+        try:
+            handle_otel_config(data, otel_root)
+        except ValueError as e:
+            LOGGER.error(str(e))
+            sys.exit(1)
+
     # NOTE: in general, we need to normalize paths to account for cygwin/Windows.
     mdb_binaries = Path(opts.mongodb_binaries)
     mdb_binaries_str = normalize_path(mdb_binaries)
@@ -560,8 +574,12 @@ def run(opts):
                 f"Could not find expected crypt_shared_path: {crypt_shared_path}"
             )
         crypt_text = f'CRYPT_SHARED_LIB_PATH: "{normalize_path(crypt_shared_path)}"'
-        MO_EXPANSION_YML.write_text(crypt_text)
-        MO_EXPANSION_SH.write_text(crypt_text.replace(": ", "="))
+        # Explicit LF: these files are sourced by sh, and Windows text-mode
+        # writes would give interior lines a trailing \r.
+        with MO_EXPANSION_YML.open("w", newline="\n") as fid:
+            fid.write(crypt_text)
+        with MO_EXPANSION_SH.open("w", newline="\n") as fid:
+            fid.write(crypt_text.replace(": ", "="))
 
     # Download mongosh
     args = f"--out {mdb_binaries_str} --strip-path-components 2 --retries 5"
@@ -575,17 +593,6 @@ def run(opts):
 
     dl_end = datetime.now()
     mo_start = datetime.now()
-
-    data = get_orchestration_data(opts)
-
-    otel_root = DRIVERS_TOOLS / OTEL_DIR_NAME
-    if opts.otel:
-        LOGGER.info("Configuring OTel trace export to %s...", otel_root)
-        try:
-            handle_otel_config(data, otel_root)
-        except ValueError as e:
-            LOGGER.error(str(e))
-            sys.exit(1)
 
     # run-mongodb.sh passes --mongodb-runner even for --local-atlas, where
     # probing for runner support would install a Node we never use.
@@ -654,8 +661,12 @@ def run(opts):
     for key, value in expansions.items():
         yml_text += f'\n{key}: "{value}"'
         sh_text += f'\n{key}="{value}"'
-    MO_EXPANSION_YML.write_text(yml_text)
-    MO_EXPANSION_SH.write_text(sh_text)
+    # Explicit LF: these files are sourced by sh, and Windows text-mode
+    # writes would give interior lines a trailing \r.
+    with MO_EXPANSION_YML.open("w", newline="\n") as fid:
+        fid.write(yml_text)
+    with MO_EXPANSION_SH.open("w", newline="\n") as fid:
+        fid.write(sh_text)
     URI_TXT.write_text(uri)
     LOGGER.info(f"Cluster URI: {uri}")
 

--- a/.evergreen/orchestration/drivers_orchestration.py
+++ b/.evergreen/orchestration/drivers_orchestration.py
@@ -337,8 +337,18 @@ def handle_otel_config(data, otel_root):
         # Pre-existing OTel settings (e.g. opentelemetryHttpEndpoint, or a
         # tracing compression the file exporter rejects) can conflict with
         # the parameters injected below and would only fail at server
-        # startup, after the download. Fail fast instead.
-        conflicts = [k for k in set_param if k.lower().startswith("opentelemetry")]
+        # startup, after the download. The tracing feature flags are also
+        # rejected: featureFlagTracing=false would start fine yet silently
+        # export no spans (the server requires it alongside
+        # featureFlagOtelTraceSampling), and a pre-set
+        # featureFlagOtelTraceSampling would be silently overwritten below.
+        # Fail fast instead.
+        conflicts = [
+            k
+            for k in set_param
+            if k.lower().startswith("opentelemetry")
+            or k in ("featureFlagTracing", "featureFlagOtelTraceSampling")
+        ]
         if conflicts:
             raise ValueError(
                 f"--otel conflicts with OpenTelemetry setParameters already "

--- a/.evergreen/orchestration/drivers_orchestration.py
+++ b/.evergreen/orchestration/drivers_orchestration.py
@@ -27,7 +27,12 @@ import psutil
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from mongodb_runner import _mongodb_runner_supported, start_mongodb_runner
-from otel import OTEL_DIR_NAME, handle_otel_config, validate_otel_opts
+from otel import (
+    OTEL_DIR_NAME,
+    check_mongod_version,
+    handle_otel_config,
+    validate_otel_opts,
+)
 
 # Get global values.
 HERE = Path(__file__).absolute().parent
@@ -544,6 +549,16 @@ def run(opts):
             shutil.copytree(opts.existing_binaries_dir, mdb_binaries)
 
         run_command(f"{mdb_binaries_str}/mongod --version")
+
+        # The authoritative --otel version gate: probe the binary that will
+        # actually run (covers aliases, nightlies, and existing binaries),
+        # before the remaining downloads and the deployment.
+        if opts.otel:
+            try:
+                check_mongod_version(mdb_binaries)
+            except ValueError as e:
+                LOGGER.error(str(e))
+                sys.exit(1)
 
     # Download legacy shell.
     if opts.install_legacy_shell:

--- a/.evergreen/orchestration/drivers_orchestration.py
+++ b/.evergreen/orchestration/drivers_orchestration.py
@@ -55,16 +55,15 @@ UNPUBLISHED_VERSIONS = {"9.0"}
 # strategy -- including defaultSampling -- also carries its own
 # tokenBucketRateLimit (default refillRate 1/s, maxTokens 10) that throttles
 # spans independently of samplingFactor, so it must be raised here too or
-# internally-initiated spans still get capped at a 10-burst. Externally-
-# propagated contexts (driver traceparents) bypass the probability sampler
-# entirely and go through the separate openTelemetryExternalTracing
-# setParameter -- NOT nested under openTelemetryTracingSampling -- which
-# needs the same raise. The values are JSON strings because
-# mongo-orchestration setParameter values must be scalars.
+# internally-initiated spans still get capped at a 10-burst.
 OTEL_SAMPLING_JSON = (
     '{"defaultSampling":{"samplingFactor":1.0,'
     '"tokenBucketRateLimit":{"refillRate":1000.0,"maxTokens":1000}}}'
 )
+# Externally-propagated contexts (driver traceparents) bypass the probability
+# sampler entirely and go through the separate openTelemetryExternalTracing
+# setParameter -- NOT nested under openTelemetryTracingSampling -- which
+# needs the same raise.
 OTEL_EXTERNAL_TRACING_JSON = (
     '{"tokenBucketRateLimit":{"refillRate":1000.0,"maxTokens":1000}}'
 )

--- a/.evergreen/orchestration/otel.py
+++ b/.evergreen/orchestration/otel.py
@@ -108,27 +108,37 @@ def validate_otel_opts(opts):
     """
     if not getattr(opts, "otel", False):
         return
-    # Optional "v" prefix: mongodl aliases like v8.0-perf resolve to servers
-    # below 9.0 and must be caught here rather than failing at startup.
-    match = re.match(r"^v?(\d+)(?:\.(\d+))?", opts.version)
-    if match:
-        if (int(match.group(1)), int(match.group(2) or 0)) < (9, 0):
+    binaries_dir = getattr(opts, "existing_binaries_dir", None)
+    if binaries_dir:
+        # --existing-binaries-dir bypasses version selection entirely (the
+        # requested version is not what runs), so the probed binary is the
+        # single source of truth and the version-string gate below does not
+        # apply. This is the primary path for OTel-enabled custom builds
+        # (see requires_otel_build in README.md).
+        _check_existing_binaries_version(binaries_dir)
+    else:
+        # Optional "v" prefix: mongodl aliases like v8.0-perf resolve to
+        # servers below 9.0 and must be caught here rather than failing at
+        # startup.
+        match = re.match(r"^v?(\d+)(?:\.(\d+))?", opts.version)
+        if match:
+            if (int(match.group(1)), int(match.group(2) or 0)) < (9, 0):
+                raise ValueError(
+                    f"--otel requires MongoDB 9.0+ (OTel setParameters do "
+                    f"not exist on {opts.version})"
+                )
+        # Non-numeric aliases are default-closed: only master nightlies are
+        # guaranteed to be 9.0+. Aliases like "rapid", "latest-release", and
+        # "latest-stable" resolve to the newest *published* release, which is
+        # still 8.x while 9.0 is unpublished (see UNPUBLISHED_VERSIONS in
+        # drivers_orchestration.py). Add an alias here once every version it
+        # can resolve to is 9.0+.
+        elif opts.version not in ("latest", "latest-build"):
             raise ValueError(
-                f"--otel requires MongoDB 9.0+ (OTel setParameters do not "
-                f"exist on {opts.version})"
+                f"--otel requires MongoDB 9.0+, which cannot be guaranteed "
+                f"for version {opts.version!r}; use 'latest' or an explicit "
+                f"9.x+ version"
             )
-    # Non-numeric aliases are default-closed: only master nightlies are
-    # guaranteed to be 9.0+. Aliases like "rapid", "latest-release", and
-    # "latest-stable" resolve to the newest *published* release, which is
-    # still 8.x while 9.0 is unpublished (see UNPUBLISHED_VERSIONS in
-    # drivers_orchestration.py). Add an alias here once every version it can
-    # resolve to is 9.0+.
-    elif opts.version not in ("latest", "latest-build"):
-        raise ValueError(
-            f"--otel requires MongoDB 9.0+, which cannot be guaranteed for "
-            f"version {opts.version!r}; use 'latest' or an explicit 9.x+ "
-            f"version"
-        )
     if os.environ.get("DOCKER_RUNNING"):
         raise ValueError(
             "--otel is not supported with DOCKER_RUNNING: the container "
@@ -136,13 +146,6 @@ def validate_otel_opts(opts):
         )
     if opts.local_atlas:
         raise ValueError("--otel is not supported with --local-atlas")
-    # --existing-binaries-dir bypasses the version selection above, so gate
-    # on the actual binary. This is the primary path for OTel-enabled custom
-    # builds (see requires_otel_build in README.md), so probe rather than
-    # reject the combination.
-    binaries_dir = getattr(opts, "existing_binaries_dir", None)
-    if binaries_dir:
-        _check_existing_binaries_version(binaries_dir)
 
 
 def _check_existing_binaries_version(binaries_dir):

--- a/.evergreen/orchestration/otel.py
+++ b/.evergreen/orchestration/otel.py
@@ -117,28 +117,29 @@ def validate_otel_opts(opts):
         # (see requires_otel_build in README.md).
         _check_existing_binaries_version(binaries_dir)
     else:
-        # Optional "v" prefix: mongodl aliases like v8.0-perf resolve to
-        # servers below 9.0 and must be caught here rather than failing at
-        # startup.
-        match = re.match(r"^v?(\d+)(?:\.(\d+))?", opts.version)
-        if match:
-            if (int(match.group(1)), int(match.group(2) or 0)) < (9, 0):
-                raise ValueError(
-                    f"--otel requires MongoDB 9.0+ (OTel setParameters do "
-                    f"not exist on {opts.version})"
-                )
-        # Non-numeric aliases are default-closed: only master nightlies are
-        # guaranteed to be 9.0+. Aliases like "rapid", "latest-release", and
-        # "latest-stable" resolve to the newest *published* release, which is
-        # still 8.x while 9.0 is unpublished (see UNPUBLISHED_VERSIONS in
-        # drivers_orchestration.py). Add an alias here once every version it
-        # can resolve to is 9.0+.
-        elif opts.version not in ("latest", "latest-build"):
+        below_90 = _numeric_below_90(opts.version)
+        if below_90:
+            # Optional "v" prefix: mongodl aliases like v8.0-perf resolve to
+            # servers below 9.0 and must be caught here rather than failing
+            # at startup.
             raise ValueError(
-                f"--otel requires MongoDB 9.0+, which cannot be guaranteed "
-                f"for version {opts.version!r}; use 'latest' or an explicit "
-                f"9.x+ version"
+                f"--otel requires MongoDB 9.0+ (OTel setParameters do not "
+                f"exist on {opts.version})"
             )
+        if below_90 is None and opts.version not in ("latest", "latest-build"):
+            # Non-numeric aliases ("rapid", "latest-release",
+            # "latest-stable", ...) are resolved through mongodl's release
+            # catalog -- the same mechanism the download uses -- and the
+            # resolved version is gated, so an alias starts passing
+            # automatically once it resolves to 9.0+. Master nightlies
+            # (latest/latest-build) do not resolve via the catalog and are
+            # always 9.0+.
+            resolved = _resolve_published_version(opts.version)
+            if _numeric_below_90(resolved) is not False:
+                raise ValueError(
+                    f"--otel requires MongoDB 9.0+, but version "
+                    f"{opts.version!r} resolves to {resolved}"
+                )
     if os.environ.get("DOCKER_RUNNING"):
         raise ValueError(
             "--otel is not supported with DOCKER_RUNNING: the container "
@@ -146,6 +147,50 @@ def validate_otel_opts(opts):
         )
     if opts.local_atlas:
         raise ValueError("--otel is not supported with --local-atlas")
+
+
+def _numeric_below_90(version):
+    """True/False when version parses as [v]major[.minor]; None otherwise."""
+    match = re.match(r"^v?(\d+)(?:\.(\d+))?", version)
+    if match is None:
+        return None
+    return (int(match.group(1)), int(match.group(2) or 0)) < (9, 0)
+
+
+def _resolve_published_version(version):
+    """Resolve a version alias to a concrete version via mongodl's catalog.
+
+    Raises ValueError when the alias cannot be resolved (unknown alias, no
+    catalog entry, or the release list is unreachable) so the gate stays
+    fail-fast rather than deferring to a server startup failure.
+    """
+    evg_dir = Path(__file__).absolute().parent.parent
+    sys.path.insert(0, str(evg_dir))
+    try:
+        # Deferred: mongodl lives in .evergreen, only on sys.path here.
+        from mongodl import Cache
+
+        cache = Cache.open_in(evg_dir.parent / ".local" / "cache")
+        cache.refresh_full_json()
+        component = next(
+            iter(cache.db.iter_available(version=version, component="archive")),
+            None,
+        )
+    except ValueError:
+        raise
+    except Exception as e:
+        raise ValueError(
+            f"--otel could not resolve version {version!r} from the release "
+            f"list: {e}"
+        ) from e
+    finally:
+        sys.path.remove(str(evg_dir))
+    if component is None:
+        raise ValueError(
+            f"--otel could not resolve version {version!r}: no published "
+            f"release matches it"
+        )
+    return component.version
 
 
 def _check_existing_binaries_version(binaries_dir):

--- a/.evergreen/orchestration/otel.py
+++ b/.evergreen/orchestration/otel.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import os
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -135,3 +136,36 @@ def validate_otel_opts(opts):
         )
     if opts.local_atlas:
         raise ValueError("--otel is not supported with --local-atlas")
+    # --existing-binaries-dir bypasses the version selection above, so gate
+    # on the actual binary. This is the primary path for OTel-enabled custom
+    # builds (see requires_otel_build in README.md), so probe rather than
+    # reject the combination.
+    binaries_dir = getattr(opts, "existing_binaries_dir", None)
+    if binaries_dir:
+        _check_existing_binaries_version(binaries_dir)
+
+
+def _check_existing_binaries_version(binaries_dir):
+    """Raise ValueError unless the mongod in binaries_dir reports 9.0+."""
+    ext = ".exe" if PLATFORM == "win32" else ""
+    mongod = Path(binaries_dir) / f"mongod{ext}"
+    try:
+        output = subprocess.check_output(
+            [str(mongod), "--version"], encoding="utf-8", stderr=subprocess.STDOUT
+        )
+    except (OSError, subprocess.CalledProcessError) as e:
+        raise ValueError(
+            f"--otel could not determine the server version from "
+            f"{mongod} --version: {e}"
+        ) from e
+    match = re.search(r"db version v(\d+)\.(\d+)", output)
+    if match is None:
+        raise ValueError(
+            f"--otel could not parse the server version from "
+            f"{mongod} --version output: {output.splitlines()[:1]}"
+        )
+    if (int(match.group(1)), int(match.group(2))) < (9, 0):
+        raise ValueError(
+            f"--otel requires MongoDB 9.0+, but --existing-binaries-dir "
+            f"contains {match.group(0)}"
+        )

--- a/.evergreen/orchestration/otel.py
+++ b/.evergreen/orchestration/otel.py
@@ -50,7 +50,8 @@ def handle_otel_config(data, otel_root):
 
     def traverse(root):
         if isinstance(root, list):
-            [traverse(i) for i in root]
+            # Guard items: custom configs can hold lists of scalars.
+            [traverse(i) for i in root if isinstance(i, (dict, list))]
             return
         if "ipv6" in root:
             members.append(root)
@@ -60,6 +61,16 @@ def handle_otel_config(data, otel_root):
                 traverse(value)
 
     traverse(data)
+
+    if not members:
+        # A config this traversal cannot recognize would otherwise be
+        # silently left un-instrumented while OTEL_TRACE_DIR is still
+        # exported, and the prose test would poll for spans that never come.
+        raise ValueError(
+            "--otel found no cluster members to configure in the "
+            "orchestration config (members are identified by an 'ipv6' key "
+            "in their process settings)"
+        )
 
     for member in members:
         if "port" not in member:
@@ -108,6 +119,16 @@ def validate_otel_opts(opts):
     """
     if not getattr(opts, "otel", False):
         return
+    # Cheap local checks first: the version gate below may hit the network
+    # (alias resolution) or exec a binary, and a resolution failure in an
+    # egress-less container would mask the real problem.
+    if os.environ.get("DOCKER_RUNNING"):
+        raise ValueError(
+            "--otel is not supported with DOCKER_RUNNING: the container "
+            "filesystem is not readable by the host test process"
+        )
+    if opts.local_atlas:
+        raise ValueError("--otel is not supported with --local-atlas")
     binaries_dir = getattr(opts, "existing_binaries_dir", None)
     if binaries_dir:
         # --existing-binaries-dir bypasses version selection entirely (the
@@ -142,13 +163,6 @@ def validate_otel_opts(opts):
                     f"--otel requires MongoDB 9.0+, but version "
                     f"{opts.version!r} resolves to {resolved}"
                 )
-    if os.environ.get("DOCKER_RUNNING"):
-        raise ValueError(
-            "--otel is not supported with DOCKER_RUNNING: the container "
-            "filesystem is not readable by the host test process"
-        )
-    if opts.local_atlas:
-        raise ValueError("--otel is not supported with --local-atlas")
 
 
 def _numeric_below_90(version):

--- a/.evergreen/orchestration/otel.py
+++ b/.evergreen/orchestration/otel.py
@@ -116,12 +116,14 @@ def validate_otel_opts(opts):
 
     The OTel file exporter requires MongoDB 9.0+ and a cluster that shares
     the host filesystem with the test process (the only way to read spans).
+
+    This only rejects what can be decided locally from the options; the
+    authoritative version check is check_mongod_version(), which probes the
+    actual binary after it is downloaded or copied and therefore also covers
+    version aliases, nightlies, and --existing-binaries-dir uniformly.
     """
     if not getattr(opts, "otel", False):
         return
-    # Cheap local checks first: the version gate below may hit the network
-    # (alias resolution) or exec a binary, and a resolution failure in an
-    # egress-less container would mask the real problem.
     if os.environ.get("DOCKER_RUNNING"):
         raise ValueError(
             "--otel is not supported with DOCKER_RUNNING: the container "
@@ -129,99 +131,28 @@ def validate_otel_opts(opts):
         )
     if opts.local_atlas:
         raise ValueError("--otel is not supported with --local-atlas")
-    binaries_dir = getattr(opts, "existing_binaries_dir", None)
-    if binaries_dir:
-        # --existing-binaries-dir bypasses version selection entirely (the
-        # requested version is not what runs), so the probed binary is the
-        # single source of truth and the version-string gate below does not
-        # apply. This is the primary path for OTel-enabled custom builds
-        # (see requires_otel_build in README.md).
-        _check_existing_binaries_version(binaries_dir)
-    else:
-        below_90 = _numeric_below_90(opts.version)
-        if below_90:
-            # Optional "v" prefix: mongodl aliases like v8.0-perf resolve to
-            # servers below 9.0 and must be caught here rather than failing
-            # at startup.
+    # Courtesy pre-check: reject obviously sub-9.0 version strings (e.g.
+    # "8.0", "v8.0-perf") before any download. Skipped when
+    # --existing-binaries-dir is set, where the requested version is not
+    # what runs. Aliases like "rapid" pass through here and are decided by
+    # the binary probe instead.
+    if not getattr(opts, "existing_binaries_dir", None):
+        match = re.match(r"^v?(\d+)(?:\.(\d+))?", opts.version)
+        if match and (int(match.group(1)), int(match.group(2) or 0)) < (9, 0):
             raise ValueError(
                 f"--otel requires MongoDB 9.0+ (OTel setParameters do not "
                 f"exist on {opts.version})"
             )
-        if below_90 is None and opts.version not in ("latest", "latest-build"):
-            # Non-numeric aliases ("rapid", "latest-release",
-            # "latest-stable", ...) are resolved through mongodl's release
-            # catalog -- the same mechanism the download uses -- and the
-            # resolved version is gated, so an alias starts passing
-            # automatically once it resolves to 9.0+. Master nightlies
-            # (latest/latest-build) do not resolve via the catalog and are
-            # always 9.0+.
-            resolved = _resolve_published_version(
-                opts.version, getattr(opts, "arch", None)
-            )
-            if _numeric_below_90(resolved) is not False:
-                raise ValueError(
-                    f"--otel requires MongoDB 9.0+, but version "
-                    f"{opts.version!r} resolves to {resolved}"
-                )
 
 
-def _numeric_below_90(version):
-    """True/False when version parses as [v]major[.minor]; None otherwise."""
-    match = re.match(r"^v?(\d+)(?:\.(\d+))?", version)
-    if match is None:
-        return None
-    return (int(match.group(1)), int(match.group(2) or 0)) < (9, 0)
+def check_mongod_version(binaries_dir):
+    """Raise ValueError unless the mongod in binaries_dir reports 9.0+.
 
-
-def _resolve_published_version(version, arch=None):
-    """Resolve a version alias to a concrete version via mongodl's catalog.
-
-    Filters by the same target/arch/edition/component the subsequent
-    download uses, so the gate judges the artifact that will actually be
-    downloaded (releases can be published for platforms at different times).
-    Raises ValueError when the alias cannot be resolved (unknown alias, no
-    catalog entry, or the release list is unreachable) so the gate stays
-    fail-fast rather than deferring to a server startup failure.
+    This is the authoritative --otel version gate: it measures the binary
+    that will actually run, so it covers explicit versions, aliases,
+    nightlies (including stale ones on dropped targets), and
+    --existing-binaries-dir with a single mechanism.
     """
-    evg_dir = Path(__file__).absolute().parent.parent
-    sys.path.insert(0, str(evg_dir))
-    try:
-        # Deferred: mongodl lives in .evergreen, only on sys.path here.
-        from mongodl import Cache, infer_arch, infer_target
-
-        cache = Cache.open_in(evg_dir.parent / ".local" / "cache")
-        cache.refresh_full_json()
-        component = next(
-            iter(
-                cache.db.iter_available(
-                    version=version,
-                    target=infer_target(version),
-                    arch=arch or infer_arch(),
-                    edition="enterprise",
-                    component="archive",
-                )
-            ),
-            None,
-        )
-    except ValueError:
-        raise
-    except Exception as e:
-        raise ValueError(
-            f"--otel could not resolve version {version!r} from the release "
-            f"list: {e}"
-        ) from e
-    finally:
-        sys.path.remove(str(evg_dir))
-    if component is None:
-        raise ValueError(
-            f"--otel could not resolve version {version!r}: no published "
-            f"release matches it for this platform"
-        )
-    return component.version
-
-
-def _check_existing_binaries_version(binaries_dir):
-    """Raise ValueError unless the mongod in binaries_dir reports 9.0+."""
     ext = ".exe" if PLATFORM == "win32" else ""
     mongod = Path(binaries_dir) / f"mongod{ext}"
     try:
@@ -233,14 +164,22 @@ def _check_existing_binaries_version(binaries_dir):
             f"--otel could not determine the server version from "
             f"{mongod} --version: {e}"
         ) from e
-    match = re.search(r"db version v(\d+)\.(\d+)", output)
-    if match is None:
+    version = _version_from_mongod_output(output)
+    if version is None:
         raise ValueError(
             f"--otel could not parse the server version from "
             f"{mongod} --version output: {output.splitlines()[:1]}"
         )
-    if (int(match.group(1)), int(match.group(2))) < (9, 0):
+    if version < (9, 0):
         raise ValueError(
-            f"--otel requires MongoDB 9.0+, but --existing-binaries-dir "
-            f"contains {match.group(0)}"
+            f"--otel requires MongoDB 9.0+, but the mongod binary reports "
+            f"db version v{version[0]}.{version[1]}"
         )
+
+
+def _version_from_mongod_output(output):
+    """(major, minor) from `mongod --version` output, or None."""
+    match = re.search(r"db version v(\d+)\.(\d+)", output)
+    if match is None:
+        return None
+    return (int(match.group(1)), int(match.group(2)))

--- a/.evergreen/orchestration/otel.py
+++ b/.evergreen/orchestration/otel.py
@@ -134,7 +134,9 @@ def validate_otel_opts(opts):
             # automatically once it resolves to 9.0+. Master nightlies
             # (latest/latest-build) do not resolve via the catalog and are
             # always 9.0+.
-            resolved = _resolve_published_version(opts.version)
+            resolved = _resolve_published_version(
+                opts.version, getattr(opts, "arch", None)
+            )
             if _numeric_below_90(resolved) is not False:
                 raise ValueError(
                     f"--otel requires MongoDB 9.0+, but version "
@@ -157,9 +159,12 @@ def _numeric_below_90(version):
     return (int(match.group(1)), int(match.group(2) or 0)) < (9, 0)
 
 
-def _resolve_published_version(version):
+def _resolve_published_version(version, arch=None):
     """Resolve a version alias to a concrete version via mongodl's catalog.
 
+    Filters by the same target/arch/edition/component the subsequent
+    download uses, so the gate judges the artifact that will actually be
+    downloaded (releases can be published for platforms at different times).
     Raises ValueError when the alias cannot be resolved (unknown alias, no
     catalog entry, or the release list is unreachable) so the gate stays
     fail-fast rather than deferring to a server startup failure.
@@ -168,12 +173,20 @@ def _resolve_published_version(version):
     sys.path.insert(0, str(evg_dir))
     try:
         # Deferred: mongodl lives in .evergreen, only on sys.path here.
-        from mongodl import Cache
+        from mongodl import Cache, infer_arch, infer_target
 
         cache = Cache.open_in(evg_dir.parent / ".local" / "cache")
         cache.refresh_full_json()
         component = next(
-            iter(cache.db.iter_available(version=version, component="archive")),
+            iter(
+                cache.db.iter_available(
+                    version=version,
+                    target=infer_target(version),
+                    arch=arch or infer_arch(),
+                    edition="enterprise",
+                    component="archive",
+                )
+            ),
             None,
         )
     except ValueError:
@@ -188,7 +201,7 @@ def _resolve_published_version(version):
     if component is None:
         raise ValueError(
             f"--otel could not resolve version {version!r}: no published "
-            f"release matches it"
+            f"release matches it for this platform"
         )
     return component.version
 

--- a/.evergreen/orchestration/otel.py
+++ b/.evergreen/orchestration/otel.py
@@ -1,0 +1,137 @@
+"""OpenTelemetry file-exporter configuration for trace-context prose tests
+(DRIVERS-3454). Requires MongoDB 9.0+. See README.md in this directory.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+PLATFORM = sys.platform.lower()
+
+# samplingFactor 1.0 samples every span (production default is ~0.000045,
+# which would make span assertions flake). Per the server IDL
+# (src/mongo/otel/traces/trace_sampling_parameters.idl), every sampling
+# strategy -- including defaultSampling -- also carries its own
+# tokenBucketRateLimit (default refillRate 1/s, maxTokens 10) that throttles
+# spans independently of samplingFactor, so it must be raised here too or
+# internally-initiated spans still get capped at a 10-burst.
+OTEL_SAMPLING_JSON = (
+    '{"defaultSampling":{"samplingFactor":1.0,'
+    '"tokenBucketRateLimit":{"refillRate":1000.0,"maxTokens":1000}}}'
+)
+# Externally-propagated contexts (driver traceparents) bypass the probability
+# sampler entirely and go through the separate openTelemetryExternalTracing
+# setParameter -- NOT nested under openTelemetryTracingSampling -- which
+# needs the same raise.
+OTEL_EXTERNAL_TRACING_JSON = (
+    '{"tokenBucketRateLimit":{"refillRate":1000.0,"maxTokens":1000}}'
+)
+OTEL_DIR_NAME = "otel"
+
+
+def normalize_path(path: Path | str) -> str:
+    if PLATFORM != "win32":
+        return str(path)
+    path = Path(path).as_posix()
+    return re.sub("/cygdrive/(.*?)(/)", r"\1://", path, count=1)
+
+
+def handle_otel_config(data, otel_root):
+    """Configure every mongod/mongos to export OTel spans as NDJSON files.
+
+    Each member gets its own trace directory (keyed by port) under otel_root
+    so files from different members never interleave.
+    """
+    members = []
+
+    def traverse(root):
+        if isinstance(root, list):
+            [traverse(i) for i in root]
+            return
+        if "ipv6" in root:
+            members.append(root)
+            return
+        for value in root.values():
+            if isinstance(value, (dict, list)):
+                traverse(value)
+
+    traverse(data)
+
+    for member in members:
+        if "port" not in member:
+            raise ValueError(
+                "--otel requires an explicit port for every cluster member "
+                "so each gets its own trace directory"
+            )
+        member_dir = Path(otel_root) / str(member["port"])
+        os.makedirs(member_dir, exist_ok=True)
+        set_param = member.setdefault("setParameter", {})
+        # Pre-existing OTel settings (e.g. opentelemetryHttpEndpoint, or a
+        # tracing compression the file exporter rejects) can conflict with
+        # the parameters injected below and would only fail at server
+        # startup, after the download. The tracing feature flags are also
+        # rejected: featureFlagTracing=false would start fine yet silently
+        # export no spans (the server requires it alongside
+        # featureFlagOtelTraceSampling), and a pre-set
+        # featureFlagOtelTraceSampling would be silently overwritten below.
+        # Fail fast instead.
+        conflicts = [
+            k
+            for k in set_param
+            if k.lower().startswith("opentelemetry")
+            or k in ("featureFlagTracing", "featureFlagOtelTraceSampling")
+        ]
+        if conflicts:
+            raise ValueError(
+                f"--otel conflicts with OpenTelemetry setParameters already "
+                f"present in the orchestration config: {conflicts}"
+            )
+        set_param["opentelemetryTraceDirectory"] = normalize_path(member_dir)
+        set_param["featureFlagOtelTraceSampling"] = "true"
+        set_param["openTelemetryTracingSampling"] = OTEL_SAMPLING_JSON
+        set_param["openTelemetryExternalTracing"] = OTEL_EXTERNAL_TRACING_JSON
+        # The file exporter buffers 256 export batches (flushed every 30s) by
+        # default, on top of the 1s batch processor; tests emit few spans, so
+        # flush every batch to disk like the server's own file-export tests.
+        set_param["openTelemetryTracingFileFlushCount"] = 1
+
+
+def validate_otel_opts(opts):
+    """Fail fast on option combinations incompatible with --otel.
+
+    The OTel file exporter requires MongoDB 9.0+ and a cluster that shares
+    the host filesystem with the test process (the only way to read spans).
+    """
+    if not getattr(opts, "otel", False):
+        return
+    # Optional "v" prefix: mongodl aliases like v8.0-perf resolve to servers
+    # below 9.0 and must be caught here rather than failing at startup.
+    match = re.match(r"^v?(\d+)(?:\.(\d+))?", opts.version)
+    if match:
+        if (int(match.group(1)), int(match.group(2) or 0)) < (9, 0):
+            raise ValueError(
+                f"--otel requires MongoDB 9.0+ (OTel setParameters do not "
+                f"exist on {opts.version})"
+            )
+    # Non-numeric aliases are default-closed: only master nightlies are
+    # guaranteed to be 9.0+. Aliases like "rapid", "latest-release", and
+    # "latest-stable" resolve to the newest *published* release, which is
+    # still 8.x while 9.0 is unpublished (see UNPUBLISHED_VERSIONS in
+    # drivers_orchestration.py). Add an alias here once every version it can
+    # resolve to is 9.0+.
+    elif opts.version not in ("latest", "latest-build"):
+        raise ValueError(
+            f"--otel requires MongoDB 9.0+, which cannot be guaranteed for "
+            f"version {opts.version!r}; use 'latest' or an explicit 9.x+ "
+            f"version"
+        )
+    if os.environ.get("DOCKER_RUNNING"):
+        raise ValueError(
+            "--otel is not supported with DOCKER_RUNNING: the container "
+            "filesystem is not readable by the host test process"
+        )
+    if opts.local_atlas:
+        raise ValueError("--otel is not supported with --local-atlas")

--- a/.evergreen/orchestration/pyproject.toml
+++ b/.evergreen/orchestration/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
 drivers-orchestration = "drivers_orchestration:main"
 
 [tool.hatch.build]
-include = ["drivers_orchestration.py"]
+include = ["drivers_orchestration.py", "mongodb_runner.py", "otel.py"]
 
 [tool.hatch.metadata]
 allow-direct-references=true

--- a/.evergreen/orchestration/test_drivers_orchestration.py
+++ b/.evergreen/orchestration/test_drivers_orchestration.py
@@ -1,0 +1,192 @@
+"""Unit tests for drivers_orchestration helpers. Run with:
+python -m unittest test_drivers_orchestration -v
+"""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from drivers_orchestration import (
+    OTEL_EXTERNAL_TRACING_JSON,
+    OTEL_SAMPLING_JSON,
+    handle_otel_config,
+    normalize_path,
+    validate_otel_opts,
+)
+
+EXPECTED_PARAMS = {
+    "featureFlagOtelTraceSampling": "true",
+    "openTelemetryTracingSampling": OTEL_SAMPLING_JSON,
+    "openTelemetryExternalTracing": OTEL_EXTERNAL_TRACING_JSON,
+}
+
+
+class TestHandleOtelConfig(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.otel_root = Path(self._tmp.name) / "otel"
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def assert_member(self, params, port):
+        for key, value in EXPECTED_PARAMS.items():
+            self.assertEqual(params["setParameter"][key], value)
+        trace_dir = params["setParameter"]["opentelemetryTraceDirectory"]
+        self.assertEqual(trace_dir, normalize_path(self.otel_root / str(port)))
+        self.assertTrue((self.otel_root / str(port)).is_dir())
+
+    def test_standalone(self):
+        data = {
+            "name": "mongod",
+            "procParams": {"ipv6": True, "bind_ip": "127.0.0.1,::1", "port": 27017},
+        }
+        handle_otel_config(data, self.otel_root)
+        self.assert_member(data["procParams"], 27017)
+
+    def test_replica_set(self):
+        data = {
+            "id": "repl0",
+            "members": [
+                {"procParams": {"ipv6": True, "port": 27017}, "rsParams": {}},
+                {"procParams": {"ipv6": True, "port": 27018}, "rsParams": {}},
+            ],
+        }
+        handle_otel_config(data, self.otel_root)
+        for member, port in zip(data["members"], (27017, 27018)):
+            self.assert_member(member["procParams"], port)
+
+    def test_sharded_cluster_includes_routers(self):
+        data = {
+            "id": "shard_cluster_1",
+            "shards": [
+                {
+                    "id": "sh01",
+                    "shardParams": {
+                        "members": [
+                            {
+                                "procParams": {
+                                    "ipv6": True,
+                                    "shardsvr": True,
+                                    "port": 27217,
+                                }
+                            }
+                        ]
+                    },
+                }
+            ],
+            "routers": [
+                {"ipv6": True, "bind_ip": "127.0.0.1,::1", "port": 27017},
+            ],
+        }
+        handle_otel_config(data, self.otel_root)
+        self.assert_member(
+            data["shards"][0]["shardParams"]["members"][0]["procParams"], 27217
+        )
+        # Router entries hold proc params directly (no procParams wrapper).
+        self.assert_member(data["routers"][0], 27017)
+
+    def test_preserves_existing_set_parameter(self):
+        data = {
+            "name": "mongod",
+            "procParams": {
+                "ipv6": True,
+                "port": 27017,
+                "setParameter": {"enableTestCommands": 1},
+            },
+        }
+        handle_otel_config(data, self.otel_root)
+        self.assertEqual(data["procParams"]["setParameter"]["enableTestCommands"], 1)
+        self.assert_member(data["procParams"], 27017)
+
+    def test_missing_port_raises(self):
+        data = {"name": "mongod", "procParams": {"ipv6": True}}
+        with self.assertRaises(ValueError):
+            handle_otel_config(data, self.otel_root)
+
+    def test_sampling_json_is_valid_and_pinned(self):
+        # defaultSampling carries its own tokenBucketRateLimit per the server
+        # IDL (trace_sampling_parameters.idl); it must be raised alongside
+        # samplingFactor or internally-initiated spans are still capped at
+        # the default 10-burst.
+        parsed = json.loads(OTEL_SAMPLING_JSON)
+        self.assertEqual(parsed["defaultSampling"]["samplingFactor"], 1.0)
+        self.assertEqual(
+            parsed["defaultSampling"]["tokenBucketRateLimit"],
+            {"refillRate": 1000.0, "maxTokens": 1000},
+        )
+
+    def test_external_tracing_json_is_valid_and_pinned(self):
+        # openTelemetryExternalTracing is a separate top-level setParameter
+        # from openTelemetryTracingSampling on the server (verified against
+        # a 9.0 build via getParameter "*"); it is NOT a nested "external"
+        # field inside openTelemetryTracingSampling.
+        parsed = json.loads(OTEL_EXTERNAL_TRACING_JSON)
+        self.assertEqual(
+            parsed["tokenBucketRateLimit"],
+            {"refillRate": 1000.0, "maxTokens": 1000},
+        )
+
+
+def make_opts(**kwargs):
+    defaults = {
+        "otel": True,
+        "version": "latest",
+        "local_atlas": False,
+        "mongodb_runner": False,
+    }
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+class TestValidateOtelOpts(unittest.TestCase):
+    def setUp(self):
+        os.environ.pop("DOCKER_RUNNING", None)
+
+    tearDown = setUp
+
+    def test_noop_when_otel_unset(self):
+        # Must not raise even in an otherwise-invalid combination.
+        validate_otel_opts(make_opts(otel=False, version="4.2", local_atlas=True))
+
+    def test_latest_and_rapid_allowed(self):
+        validate_otel_opts(make_opts(version="latest"))
+        validate_otel_opts(make_opts(version="rapid"))
+
+    def test_90_and_above_allowed(self):
+        validate_otel_opts(make_opts(version="9.0"))
+        validate_otel_opts(make_opts(version="10.1"))
+
+    def test_below_90_rejected(self):
+        for version in ("4.2", "8.0", "8.2"):
+            with self.assertRaisesRegex(ValueError, "9.0"):
+                validate_otel_opts(make_opts(version=version))
+
+    def test_bare_major_version_below_90_rejected(self):
+        with self.assertRaisesRegex(ValueError, "9.0"):
+            validate_otel_opts(make_opts(version="8"))
+
+    def test_bare_major_version_90_allowed(self):
+        validate_otel_opts(make_opts(version="9"))
+
+    def test_docker_running_rejected(self):
+        os.environ["DOCKER_RUNNING"] = "true"
+        with self.assertRaisesRegex(ValueError, "DOCKER_RUNNING"):
+            validate_otel_opts(make_opts())
+
+    def test_local_atlas_rejected(self):
+        with self.assertRaisesRegex(ValueError, "local-atlas"):
+            validate_otel_opts(make_opts(local_atlas=True))
+
+    def test_mongodb_runner_rejected(self):
+        with self.assertRaisesRegex(ValueError, "mongodb-runner"):
+            validate_otel_opts(make_opts(mongodb_runner=True))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.evergreen/orchestration/test_drivers_orchestration.py
+++ b/.evergreen/orchestration/test_drivers_orchestration.py
@@ -23,6 +23,7 @@ EXPECTED_PARAMS = {
     "featureFlagOtelTraceSampling": "true",
     "openTelemetryTracingSampling": OTEL_SAMPLING_JSON,
     "openTelemetryExternalTracing": OTEL_EXTERNAL_TRACING_JSON,
+    "openTelemetryTracingFileFlushCount": 1,
 }
 
 
@@ -173,6 +174,15 @@ class TestValidateOtelOpts(unittest.TestCase):
 
     def test_bare_major_version_90_allowed(self):
         validate_otel_opts(make_opts(version="9"))
+
+    def test_v_prefixed_perf_aliases_rejected(self):
+        # mongodl resolves these to 6.0.x / 8.0.x servers.
+        for version in ("v6.0-perf", "v8.0-perf"):
+            with self.assertRaisesRegex(ValueError, "9.0"):
+                validate_otel_opts(make_opts(version=version))
+
+    def test_v_prefixed_90_allowed(self):
+        validate_otel_opts(make_opts(version="v9.0"))
 
     def test_docker_running_rejected(self):
         os.environ["DOCKER_RUNNING"] = "true"

--- a/.evergreen/orchestration/test_drivers_orchestration.py
+++ b/.evergreen/orchestration/test_drivers_orchestration.py
@@ -118,6 +118,20 @@ class TestHandleOtelConfig(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "opentelemetryHttpEndpoint"):
             handle_otel_config(data, self.otel_root)
 
+    def test_disabled_tracing_feature_flag_raises(self):
+        # featureFlagTracing=false starts fine but silently exports no spans:
+        # the server requires it alongside featureFlagOtelTraceSampling.
+        data = {
+            "name": "mongod",
+            "procParams": {
+                "ipv6": True,
+                "port": 27017,
+                "setParameter": {"featureFlagTracing": False},
+            },
+        }
+        with self.assertRaisesRegex(ValueError, "featureFlagTracing"):
+            handle_otel_config(data, self.otel_root)
+
     def test_missing_port_raises(self):
         data = {"name": "mongod", "procParams": {"ipv6": True}}
         with self.assertRaises(ValueError):

--- a/.evergreen/orchestration/test_drivers_orchestration.py
+++ b/.evergreen/orchestration/test_drivers_orchestration.py
@@ -9,12 +9,12 @@ import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
-from unittest import mock
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from otel import (
     OTEL_EXTERNAL_TRACING_JSON,
     OTEL_SAMPLING_JSON,
+    _version_from_mongod_output,
     handle_otel_config,
     normalize_path,
     validate_otel_opts,
@@ -203,22 +203,11 @@ class TestValidateOtelOpts(unittest.TestCase):
         validate_otel_opts(make_opts(version="latest"))
         validate_otel_opts(make_opts(version="latest-build"))
 
-    def test_alias_resolving_below_90_rejected(self):
-        with mock.patch(
-            "otel._resolve_published_version", return_value="8.2.1"
-        ), self.assertRaisesRegex(ValueError, "resolves to 8.2.1"):
-            validate_otel_opts(make_opts(version="rapid"))
-
-    def test_alias_resolving_to_90_allowed(self):
-        with mock.patch("otel._resolve_published_version", return_value="9.1.0"):
-            validate_otel_opts(make_opts(version="latest-release"))
-
-    def test_unresolvable_alias_rejected(self):
-        with mock.patch(
-            "otel._resolve_published_version",
-            side_effect=ValueError("--otel could not resolve"),
-        ), self.assertRaisesRegex(ValueError, "could not resolve"):
-            validate_otel_opts(make_opts(version="rapid"))
+    def test_aliases_pass_through_to_binary_probe(self):
+        # Aliases are not decided here: the authoritative gate is
+        # check_mongod_version() on the downloaded binary.
+        for version in ("rapid", "latest-release", "latest-stable"):
+            validate_otel_opts(make_opts(version=version))
 
     def test_90_and_above_allowed(self):
         validate_otel_opts(make_opts(version="9.0"))
@@ -257,6 +246,26 @@ class TestValidateOtelOpts(unittest.TestCase):
     def test_not_probed_when_otel_unset(self):
         # existing-binaries probing must not run when otel is off.
         validate_otel_opts(make_opts(otel=False, existing_binaries_dir="/nonexistent"))
+
+    def test_version_string_gate_skipped_with_existing_binaries(self):
+        # The requested version is not what runs; the binary probe decides.
+        validate_otel_opts(make_opts(version="8.0", existing_binaries_dir="/some/dir"))
+
+
+class TestVersionFromMongodOutput(unittest.TestCase):
+    def test_parses_real_output_shape(self):
+        output = (
+            "db version v9.1.0\n"
+            'Build Info: {"version": "9.1.0", "openSSLVersion": '
+            '"OpenSSL 1.1.1k  FIPS 25 Mar 2021"}\n'
+        )
+        self.assertEqual(_version_from_mongod_output(output), (9, 1))
+
+    def test_does_not_match_other_numbers(self):
+        # OpenSSL versions, distro strings etc. must not be picked up.
+        self.assertIsNone(
+            _version_from_mongod_output("OpenSSL 1.1.1k\ndistmod: rhel88\n")
+        )
 
 
 if __name__ == "__main__":

--- a/.evergreen/orchestration/test_drivers_orchestration.py
+++ b/.evergreen/orchestration/test_drivers_orchestration.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from drivers_orchestration import (
+from otel import (
     OTEL_EXTERNAL_TRACING_JSON,
     OTEL_SAMPLING_JSON,
     handle_otel_config,
@@ -166,7 +166,6 @@ def make_opts(**kwargs):
         "otel": True,
         "version": "latest",
         "local_atlas": False,
-        "mongodb_runner": False,
     }
     defaults.update(kwargs)
     return SimpleNamespace(**defaults)
@@ -226,10 +225,6 @@ class TestValidateOtelOpts(unittest.TestCase):
     def test_local_atlas_rejected(self):
         with self.assertRaisesRegex(ValueError, "local-atlas"):
             validate_otel_opts(make_opts(local_atlas=True))
-
-    def test_mongodb_runner_rejected(self):
-        with self.assertRaisesRegex(ValueError, "mongodb-runner"):
-            validate_otel_opts(make_opts(mongodb_runner=True))
 
 
 if __name__ == "__main__":

--- a/.evergreen/orchestration/test_drivers_orchestration.py
+++ b/.evergreen/orchestration/test_drivers_orchestration.py
@@ -9,6 +9,7 @@ import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
+from unittest import mock
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from otel import (
@@ -185,12 +186,22 @@ class TestValidateOtelOpts(unittest.TestCase):
         validate_otel_opts(make_opts(version="latest"))
         validate_otel_opts(make_opts(version="latest-build"))
 
-    def test_unguaranteed_aliases_rejected(self):
-        # These resolve to the newest *published* release, which can be
-        # below 9.0 while 9.0 is unpublished.
-        for version in ("rapid", "latest-release", "latest-stable"):
-            with self.assertRaisesRegex(ValueError, "9.0"):
-                validate_otel_opts(make_opts(version=version))
+    def test_alias_resolving_below_90_rejected(self):
+        with mock.patch(
+            "otel._resolve_published_version", return_value="8.2.1"
+        ), self.assertRaisesRegex(ValueError, "resolves to 8.2.1"):
+            validate_otel_opts(make_opts(version="rapid"))
+
+    def test_alias_resolving_to_90_allowed(self):
+        with mock.patch("otel._resolve_published_version", return_value="9.1.0"):
+            validate_otel_opts(make_opts(version="latest-release"))
+
+    def test_unresolvable_alias_rejected(self):
+        with mock.patch(
+            "otel._resolve_published_version",
+            side_effect=ValueError("--otel could not resolve"),
+        ), self.assertRaisesRegex(ValueError, "could not resolve"):
+            validate_otel_opts(make_opts(version="rapid"))
 
     def test_90_and_above_allowed(self):
         validate_otel_opts(make_opts(version="9.0"))

--- a/.evergreen/orchestration/test_drivers_orchestration.py
+++ b/.evergreen/orchestration/test_drivers_orchestration.py
@@ -138,6 +138,23 @@ class TestHandleOtelConfig(unittest.TestCase):
         with self.assertRaises(ValueError):
             handle_otel_config(data, self.otel_root)
 
+    def test_no_recognizable_members_raises(self):
+        # A config the traversal cannot recognize must fail loudly rather
+        # than exporting OTEL_TRACE_DIR with nothing instrumented.
+        data = {"name": "mongod", "procParams": {"port": 27017}}
+        with self.assertRaisesRegex(ValueError, "no cluster members"):
+            handle_otel_config(data, self.otel_root)
+
+    def test_scalar_lists_are_tolerated(self):
+        # Lists of scalars in custom configs must not crash the traversal.
+        data = {
+            "name": "mongod",
+            "labels": ["a", "b", 3],
+            "procParams": {"ipv6": True, "port": 27017},
+        }
+        handle_otel_config(data, self.otel_root)
+        self.assert_member(data["procParams"], 27017)
+
     def test_sampling_json_is_valid_and_pinned(self):
         # defaultSampling carries its own tokenBucketRateLimit per the server
         # IDL (trace_sampling_parameters.idl); it must be raised alongside

--- a/.evergreen/orchestration/test_drivers_orchestration.py
+++ b/.evergreen/orchestration/test_drivers_orchestration.py
@@ -226,6 +226,10 @@ class TestValidateOtelOpts(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "local-atlas"):
             validate_otel_opts(make_opts(local_atlas=True))
 
+    def test_not_probed_when_otel_unset(self):
+        # existing-binaries probing must not run when otel is off.
+        validate_otel_opts(make_opts(otel=False, existing_binaries_dir="/nonexistent"))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.evergreen/orchestration/test_drivers_orchestration.py
+++ b/.evergreen/orchestration/test_drivers_orchestration.py
@@ -104,6 +104,20 @@ class TestHandleOtelConfig(unittest.TestCase):
         self.assertEqual(data["procParams"]["setParameter"]["enableTestCommands"], 1)
         self.assert_member(data["procParams"], 27017)
 
+    def test_conflicting_otel_settings_raise(self):
+        # A config that already enables another OTel exporter (e.g. the HTTP
+        # endpoint) would only fail at server startup; fail fast instead.
+        data = {
+            "name": "mongod",
+            "procParams": {
+                "ipv6": True,
+                "port": 27017,
+                "setParameter": {"opentelemetryHttpEndpoint": "localhost:4318"},
+            },
+        }
+        with self.assertRaisesRegex(ValueError, "opentelemetryHttpEndpoint"):
+            handle_otel_config(data, self.otel_root)
+
     def test_missing_port_raises(self):
         data = {"name": "mongod", "procParams": {"ipv6": True}}
         with self.assertRaises(ValueError):

--- a/.evergreen/orchestration/test_drivers_orchestration.py
+++ b/.evergreen/orchestration/test_drivers_orchestration.py
@@ -155,9 +155,16 @@ class TestValidateOtelOpts(unittest.TestCase):
         # Must not raise even in an otherwise-invalid combination.
         validate_otel_opts(make_opts(otel=False, version="4.2", local_atlas=True))
 
-    def test_latest_and_rapid_allowed(self):
+    def test_nightly_aliases_allowed(self):
         validate_otel_opts(make_opts(version="latest"))
-        validate_otel_opts(make_opts(version="rapid"))
+        validate_otel_opts(make_opts(version="latest-build"))
+
+    def test_unguaranteed_aliases_rejected(self):
+        # These resolve to the newest *published* release, which can be
+        # below 9.0 while 9.0 is unpublished.
+        for version in ("rapid", "latest-release", "latest-stable"):
+            with self.assertRaisesRegex(ValueError, "9.0"):
+                validate_otel_opts(make_opts(version=version))
 
     def test_90_and_above_allowed(self):
         validate_otel_opts(make_opts(version="9.0"))

--- a/.evergreen/orchestration/test_drivers_orchestration.py
+++ b/.evergreen/orchestration/test_drivers_orchestration.py
@@ -89,7 +89,6 @@ class TestHandleOtelConfig(unittest.TestCase):
         self.assert_member(
             data["shards"][0]["shardParams"]["members"][0]["procParams"], 27217
         )
-        # Router entries hold proc params directly (no procParams wrapper).
         self.assert_member(data["routers"][0], 27017)
 
     def test_preserves_existing_set_parameter(self):

--- a/.evergreen/run-mongodb.sh
+++ b/.evergreen/run-mongodb.sh
@@ -21,6 +21,7 @@ set -eu
 #   INSTALL_LEGACY_SHELL   Set to a non-empty string to install the legacy mongo shell.
 #   TLS_PEM_KEY_FILE       Set a .pem file that contains the TLS certificate and key for the server
 #   TLS_CA_FILE            Set a .pem file that contains the root certificate chain for the server
+#   OTEL                   Set to a non-empty string to enable the OpenTelemetry file exporter on every mongod/mongos (requires MongoDB 9.0+; exports OTEL_TRACE_DIR via mo-expansion). See .evergreen/orchestration/README.md.
 
 # See https://stackoverflow.com/questions/35006457/choosing-between-0-and-bash-source/35006505#35006505
 # Why we need this syntax when sh is not aliased to bash (this script must be able to be called from sh)

--- a/.evergreen/run-orchestration.sh
+++ b/.evergreen/run-orchestration.sh
@@ -21,6 +21,7 @@ set -eu
 #   INSTALL_LEGACY_SHELL   Set to a non-empty string to install the legacy mongo shell.
 #   TLS_PEM_KEY_FILE       Set a .pem file that contains the TLS certificate and key for the server
 #   TLS_CA_FILE            Set a .pem file that contains the root certificate chain for the server
+#   OTEL                   Set to a non-empty string to enable the OpenTelemetry file exporter on every mongod/mongos (requires MongoDB 9.0+; exports OTEL_TRACE_DIR via mo-expansion). See .evergreen/orchestration/README.md.
 
 # The following variables affect the mongo-orchestration server:
 #  MONGO_ORCHESTRATION_HOME  Set the path where the files used by mongo-orchestration will be located.

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -6,7 +6,7 @@ set -o errexit  # Exit the script with error if any of the commands fail
 #       SSL                     Set to enable SSL. Defaults to "nossl"
 #       MONGODB_URI             Set the suggested connection MONGODB_URI (including credentials and topology info)
 #       MARCH                   Machine Architecture. Defaults to lowercase uname -m
-#       OTEL_TRACE_DIR          Set when the cluster was started with OTEL=1 (directory of server OTel span files; absence means OTel prose tests should be skipped)
+#       OTEL_TRACE_DIR          Set when the cluster was started with OTEL=1 (directory of server OTel span files; unset or empty means OTel prose tests should be skipped)
 
 SCRIPT_DIR=$(dirname ${BASH_SOURCE:-$0})
 . $SCRIPT_DIR/handle-paths.sh

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -6,6 +6,7 @@ set -o errexit  # Exit the script with error if any of the commands fail
 #       SSL                     Set to enable SSL. Defaults to "nossl"
 #       MONGODB_URI             Set the suggested connection MONGODB_URI (including credentials and topology info)
 #       MARCH                   Machine Architecture. Defaults to lowercase uname -m
+#       OTEL_TRACE_DIR          Set when the cluster was started with OTEL=1 (directory of server OTel span files; absence means OTel prose tests should be skipped)
 
 SCRIPT_DIR=$(dirname ${BASH_SOURCE:-$0})
 . $SCRIPT_DIR/handle-paths.sh

--- a/.evergreen/tests/test-otel.sh
+++ b/.evergreen/tests/test-otel.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+# Test the OTel span-export orchestration configuration (DRIVERS-3454).
+set -eu
+
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+. $SCRIPT_DIR/../handle-paths.sh
+. $SCRIPT_DIR/../ensure-uv.sh
+
+pushd $SCRIPT_DIR/.. > /dev/null
+
+ensure_uv || exit 1
+
+# Unit tests for the injection and gating helpers.
+pushd orchestration > /dev/null
+uv run python -m unittest test_drivers_orchestration -v
+popd > /dev/null
+
+bash install-cli.sh "$(pwd)/orchestration"
+
+# Fail-fast checks: incompatible combinations must error before any download.
+if OTEL=1 ./orchestration/drivers-orchestration run --version 8.0 2>/dev/null; then
+  echo "ERROR: OTEL=1 with server 8.0 should have failed"
+  exit 1
+fi
+if OTEL=1 ./orchestration/drivers-orchestration run --version latest --local-atlas 2>/dev/null; then
+  echo "ERROR: OTEL=1 with --local-atlas should have failed"
+  exit 1
+fi
+if OTEL=1 DOCKER_RUNNING=true ./orchestration/drivers-orchestration run --version latest 2>/dev/null; then
+  echo "ERROR: OTEL=1 with DOCKER_RUNNING should have failed"
+  exit 1
+fi
+
+# Live run: the OTel parameters must be applied and the trace dir exported.
+OTEL=1 ./orchestration/drivers-orchestration run --version latest
+
+grep -q '^OTEL_TRACE_DIR=' mo-expansion.sh
+# shellcheck disable=SC1091
+. ./mo-expansion.sh
+test -d "${OTEL_TRACE_DIR}/27017"
+
+$MONGODB_BINARIES/mongosh "mongodb://localhost:27017/?directConnection=true" --eval '
+  const p = db.adminCommand({
+    getParameter: 1,
+    opentelemetryTraceDirectory: 1,
+    openTelemetryExternalTracing: 1,
+    openTelemetryTracingSampling: 1,
+  });
+  if (!p.opentelemetryTraceDirectory.endsWith("27017") ||
+      p.openTelemetryExternalTracing.tokenBucketRateLimit.maxTokens !== 1000 ||
+      p.openTelemetryTracingSampling.defaultSampling.samplingFactor !== 1.0) {
+    throw new Error("unexpected OTel parameters: " + JSON.stringify(p));
+  }
+  print("OTEL_PARAMS_OK");
+' | grep -q OTEL_PARAMS_OK
+
+./orchestration/drivers-orchestration stop
+
+# Opt-in regression: without OTEL, no trace dir and no expansion entry.
+./orchestration/drivers-orchestration run --version latest
+if grep -q OTEL_TRACE_DIR mo-expansion.sh; then
+  echo "ERROR: OTEL_TRACE_DIR exported without OTEL=1"
+  exit 1
+fi
+if [ -d "${DRIVERS_TOOLS}/otel" ]; then
+  echo "ERROR: otel directory created without OTEL=1"
+  exit 1
+fi
+./orchestration/drivers-orchestration stop
+
+popd > /dev/null
+echo "OTel orchestration test... done."

--- a/.evergreen/tests/test-otel.sh
+++ b/.evergreen/tests/test-otel.sh
@@ -46,10 +46,12 @@ $MONGODB_BINARIES/mongosh "mongodb://localhost:27017/?directConnection=true" --e
     opentelemetryTraceDirectory: 1,
     openTelemetryExternalTracing: 1,
     openTelemetryTracingSampling: 1,
+    openTelemetryTracingFileFlushCount: 1,
   });
   if (!p.opentelemetryTraceDirectory.endsWith("27017") ||
       p.openTelemetryExternalTracing.tokenBucketRateLimit.maxTokens !== 1000 ||
-      p.openTelemetryTracingSampling.defaultSampling.samplingFactor !== 1.0) {
+      p.openTelemetryTracingSampling.defaultSampling.samplingFactor !== 1.0 ||
+      p.openTelemetryTracingFileFlushCount !== 1) {
     throw new Error("unexpected OTel parameters: " + JSON.stringify(p));
   }
   print("OTEL_PARAMS_OK");

--- a/.evergreen/tests/test-otel.sh
+++ b/.evergreen/tests/test-otel.sh
@@ -72,4 +72,6 @@ fi
 ./orchestration/drivers-orchestration stop
 
 popd > /dev/null
+# Overwrite the placeholder FAIL result seeded by setup.sh with a PASS entry.
+make -C ${DRIVERS_TOOLS} test
 echo "OTel orchestration test... done."

--- a/.evergreen/tests/test-otel.sh
+++ b/.evergreen/tests/test-otel.sh
@@ -18,9 +18,9 @@ popd > /dev/null
 
 bash install-cli.sh "$(pwd)/orchestration"
 
-# Fail-fast checks: incompatible combinations must error before any download,
-# with the expected message -- a bare non-zero exit could also be an
-# unrelated crash (e.g. an ImportError) masquerading as a working gate.
+# Fail-fast checks: incompatible combinations must error with the expected
+# message -- a bare non-zero exit could also be an unrelated crash (e.g. an
+# ImportError) masquerading as a working gate.
 assert_gate_rejects() {
   local expected="$1"
   shift
@@ -43,25 +43,37 @@ assert_gate_rejects "local-atlas" \
 assert_gate_rejects "DOCKER_RUNNING" \
   env OTEL=1 DOCKER_RUNNING=true ./orchestration/drivers-orchestration run --version latest
 
-# --existing-binaries-dir bypasses version selection, so the gate probes the
-# actual mongod binary: a real 8.0 binary must be rejected before any
-# download or deployment.
-EXISTING_BIN_DIR=mongodl_otel_test
-rm -rf ${EXISTING_BIN_DIR}
-uv run python mongodl.py --edition enterprise --version 8.0 --component archive --out ${EXISTING_BIN_DIR} --strip-path-components 2 --cache-dir "${DRIVERS_TOOLS}/.local/cache" --retries 5
-assert_gate_rejects "existing-binaries-dir contains" \
-  env OTEL=1 ./orchestration/drivers-orchestration run --existing-binaries-dir=${EXISTING_BIN_DIR}
-rm -rf ${EXISTING_BIN_DIR}
+# The authoritative version gate probes the binary that will actually run: a
+# real 8.0 binary via --existing-binaries-dir must be rejected before the
+# remaining downloads and the deployment.
+EXISTING_BIN_80=mongodl_otel_test_80
+rm -rf ${EXISTING_BIN_80}
+uv run python mongodl.py --edition enterprise --version 8.0 --component archive --out ${EXISTING_BIN_80} --strip-path-components 2 --cache-dir "${DRIVERS_TOOLS}/.local/cache" --retries 5
+assert_gate_rejects "mongod binary reports db version v8.0" \
+  env OTEL=1 ./orchestration/drivers-orchestration run --existing-binaries-dir=${EXISTING_BIN_80}
+rm -rf ${EXISTING_BIN_80}
 
-# Live run: the OTel parameters must be applied and the trace dir exported.
-OTEL=1 ./orchestration/drivers-orchestration run --version latest
-
+# Live sharded cluster through --existing-binaries-dir, in one leg:
+# - mongos must accept the injected setParameters (router entries hold proc
+#   params directly, without a procParams wrapper);
+# - per-port trace directories for routers and shard members;
+# - --version 8.0 is deliberate: the probed binary is authoritative and a
+#   stale requested version must not veto a compatible 9.0+ build
+#   (--skip-crypt-shared avoids downloading the only 8.0 artifact the
+#   version would otherwise select).
+EXISTING_BIN_LATEST=otel_existing_bin_test
+rm -rf ${EXISTING_BIN_LATEST}
+uv run python mongodl.py --edition enterprise --version latest --component archive --out ${EXISTING_BIN_LATEST} --strip-path-components 2 --cache-dir "${DRIVERS_TOOLS}/.local/cache" --retries 5
+OTEL=1 ./orchestration/drivers-orchestration run --topology sharded_cluster --existing-binaries-dir=${EXISTING_BIN_LATEST} --version 8.0 --skip-crypt-shared
 grep -q '^OTEL_TRACE_DIR=' mo-expansion.sh
 # shellcheck disable=SC1091
 . ./mo-expansion.sh
+test -n "${OTEL_TRACE_DIR}"
+# Per-port directories for the mongos (27017) and a shard member (27217).
 test -d "${OTEL_TRACE_DIR}/27017"
-
-$MONGODB_BINARIES/mongosh "mongodb://localhost:27017/?directConnection=true" --eval '
+test -d "${OTEL_TRACE_DIR}/27217"
+# getParameter against the mongos itself: the router's own parameters.
+$MONGODB_BINARIES/mongosh "mongodb://localhost:27017" --eval '
   const p = db.adminCommand({
     getParameter: 1,
     opentelemetryTraceDirectory: 1,
@@ -73,33 +85,10 @@ $MONGODB_BINARIES/mongosh "mongodb://localhost:27017/?directConnection=true" --e
       p.openTelemetryExternalTracing.tokenBucketRateLimit.maxTokens !== 1000 ||
       p.openTelemetryTracingSampling.defaultSampling.samplingFactor !== 1.0 ||
       p.openTelemetryTracingFileFlushCount !== 1) {
-    throw new Error("unexpected OTel parameters: " + JSON.stringify(p));
+    throw new Error("unexpected OTel parameters on mongos: " + JSON.stringify(p));
   }
-  print("OTEL_PARAMS_OK");
-' | grep -q OTEL_PARAMS_OK
-
-./orchestration/drivers-orchestration stop
-
-# Positive probe path: a 9.0+ --existing-binaries-dir (copied from the latest
-# binaries the previous run downloaded) passes the gate and the cluster comes
-# up with the OTel parameters applied.
-EXISTING_BIN_LATEST=otel_existing_bin_test
-rm -rf ${EXISTING_BIN_LATEST}
-# The previous run already downloaded the latest archive into this cache
-# dir, so this is a re-extract, not a second download.
-uv run python mongodl.py --edition enterprise --version latest --component archive --out ${EXISTING_BIN_LATEST} --strip-path-components 2 --cache-dir "${DRIVERS_TOOLS}/.local/cache" --retries 5
-# --version 8.0 is deliberate: with --existing-binaries-dir the probed
-# binary is authoritative and a stale requested version must not veto a
-# compatible 9.0+ build (--skip-crypt-shared avoids downloading the only
-# 8.0 artifact the version would otherwise select).
-OTEL=1 ./orchestration/drivers-orchestration run --existing-binaries-dir=${EXISTING_BIN_LATEST} --version 8.0 --skip-crypt-shared
-$MONGODB_BINARIES/mongosh "mongodb://localhost:27017/?directConnection=true" --eval '
-  const p = db.adminCommand({getParameter: 1, opentelemetryTraceDirectory: 1});
-  if (!p.opentelemetryTraceDirectory.endsWith("27017")) {
-    throw new Error("unexpected OTel parameters via existing binaries: " + JSON.stringify(p));
-  }
-  print("OTEL_EXISTING_BIN_PARAMS_OK");
-' | grep -q OTEL_EXISTING_BIN_PARAMS_OK
+  print("OTEL_MONGOS_PARAMS_OK");
+' | grep -q OTEL_MONGOS_PARAMS_OK
 ./orchestration/drivers-orchestration stop
 rm -rf ${EXISTING_BIN_LATEST}
 
@@ -134,29 +123,6 @@ $MONGODB_BINARIES/mongosh "mongodb://localhost:27017/?directConnection=true" --e
   print("OTEL_RUNNER_PARAMS_OK");
 ' | grep -q OTEL_RUNNER_PARAMS_OK
 bash ./run-mongodb.sh stop
-
-# Sharded topology: mongos must accept the injected setParameters too
-# (router entries hold proc params directly, without a procParams wrapper).
-OTEL=1 ./orchestration/drivers-orchestration run --version latest --topology sharded_cluster
-# shellcheck disable=SC1091
-. ./mo-expansion.sh
-# Per-port directories for a shard member (27217) and the mongos (27017).
-test -d "${OTEL_TRACE_DIR}/27217"
-test -d "${OTEL_TRACE_DIR}/27017"
-# getParameter against the mongos itself: the router's own parameters.
-$MONGODB_BINARIES/mongosh "mongodb://localhost:27017" --eval '
-  const p = db.adminCommand({
-    getParameter: 1,
-    opentelemetryTraceDirectory: 1,
-    openTelemetryExternalTracing: 1,
-  });
-  if (!p.opentelemetryTraceDirectory.endsWith("27017") ||
-      p.openTelemetryExternalTracing.tokenBucketRateLimit.maxTokens !== 1000) {
-    throw new Error("unexpected OTel parameters on mongos: " + JSON.stringify(p));
-  }
-  print("OTEL_MONGOS_PARAMS_OK");
-' | grep -q OTEL_MONGOS_PARAMS_OK
-./orchestration/drivers-orchestration stop
 
 # Opt-in regression: without OTEL, no trace dir and no expansion entry.
 ./orchestration/drivers-orchestration run --version latest

--- a/.evergreen/tests/test-otel.sh
+++ b/.evergreen/tests/test-otel.sh
@@ -18,30 +18,39 @@ popd > /dev/null
 
 bash install-cli.sh "$(pwd)/orchestration"
 
-# Fail-fast checks: incompatible combinations must error before any download.
-if OTEL=1 ./orchestration/drivers-orchestration run --version 8.0 2>/dev/null; then
-  echo "ERROR: OTEL=1 with server 8.0 should have failed"
-  exit 1
-fi
-if OTEL=1 ./orchestration/drivers-orchestration run --version latest --local-atlas 2>/dev/null; then
-  echo "ERROR: OTEL=1 with --local-atlas should have failed"
-  exit 1
-fi
-if OTEL=1 DOCKER_RUNNING=true ./orchestration/drivers-orchestration run --version latest 2>/dev/null; then
-  echo "ERROR: OTEL=1 with DOCKER_RUNNING should have failed"
-  exit 1
-fi
+# Fail-fast checks: incompatible combinations must error before any download,
+# with the expected message -- a bare non-zero exit could also be an
+# unrelated crash (e.g. an ImportError) masquerading as a working gate.
+assert_gate_rejects() {
+  local expected="$1"
+  shift
+  local output
+  if output=$("$@" 2>&1); then
+    echo "ERROR: '$*' should have failed"
+    exit 1
+  fi
+  if ! echo "$output" | grep -q "$expected"; then
+    echo "ERROR: '$*' failed for the wrong reason (expected '$expected'):"
+    echo "$output"
+    exit 1
+  fi
+}
+
+assert_gate_rejects "requires MongoDB 9.0" \
+  env OTEL=1 ./orchestration/drivers-orchestration run --version 8.0
+assert_gate_rejects "local-atlas" \
+  env OTEL=1 ./orchestration/drivers-orchestration run --version latest --local-atlas
+assert_gate_rejects "DOCKER_RUNNING" \
+  env OTEL=1 DOCKER_RUNNING=true ./orchestration/drivers-orchestration run --version latest
 
 # --existing-binaries-dir bypasses version selection, so the gate probes the
 # actual mongod binary: a real 8.0 binary must be rejected before any
 # download or deployment.
 EXISTING_BIN_DIR=mongodl_otel_test
 rm -rf ${EXISTING_BIN_DIR}
-uv run python mongodl.py --edition enterprise --version 8.0 --component archive --out ${EXISTING_BIN_DIR} --strip-path-components 2 --retries 5
-if OTEL=1 ./orchestration/drivers-orchestration run --existing-binaries-dir=${EXISTING_BIN_DIR} 2>/dev/null; then
-  echo "ERROR: OTEL=1 with an 8.0 --existing-binaries-dir should have failed"
-  exit 1
-fi
+uv run python mongodl.py --edition enterprise --version 8.0 --component archive --out ${EXISTING_BIN_DIR} --strip-path-components 2 --cache-dir "${DRIVERS_TOOLS}/.local/cache" --retries 5
+assert_gate_rejects "existing-binaries-dir contains" \
+  env OTEL=1 ./orchestration/drivers-orchestration run --existing-binaries-dir=${EXISTING_BIN_DIR}
 rm -rf ${EXISTING_BIN_DIR}
 
 # Live run: the OTel parameters must be applied and the trace dir exported.
@@ -125,6 +134,29 @@ $MONGODB_BINARIES/mongosh "mongodb://localhost:27017/?directConnection=true" --e
   print("OTEL_RUNNER_PARAMS_OK");
 ' | grep -q OTEL_RUNNER_PARAMS_OK
 bash ./run-mongodb.sh stop
+
+# Sharded topology: mongos must accept the injected setParameters too
+# (router entries hold proc params directly, without a procParams wrapper).
+OTEL=1 ./orchestration/drivers-orchestration run --version latest --topology sharded_cluster
+# shellcheck disable=SC1091
+. ./mo-expansion.sh
+# Per-port directories for a shard member (27217) and the mongos (27017).
+test -d "${OTEL_TRACE_DIR}/27217"
+test -d "${OTEL_TRACE_DIR}/27017"
+# getParameter against the mongos itself: the router's own parameters.
+$MONGODB_BINARIES/mongosh "mongodb://localhost:27017" --eval '
+  const p = db.adminCommand({
+    getParameter: 1,
+    opentelemetryTraceDirectory: 1,
+    openTelemetryExternalTracing: 1,
+  });
+  if (!p.opentelemetryTraceDirectory.endsWith("27017") ||
+      p.openTelemetryExternalTracing.tokenBucketRateLimit.maxTokens !== 1000) {
+    throw new Error("unexpected OTel parameters on mongos: " + JSON.stringify(p));
+  }
+  print("OTEL_MONGOS_PARAMS_OK");
+' | grep -q OTEL_MONGOS_PARAMS_OK
+./orchestration/drivers-orchestration stop
 
 # Opt-in regression: without OTEL, no trace dir and no expansion entry.
 ./orchestration/drivers-orchestration run --version latest

--- a/.evergreen/tests/test-otel.sh
+++ b/.evergreen/tests/test-otel.sh
@@ -79,7 +79,11 @@ rm -rf ${EXISTING_BIN_LATEST}
 # The previous run already downloaded the latest archive into this cache
 # dir, so this is a re-extract, not a second download.
 uv run python mongodl.py --edition enterprise --version latest --component archive --out ${EXISTING_BIN_LATEST} --strip-path-components 2 --cache-dir "${DRIVERS_TOOLS}/.local/cache" --retries 5
-OTEL=1 ./orchestration/drivers-orchestration run --existing-binaries-dir=${EXISTING_BIN_LATEST}
+# --version 8.0 is deliberate: with --existing-binaries-dir the probed
+# binary is authoritative and a stale requested version must not veto a
+# compatible 9.0+ build (--skip-crypt-shared avoids downloading the only
+# 8.0 artifact the version would otherwise select).
+OTEL=1 ./orchestration/drivers-orchestration run --existing-binaries-dir=${EXISTING_BIN_LATEST} --version 8.0 --skip-crypt-shared
 $MONGODB_BINARIES/mongosh "mongodb://localhost:27017/?directConnection=true" --eval '
   const p = db.adminCommand({getParameter: 1, opentelemetryTraceDirectory: 1});
   if (!p.opentelemetryTraceDirectory.endsWith("27017")) {

--- a/.evergreen/tests/test-otel.sh
+++ b/.evergreen/tests/test-otel.sh
@@ -63,6 +63,14 @@ $MONGODB_BINARIES/mongosh "mongodb://localhost:27017/?directConnection=true" --e
 # the runner translates procParams.setParameter into --setParameter args, so
 # the injected OTel parameters must be applied there too.
 OTEL=1 MONGODB_VERSION=latest bash ./run-mongodb.sh start
+# run() silently falls back to mongo-orchestration when mongodb-runner is
+# unsupported on the host, which would make the assertions below meaningless
+# for this leg. Only the runner path writes out.log as JSON-serialized
+# cluster info; mongo-orchestration writes plain daemon log text.
+if ! python3 -c "import json; json.load(open('orchestration/out.log'))" 2>/dev/null; then
+  echo "ERROR: mongodb-runner path fell back to mongo-orchestration"
+  exit 1
+fi
 # shellcheck disable=SC1091
 . ./mo-expansion.sh
 test -n "${OTEL_TRACE_DIR}"

--- a/.evergreen/tests/test-otel.sh
+++ b/.evergreen/tests/test-otel.sh
@@ -32,6 +32,18 @@ if OTEL=1 DOCKER_RUNNING=true ./orchestration/drivers-orchestration run --versio
   exit 1
 fi
 
+# --existing-binaries-dir bypasses version selection, so the gate probes the
+# actual mongod binary: a real 8.0 binary must be rejected before any
+# download or deployment.
+EXISTING_BIN_DIR=mongodl_otel_test
+rm -rf ${EXISTING_BIN_DIR}
+uv run python mongodl.py --edition enterprise --version 8.0 --component archive --out ${EXISTING_BIN_DIR} --strip-path-components 2 --retries 5
+if OTEL=1 ./orchestration/drivers-orchestration run --existing-binaries-dir=${EXISTING_BIN_DIR} 2>/dev/null; then
+  echo "ERROR: OTEL=1 with an 8.0 --existing-binaries-dir should have failed"
+  exit 1
+fi
+rm -rf ${EXISTING_BIN_DIR}
+
 # Live run: the OTel parameters must be applied and the trace dir exported.
 OTEL=1 ./orchestration/drivers-orchestration run --version latest
 
@@ -59,6 +71,25 @@ $MONGODB_BINARIES/mongosh "mongodb://localhost:27017/?directConnection=true" --e
 
 ./orchestration/drivers-orchestration stop
 
+# Positive probe path: a 9.0+ --existing-binaries-dir (copied from the latest
+# binaries the previous run downloaded) passes the gate and the cluster comes
+# up with the OTel parameters applied.
+EXISTING_BIN_LATEST=otel_existing_bin_test
+rm -rf ${EXISTING_BIN_LATEST}
+# The previous run already downloaded the latest archive into this cache
+# dir, so this is a re-extract, not a second download.
+uv run python mongodl.py --edition enterprise --version latest --component archive --out ${EXISTING_BIN_LATEST} --strip-path-components 2 --cache-dir "${DRIVERS_TOOLS}/.local/cache" --retries 5
+OTEL=1 ./orchestration/drivers-orchestration run --existing-binaries-dir=${EXISTING_BIN_LATEST}
+$MONGODB_BINARIES/mongosh "mongodb://localhost:27017/?directConnection=true" --eval '
+  const p = db.adminCommand({getParameter: 1, opentelemetryTraceDirectory: 1});
+  if (!p.opentelemetryTraceDirectory.endsWith("27017")) {
+    throw new Error("unexpected OTel parameters via existing binaries: " + JSON.stringify(p));
+  }
+  print("OTEL_EXISTING_BIN_PARAMS_OK");
+' | grep -q OTEL_EXISTING_BIN_PARAMS_OK
+./orchestration/drivers-orchestration stop
+rm -rf ${EXISTING_BIN_LATEST}
+
 # Same flow through the preferred mongodb-runner entry point (run-mongodb.sh):
 # the runner translates procParams.setParameter into --setParameter args, so
 # the injected OTel parameters must be applied there too.
@@ -67,7 +98,7 @@ OTEL=1 MONGODB_VERSION=latest bash ./run-mongodb.sh start
 # unsupported on the host, which would make the assertions below meaningless
 # for this leg. Only the runner path writes out.log as JSON-serialized
 # cluster info; mongo-orchestration writes plain daemon log text.
-if ! python3 -c "import json; json.load(open('orchestration/out.log'))" 2>/dev/null; then
+if ! uv run python -c "import json; json.load(open('orchestration/out.log'))" 2>/dev/null; then
   echo "ERROR: mongodb-runner path fell back to mongo-orchestration"
   exit 1
 fi

--- a/.evergreen/tests/test-otel.sh
+++ b/.evergreen/tests/test-otel.sh
@@ -61,8 +61,8 @@ $MONGODB_BINARIES/mongosh "mongodb://localhost:27017/?directConnection=true" --e
 
 # Opt-in regression: without OTEL, no trace dir and no expansion entry.
 ./orchestration/drivers-orchestration run --version latest
-if grep -q OTEL_TRACE_DIR mo-expansion.sh; then
-  echo "ERROR: OTEL_TRACE_DIR exported without OTEL=1"
+if ! grep -q '^OTEL_TRACE_DIR=""$' mo-expansion.sh; then
+  echo "ERROR: OTEL_TRACE_DIR should be exported as empty without OTEL=1 (to clear stale values)"
   exit 1
 fi
 if [ -d "${DRIVERS_TOOLS}/otel" ]; then

--- a/.evergreen/tests/test-otel.sh
+++ b/.evergreen/tests/test-otel.sh
@@ -59,6 +59,30 @@ $MONGODB_BINARIES/mongosh "mongodb://localhost:27017/?directConnection=true" --e
 
 ./orchestration/drivers-orchestration stop
 
+# Same flow through the preferred mongodb-runner entry point (run-mongodb.sh):
+# the runner translates procParams.setParameter into --setParameter args, so
+# the injected OTel parameters must be applied there too.
+OTEL=1 MONGODB_VERSION=latest bash ./run-mongodb.sh start
+# shellcheck disable=SC1091
+. ./mo-expansion.sh
+test -n "${OTEL_TRACE_DIR}"
+test -d "${OTEL_TRACE_DIR}/27017"
+$MONGODB_BINARIES/mongosh "mongodb://localhost:27017/?directConnection=true" --eval '
+  const p = db.adminCommand({
+    getParameter: 1,
+    opentelemetryTraceDirectory: 1,
+    openTelemetryExternalTracing: 1,
+    openTelemetryTracingFileFlushCount: 1,
+  });
+  if (!p.opentelemetryTraceDirectory.endsWith("27017") ||
+      p.openTelemetryExternalTracing.tokenBucketRateLimit.maxTokens !== 1000 ||
+      p.openTelemetryTracingFileFlushCount !== 1) {
+    throw new Error("unexpected OTel parameters via mongodb-runner: " + JSON.stringify(p));
+  }
+  print("OTEL_RUNNER_PARAMS_OK");
+' | grep -q OTEL_RUNNER_PARAMS_OK
+bash ./run-mongodb.sh stop
+
 # Opt-in regression: without OTEL, no trace dir and no expansion entry.
 ./orchestration/drivers-orchestration run --version latest
 if ! grep -q '^OTEL_TRACE_DIR=""$' mo-expansion.sh; then

--- a/.gitignore
+++ b/.gitignore
@@ -99,10 +99,12 @@ test-env.sh
 /results.json
 /test-results.json
 /mongodb
+/otel
 node_index.tab
 mongodb-binaries.tgz
 .evergreen/orchestration/configs/*/auth-oidc.json
 /.evergreen/docker/ubuntu*/mongodb
+/otel
 /mongosh
 tmp.json
 haproxy.conf

--- a/README.md
+++ b/README.md
@@ -115,6 +115,14 @@ export TLS_PEM_KEY_FILE=<path-to>/server.pem
 export TLS_CA_FILE=<path-to>/ca.pem
 ```
 
+### OpenTelemetry trace export (MongoDB 9.0+)
+
+Orchestration can start clusters with the server's OpenTelemetry file
+exporter enabled (opt-in via `OTEL=1`), for the trace-context propagation
+prose tests ([DRIVERS-3454](https://jira.mongodb.org/browse/DRIVERS-3454)).
+See [.evergreen/orchestration/README.md](.evergreen/orchestration/README.md)
+for usage, requirements, and driver integration guidance.
+
 ### Manual use of start-orchestration
 
 The [start-orchestration.sh](./.evergreen/start-orchestration.sh) script can be used directly as a way to

--- a/ruff.toml
+++ b/ruff.toml
@@ -42,3 +42,4 @@ unfixable = ["F401"]
 ".evergreen/csfle/kms_*.py" = ["PLW"]
 ".evergreen/csfle/gcpkms/mock_server.py" = ["PLW"]
 ".github/scripts/test_*.py" = ["PT"]      # unittest, not pytest
+".evergreen/orchestration/test_drivers_orchestration.py" = ["PT009", "PT027"]


### PR DESCRIPTION
## Summary

The trace-context propagation spec ([mongodb/specifications#1966](https://github.com/mongodb/specifications/pull/1966), MongoDB 9.0+) requires a prose test verifying server-created spans (parent linkage, one span per retry, none for auth/monitoring commands). Server spans are only observable via mongod's OpenTelemetry file exporter, which driver CI orchestration doesn't provision today.

This PR adds an opt-in `OTEL=1` configuration that starts every `mongod`/`mongos` with the required setParameters and exposes the trace directory to driver test suites as `OTEL_TRACE_DIR`. Works through both `run-mongodb.sh` (preferred) and the legacy `run-orchestration.sh`. Reference consumer: [mongodb/mongo-java-driver#2022](https://github.com/mongodb/mongo-java-driver/pull/2022).

## Changes in this PR

- **`otel.py`** (new sibling module): the `--otel`/`OTEL` flag on the `run` command.
  - Injects into every `mongod`/`mongos`: `opentelemetryTraceDirectory` (per-port dir under `$DRIVERS_TOOLS/otel/`), `featureFlagOtelTraceSampling`, `openTelemetryTracingSampling` (samplingFactor 1.0 + raised token bucket), `openTelemetryExternalTracing` (raised token bucket for driver traceparents), and `openTelemetryTracingFileFlushCount: 1`. Pre-existing OTel/tracing setParameters are rejected as conflicts.
  - **Version gate**: probes the `mongod` binary that will actually run (after download/copy, before deployment), covering explicit versions, aliases like `rapid` (which self-heal once they deliver 9.0+), nightlies, and `--existing-binaries-dir` with one mechanism. Local fail-fasts for `DOCKER_RUNNING`, `--local-atlas`, and explicitly sub-9.0 version strings.
  - `OTEL_TRACE_DIR` in `mo-expansion.sh`/`.yml` (empty when off, clearing stale values); trace dir wiped between runs.
- **Tests**: unit tests + a `pr`-tagged `test-otel` CI task (fail-fast gates asserted by message; live sharded, mongodb-runner, and no-`OTEL` legs).
- **Docs**: `.evergreen/orchestration/README.md` (usage + driver integration), env-var headers, top-level README pointer.
- Adjacent pre-existing fixes: `drivers-orchestration clean` crash, `REQUIRE_API_VERSION` never forwarded (trailing comma), missing hatch build includes.

Everything is additive and opt-in — with `OTEL` unset, behavior is unchanged.

## Test Plan

- **Unit tests** (26): setParameter injection across all topologies incl. mongos routers, merge/conflict handling, pinned parameter values, gating, and `mongod --version` parsing.
- **CI task `test-otel`** (`pr`-tagged, runs live): message-asserted fail-fast gates (incl. a real 8.0 binary rejected by the probe); a sharded cluster via `--existing-binaries-dir` verifying mongos/mongod parameters by `getParameter`, per-port dirs, and that a stale requested version doesn't veto a 9.0+ binary; a `run-mongodb.sh`/mongodb-runner leg with fallback detection; a no-`OTEL` regression. Verified passing locally.
- Parameter shapes cross-checked against `src/mongo/otel/traces/trace_sampling_parameters.idl` and live `getParameter` on a 9.0 build. Note: span files require an OTel-enabled mongod build (`requires_otel_build`, documented); end-to-end span verification lives in mongo-java-driver#2022.
- `make lint` passes.

## Checklist

### Checklist for Author

- [x] Does the title of the PR reference a JIRA Ticket?
- [x] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [x] Is all relevant documentation (README or docstring) updated?

### Checklist for Reviewer

- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?
