### PR TITLE
DRIVERS-3631: Move GCP/Azure KMS test VMs from debian-12 to debian-13

### DIFF
--- a/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
+++ b/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
@@ -20,7 +20,7 @@ export AZUREKMS_PRIVATEKEYPATH="$SCRIPT_DIR/keyfile"
 export AZUREKMS_CERTFILE="$SCRIPT_DIR/cert.pem"
 export AZUREKMS_VMNAME_PREFIX=$AZUREOIDC_VMNAME_PREFIX
 export AZUREOIDC_ENVPATH="$SCRIPT_DIR/env.sh"
-export AZUREKMS_IMAGE=${AZUREOIDC_IMAGE:-"Debian:debian-12:12:0.20260821.2577"}
+export AZUREKMS_IMAGE=${AZUREOIDC_IMAGE:-"Debian:debian-13:13:0.20260831.2587"}
 
 # Handle secrets from AWS vault.
 if [ ! -f ./secrets-export.sh ]; then

--- a/.evergreen/csfle/azurekms/README.md
+++ b/.evergreen/csfle/azurekms/README.md
@@ -14,11 +14,11 @@ The distro used must have the Azure Command-Line Interface (`az`) version 2.25.0
 - ubuntu2204
 If another distro is required, consider filing a BUILD ticket similar to [BUILD-16836](https://jira.mongodb.org/browse/BUILD-16836).
 
-The image of the remote Virtual Machine defaults to the URN `Debian:debian-12:12:0.20260821.2577`. It may be overridden with the environment variable `AZUREKMS_IMAGE` set to the value of `--image` in `az vm create`. See [Azure documentation](https://learn.microsoft.com/en-us/cli/azure/vm?view=azure-cli-latest#az-vm-create) for valid values.
+The image of the remote Virtual Machine defaults to the URN `Debian:debian-13:13:0.20260831.2587`. It may be overridden with the environment variable `AZUREKMS_IMAGE` set to the value of `--image` in `az vm create`. See [Azure documentation](https://learn.microsoft.com/en-us/cli/azure/vm?view=azure-cli-latest#az-vm-create) for valid values.
 
-The list of images may be determined with `az vm image list`. The following script can get the latest version of the `debian-12` image:
+The list of images may be determined with `az vm image list`. The following script can get the latest version of the `debian-13` image:
 ```
-LATEST_DEBIAN_URN=$(az vm image list -p Debian -s 12 --all --query "[?offer=='debian-12'].urn" -o tsv | sort -u | tail -n 1)
+LATEST_DEBIAN_URN=$(az vm image list -p Debian -s 13 --all --query "[?offer=='debian-13'].urn" -o tsv | sort -u | tail -n 1)
 echo "LATEST_DEBIAN_URN=$LATEST_DEBIAN_URN"
 ```
 The URN may be passed as `AZUREKMS_IMAGE`.

--- a/.evergreen/csfle/azurekms/create-and-setup-vm.sh
+++ b/.evergreen/csfle/azurekms/create-and-setup-vm.sh
@@ -47,7 +47,7 @@ done
 # Set defaults.
 # If this default changes, update the azurekms base_image in
 # .evergreen/tests/test-remote-kms-provisioning.sh to match.
-export AZUREKMS_IMAGE=${AZUREKMS_IMAGE:-"Debian:debian-12:12:0.20260821.2577"}
+export AZUREKMS_IMAGE=${AZUREKMS_IMAGE:-"Debian:debian-13:13:0.20260831.2587"}
 
 # Login.
 . "$DRIVERS_TOOLS"/.evergreen/csfle/azurekms/login.sh

--- a/.evergreen/csfle/gcpkms/create-and-setup-instance.sh
+++ b/.evergreen/csfle/gcpkms/create-and-setup-instance.sh
@@ -45,7 +45,7 @@ export GCPKMS_ZONE=${GCPKMS_ZONE:-"us-east1-b"}
 export GCPKMS_IMAGEPROJECT=${GCPKMS_IMAGEPROJECT:-"debian-cloud"}
 # If this default changes, update the gcpkms base_image in
 # .evergreen/tests/test-remote-kms-provisioning.sh to match.
-export GCPKMS_IMAGEFAMILY=${GCPKMS_IMAGEFAMILY:-"debian-12"}
+export GCPKMS_IMAGEFAMILY=${GCPKMS_IMAGEFAMILY:-"debian-13"}
 export GCPKMS_MACHINETYPE=${GCPKMS_MACHINETYPE:-"e2-micro"}
 export GCPKMS_DISKSIZE=${GCPKMS_DISKSIZE:-"20gb"}
 

--- a/.evergreen/tests/docker/remote-kms-provisioning.Dockerfile
+++ b/.evergreen/tests/docker/remote-kms-provisioning.Dockerfile
@@ -1,7 +1,7 @@
 # Mirrors the environment the gcpkms/azurekms remote-scripts actually run in:
 # a fresh host reached as a non-root user with passwordless sudo. BASE_IMAGE
 # lets gcpkms and azurekms test against their own default VM image versions.
-ARG BASE_IMAGE=debian:12
+ARG BASE_IMAGE=debian:13
 FROM ${BASE_IMAGE}
 # man-db ships preinstalled on the real GCE/Azure base images; the
 # remote-scripts assume it's there when they silence its update trigger.

--- a/.evergreen/tests/test-remote-kms-provisioning.sh
+++ b/.evergreen/tests/test-remote-kms-provisioning.sh
@@ -206,16 +206,16 @@ test_start_mongodb_uses_archive azurekms .evergreen/csfle/azurekms/remote-script
 
 # Keep these in sync with the defaults in create-and-setup-instance.sh
 # (GCPKMS_IMAGEFAMILY) and create-and-setup-vm.sh (AZUREKMS_IMAGE).
-test_provisioning gcpkms .evergreen/csfle/gcpkms/remote-scripts/setup-gce-instance.sh debian:12
-test_provisioning azurekms .evergreen/csfle/azurekms/remote-scripts/setup-azure-vm.sh debian:12
+test_provisioning gcpkms .evergreen/csfle/gcpkms/remote-scripts/setup-gce-instance.sh debian:13
+test_provisioning azurekms .evergreen/csfle/azurekms/remote-scripts/setup-azure-vm.sh debian:13
 
-# debian:12 matches both defaults above. ubuntu:20.04 is a supported
+# debian:13 matches both defaults above. ubuntu:20.04 is a supported
 # AZUREKMS_IMAGE (see azurekms/README.md) and additionally covers a system
 # interpreter whose bundled pip predates PEP 600.
-test_no_system_pip nopip-debian12 debian:12
+test_no_system_pip nopip-debian13 debian:13
 test_no_system_pip nopip-ubuntu2004 ubuntu:20.04
 
-# debian:12 matches the current default VM image; this case covers hosts where python3-venv is missing.
-test_no_venv_module novenv-debian12 debian:12
+# debian:13 matches the current default VM image; this case covers hosts where python3-venv is missing.
+test_no_venv_module novenv-debian13 debian:13
 
-test_inside_active_venv invenv-debian12 debian:12
+test_inside_active_venv invenv-debian13 debian:13


### PR DESCRIPTION
[DRIVERS-3631](https://jira.mongodb.org/browse/DRIVERS-3631)

## Summary

Follow-up to #836, which moved the GCP/Azure KMS test VM defaults from the EOL `debian-11` to `debian-12`. This moves them one version further, to `debian-13`.

## Changes in this PR

- Changed the GCP KMS instance default (`GCPKMS_IMAGEFAMILY`) from `debian-12` to `debian-13`.
- Changed the Azure KMS VM default (`AZUREKMS_IMAGE`) to a pinned Debian 13 URN (`Debian:debian-13:13:0.20260831.2587`).
- Changed the Azure OIDC VM default (`AZUREOIDC_IMAGE`) to the same pinned Debian 13 URN.
- Updated `azurekms/README.md`'s documented default URN and `az vm image list` example to match.
- Updated the Docker base images in `test-remote-kms-provisioning.sh` and the `remote-kms-provisioning.Dockerfile` default to `debian:13`.

## Test Plan

- Local pre-commit hooks (shellcheck, codespell, etc.) pass on the changed files.
- Confirmed using `az vm image list -p Debian -s 13` that the pinned Azure URN and offer/sku resolve.

## Checklist

### Checklist for Author

- [x] Does the title of the PR reference a JIRA Ticket?
- [x] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [x] Is all relevant documentation (README or docstring) updated?

### Checklist for Reviewer

- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?