### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default ownership
+* @mongodb-labs/dbx-drivers-tools-maintainers


### PR DESCRIPTION
## Summary

Adds a `.github/CODEOWNERS` and `@mongodb-labs/dbx-drivers-tools-maintainers`

Similar to mongodb-labs/drivers-github-tools#128